### PR TITLE
fix: Orbitトップの今日判定をJST基準に統一

### DIFF
--- a/apps/oshikatsu-web/app/(authenticated)/page.tsx
+++ b/apps/oshikatsu-web/app/(authenticated)/page.tsx
@@ -9,7 +9,10 @@ import { EventCalendar } from "@/components/events/EventCalendar";
 import { EventList } from "@/components/events/EventList";
 import { OnThisDay } from "@/components/events/OnThisDay";
 import { MonthSelector } from "@/components/events/MonthSelector";
-import { parseCalendarDateParams } from "@/lib/dateParams";
+import {
+  getTodayInAppTimeZone,
+  parseCalendarDateParams,
+} from "@/lib/dateParams";
 
 type TopPageProps = {
   searchParams: Promise<{ year?: string; month?: string; day?: string }>;
@@ -17,7 +20,7 @@ type TopPageProps = {
 
 export default async function TopPage({ searchParams }: TopPageProps) {
   const params = await searchParams;
-  const now = new Date();
+  const now = getTodayInAppTimeZone();
   const { year, month, day } = parseCalendarDateParams(params, now);
   const selectedDate = new Date(year, month - 1, day);
   const selectedDateStr = `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;

--- a/apps/oshikatsu-web/components/events/EventCalendar.tsx
+++ b/apps/oshikatsu-web/components/events/EventCalendar.tsx
@@ -3,6 +3,7 @@ import type { CalendarEvent } from "@/types/event";
 import { generateCalendarGrid } from "@/lib/calendarUtils";
 import { formatMonthLabel } from "@/lib/formatters";
 import { BIRTHDAY_COLOR } from "@/lib/constants";
+import { getTodayInAppTimeZone } from "@/lib/dateParams";
 
 type EventCalendarProps = {
   events: CalendarEvent[];
@@ -20,7 +21,7 @@ export function EventCalendar({
   selectedDateStr,
 }: EventCalendarProps) {
   const weeks = generateCalendarGrid(year, month);
-  const today = new Date();
+  const today = getTodayInAppTimeZone();
   const todayStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, "0")}-${String(today.getDate()).padStart(2, "0")}`;
 
   const eventsByDate = new Map<string, CalendarEvent[]>();

--- a/apps/oshikatsu-web/components/events/MonthSelector.tsx
+++ b/apps/oshikatsu-web/components/events/MonthSelector.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter, useSearchParams } from "next/navigation";
 import { formatMonthLabel } from "@/lib/formatters";
-import { getDaysInMonth } from "@/lib/dateParams";
+import { getDaysInMonth, getTodayInAppTimeZone } from "@/lib/dateParams";
 
 type MonthSelectorProps = {
   year: number;
@@ -88,7 +88,7 @@ export function MonthSelector({
   };
 
   const handleToday = () => {
-    const now = new Date();
+    const now = getTodayInAppTimeZone();
     navigate(
       now.getFullYear(),
       now.getMonth() + 1,

--- a/apps/oshikatsu-web/lib/dateParams.ts
+++ b/apps/oshikatsu-web/lib/dateParams.ts
@@ -1,3 +1,46 @@
+export const APP_TIME_ZONE = "Asia/Tokyo";
+
+type DateParts = {
+  year: number;
+  month: number;
+  day: number;
+};
+
+export function getDatePartsInTimeZone(
+  date: Date,
+  timeZone: string = APP_TIME_ZONE
+): DateParts {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(date);
+
+  const year = Number(parts.find((part) => part.type === "year")?.value);
+  const month = Number(parts.find((part) => part.type === "month")?.value);
+  const day = Number(parts.find((part) => part.type === "day")?.value);
+
+  if (
+    Number.isInteger(year) &&
+    Number.isInteger(month) &&
+    Number.isInteger(day)
+  ) {
+    return { year, month, day };
+  }
+
+  return {
+    year: date.getFullYear(),
+    month: date.getMonth() + 1,
+    day: date.getDate(),
+  };
+}
+
+export function getTodayInAppTimeZone(now: Date = new Date()): Date {
+  const { year, month, day } = getDatePartsInTimeZone(now, APP_TIME_ZONE);
+  return new Date(year, month - 1, day);
+}
+
 /**
  * URL search params から year/month を安全にパースする。
  * 無効な値の場合は現在の年月にフォールバックする。
@@ -5,7 +48,7 @@
 export function parseMonthParams(params: {
   year?: string;
   month?: string;
-}, now: Date = new Date()): { year: number; month: number } {
+}, now: Date = getTodayInAppTimeZone()): { year: number; month: number } {
   const rawYear = Number(params.year);
   const rawMonth = Number(params.month);
   return {
@@ -37,7 +80,7 @@ type CalendarDateParams = {
  */
 export function parseCalendarDateParams(
   params: CalendarDateParams,
-  now: Date = new Date()
+  now: Date = getTodayInAppTimeZone()
 ): { year: number; month: number; day: number } {
   const { year, month } = parseMonthParams(params, now);
   const lastDay = getDaysInMonth(year, month);


### PR DESCRIPTION
## 概要
本番環境（Vercel）で「今日」がUTC基準になり、JSTと日付ズレする問題を修正しました。

## 変更内容
- `apps/oshikatsu-web/lib/dateParams.ts`
  - `APP_TIME_ZONE`（`Asia/Tokyo`）を追加
  - タイムゾーン指定で年月日を取得する `getDatePartsInTimeZone` を追加
  - JST基準の当日を返す `getTodayInAppTimeZone` を追加
  - `parseMonthParams` / `parseCalendarDateParams` の既定 `now` をJST基準に変更
- `apps/oshikatsu-web/app/(authenticated)/page.tsx`
  - 今日判定の基準日を `getTodayInAppTimeZone()` に変更
- `apps/oshikatsu-web/components/events/EventCalendar.tsx`
  - カレンダーの「今日」ハイライト基準をJSTに変更
- `apps/oshikatsu-web/components/events/MonthSelector.tsx`
  - Todayボタン遷移先の日付をJST基準に変更

## 検証
- `pnpm --filter oshikatsu-web typecheck`
- `pnpm --filter oshikatsu-web lint`

どちらも成功しています。