### PR TITLE
feat: 推し活モード切替 + 追加フィールド (#11)

### DIFF
--- a/apps/household-web/components/transactions/OshikatsuFields.tsx
+++ b/apps/household-web/components/transactions/OshikatsuFields.tsx
@@ -1,0 +1,53 @@
+import { Input } from "@/components/ui/Input";
+import { Select } from "@/components/ui/Select";
+import { OSHIKATSU_ACTIVITY_TYPES } from "@/lib/constants";
+
+type OshikatsuFieldsProps = {
+  groupName: string | null;
+  activityType: string | null;
+  onGroupNameChange: (value: string | null) => void;
+  onActivityTypeChange: (value: string | null) => void;
+  errors?: {
+    groupName?: string;
+    activityType?: string;
+  };
+};
+
+export function OshikatsuFields({
+  groupName,
+  activityType,
+  onGroupNameChange,
+  onActivityTypeChange,
+  errors,
+}: OshikatsuFieldsProps) {
+  return (
+    <div className="space-y-4 rounded-lg border border-purple-200 bg-purple-50/50 p-4 dark:border-purple-800 dark:bg-purple-950/30">
+      <p className="text-xs font-medium text-purple-700 dark:text-purple-300">
+        推し活情報
+      </p>
+
+      <Input
+        id="groupName"
+        label="推しグループ名"
+        type="text"
+        placeholder="例: 乃木坂46"
+        value={groupName ?? ""}
+        onChange={(e) => onGroupNameChange(e.target.value || null)}
+        error={errors?.groupName}
+      />
+
+      <Select
+        id="activityType"
+        label="活動タイプ"
+        placeholder="選択してください"
+        options={OSHIKATSU_ACTIVITY_TYPES.map((type) => ({
+          value: type,
+          label: type,
+        }))}
+        value={activityType ?? ""}
+        onChange={(e) => onActivityTypeChange(e.target.value || null)}
+        error={errors?.activityType}
+      />
+    </div>
+  );
+}

--- a/apps/household-web/components/transactions/TransactionForm.tsx
+++ b/apps/household-web/components/transactions/TransactionForm.tsx
@@ -8,6 +8,7 @@ import type { ValidationError } from "@/types/errors";
 import { Input } from "@/components/ui/Input";
 import { Select } from "@/components/ui/Select";
 import { Button } from "@/components/ui/Button";
+import { OshikatsuFields } from "@/components/transactions/OshikatsuFields";
 
 type TransactionFormProps = {
   mode: "create" | "edit";
@@ -75,6 +76,23 @@ export function TransactionForm({
       categoryId: "",
       paymentMethodId: null,
     }));
+  };
+
+  const handleOshikatsuToggle = (enabled: boolean) => {
+    setValues((prev) => ({
+      ...prev,
+      isOshikatsu: enabled,
+      groupName: enabled ? prev.groupName : null,
+      activityType: enabled ? prev.activityType : null,
+    }));
+    if (!enabled) {
+      setErrors((prev) => {
+        const next = { ...prev };
+        delete next.groupName;
+        delete next.activityType;
+        return next;
+      });
+    }
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -176,6 +194,44 @@ export function TransactionForm({
             update("paymentMethodId", e.target.value || null)
           }
           error={errors.paymentMethodId}
+        />
+      )}
+
+      {/* 推し活トグル */}
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-medium text-foreground/70">
+          推し活
+        </span>
+        <button
+          type="button"
+          onClick={() => handleOshikatsuToggle(!values.isOshikatsu)}
+          className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full transition-colors ${
+            values.isOshikatsu
+              ? "bg-purple-500"
+              : "bg-foreground/10"
+          }`}
+          role="switch"
+          aria-checked={values.isOshikatsu}
+        >
+          <span
+            className={`pointer-events-none inline-block h-5 w-5 translate-y-0.5 rounded-full bg-white shadow-sm transition-transform ${
+              values.isOshikatsu ? "translate-x-5" : "translate-x-0.5"
+            }`}
+          />
+        </button>
+      </div>
+
+      {/* 推し活フィールド */}
+      {values.isOshikatsu && (
+        <OshikatsuFields
+          groupName={values.groupName}
+          activityType={values.activityType}
+          onGroupNameChange={(v) => update("groupName", v)}
+          onActivityTypeChange={(v) => update("activityType", v)}
+          errors={{
+            groupName: errors.groupName,
+            activityType: errors.activityType,
+          }}
         />
       )}
 

--- a/apps/household-web/lib/constants.ts
+++ b/apps/household-web/lib/constants.ts
@@ -1,0 +1,16 @@
+export const OSHIKATSU_ACTIVITY_TYPES = [
+  "ライブ・コンサート",
+  "グッズ購入",
+  "CD・DVD・Blu-ray",
+  "配信・サブスク",
+  "遠征・交通費",
+  "宿泊",
+  "飲食",
+  "雑誌・書籍",
+  "ファンクラブ",
+  "イベント・舞台",
+  "その他",
+] as const;
+
+export type OshikatsuActivityType =
+  (typeof OSHIKATSU_ACTIVITY_TYPES)[number];


### PR DESCRIPTION
## Summary

- 取引入力フォームに推し活トグルスイッチを追加
- トグルONで推しグループ名・活動タイプの入力フィールドを表示
- 推し活活動タイプ定数（11種類）を`lib/constants.ts`に定義
- トグルOFF時にフィールド値とバリデーションエラーをクリア

### 新規ファイル
- `lib/constants.ts` — `OSHIKATSU_ACTIVITY_TYPES` 定数 + `OshikatsuActivityType` 型
- `components/transactions/OshikatsuFields.tsx` — グループ名Input + 活動タイプSelect

### 変更ファイル
- `components/transactions/TransactionForm.tsx` — トグルUI追加、OshikatsuFieldsの条件表示

## Test plan

- [ ] 新規入力画面で推し活トグルが表示される
- [ ] トグルONで推し活情報フィールド（グループ名・活動タイプ）が表示される
- [ ] トグルOFFでフィールドが非表示になり、値がクリアされる
- [ ] 推し活ONでグループ名・活動タイプ未入力時にバリデーションエラーが表示される
- [ ] 推し活ONで全項目入力後に正常に登録できる
- [ ] ダッシュボードで推し活バッジと推し活小計が表示される

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)

@codex review