### PR TITLE
feat: Issue #33 残タスク対応（UI改善 + Event更新RPC化）

### DIFF
--- a/apps/household-web/app/(authenticated)/dashboard/page.tsx
+++ b/apps/household-web/app/(authenticated)/dashboard/page.tsx
@@ -39,7 +39,7 @@ export default async function DashboardPage({
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <h1 className="text-xl font-bold text-foreground">ダッシュボード</h1>
-        <Suspense>
+        <Suspense fallback={<div className="h-10" />}>
           <MonthSelector year={year} month={month} />
         </Suspense>
       </div>

--- a/apps/household-web/components/dashboard/MonthSelector.tsx
+++ b/apps/household-web/components/dashboard/MonthSelector.tsx
@@ -6,9 +6,14 @@ import { formatMonthLabel } from "@/lib/formatters";
 type MonthSelectorProps = {
   year: number;
   month: number;
+  basePath?: string;
 };
 
-export function MonthSelector({ year, month }: MonthSelectorProps) {
+export function MonthSelector({
+  year,
+  month,
+  basePath = "/dashboard",
+}: MonthSelectorProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
 
@@ -16,7 +21,7 @@ export function MonthSelector({ year, month }: MonthSelectorProps) {
     const params = new URLSearchParams(searchParams.toString());
     params.set("year", String(newYear));
     params.set("month", String(newMonth));
-    router.push(`/dashboard?${params.toString()}`);
+    router.push(`${basePath}?${params.toString()}`);
   };
 
   const isAtMin = year === 2000 && month === 1;

--- a/apps/oshikatsu-web/components/events/EventCalendar.tsx
+++ b/apps/oshikatsu-web/components/events/EventCalendar.tsx
@@ -1,7 +1,6 @@
 import Link from "next/link";
 import type { CalendarEvent } from "@/types/event";
 import { generateCalendarGrid } from "@/lib/calendarUtils";
-import { formatMonthLabel } from "@/lib/formatters";
 import { BIRTHDAY_COLOR } from "@/lib/constants";
 import { getTodayInAppTimeZone } from "@/lib/dateParams";
 
@@ -33,10 +32,6 @@ export function EventCalendar({
 
   return (
     <div className="rounded-lg border border-foreground/10 bg-background p-4">
-      <h2 className="mb-4 text-center text-sm font-medium text-foreground">
-        {formatMonthLabel(year, month)}
-      </h2>
-
       <div className="grid grid-cols-7 gap-px">
         {WEEKDAYS.map((day, i) => (
           <div

--- a/apps/oshikatsu-web/repositories/eventRepository.ts
+++ b/apps/oshikatsu-web/repositories/eventRepository.ts
@@ -173,68 +173,22 @@ export function createEventRepository(
     },
 
     async update(id, input) {
-      const { error: eventError } = await supabase
-        .from("orbit_events")
-        .update({
-          event_type_id: input.eventTypeId,
-          title: input.title,
-          description: input.description || "",
-          date: input.date,
-          end_date: input.endDate || null,
-          start_time: input.startTime || null,
-          venue: input.venue || null,
-          url: input.url || null,
-        })
-        .eq("id", id);
+      const { error: rpcError } = await supabase.rpc("update_event_with_relations", {
+        p_event_id: id,
+        p_event_type_id: input.eventTypeId,
+        p_title: input.title,
+        p_description: input.description || "",
+        p_date: input.date,
+        p_end_date: input.endDate || null,
+        p_start_time: input.startTime || null,
+        p_venue: input.venue || null,
+        p_url: input.url || null,
+        p_group_ids: input.groupIds,
+        p_member_ids: input.memberIds,
+      });
 
-      if (eventError) {
-        throw new RepositoryError("イベントの更新に失敗しました", eventError);
-      }
-
-      // グループ: 全削除→再挿入
-      const { error: deleteGroupError } = await supabase
-        .from("orbit_event_groups")
-        .delete()
-        .eq("event_id", id);
-      if (deleteGroupError) {
-        throw new RepositoryError("イベントのグループ更新に失敗しました", deleteGroupError);
-      }
-
-      if (input.groupIds.length > 0) {
-        const { error: groupError } = await supabase
-          .from("orbit_event_groups")
-          .insert(
-            input.groupIds.map((groupId) => ({
-              event_id: id,
-              group_id: groupId,
-            }))
-          );
-        if (groupError) {
-          throw new RepositoryError("イベントのグループ登録に失敗しました", groupError);
-        }
-      }
-
-      // メンバー: 全削除→再挿入
-      const { error: deleteMemberError } = await supabase
-        .from("orbit_event_members")
-        .delete()
-        .eq("event_id", id);
-      if (deleteMemberError) {
-        throw new RepositoryError("イベントのメンバー更新に失敗しました", deleteMemberError);
-      }
-
-      if (input.memberIds.length > 0) {
-        const { error: memberError } = await supabase
-          .from("orbit_event_members")
-          .insert(
-            input.memberIds.map((memberId) => ({
-              event_id: id,
-              member_id: memberId,
-            }))
-          );
-        if (memberError) {
-          throw new RepositoryError("イベントのメンバー登録に失敗しました", memberError);
-        }
+      if (rpcError) {
+        throw new RepositoryError("イベントの更新に失敗しました", rpcError);
       }
 
       const updated = await this.findById(id);

--- a/apps/oshikatsu-web/supabase/migrations/015_event_update_transaction_rpc.sql
+++ b/apps/oshikatsu-web/supabase/migrations/015_event_update_transaction_rpc.sql
@@ -1,0 +1,60 @@
+-- ============================================================
+-- イベント更新をトランザクション境界内に集約する RPC
+-- ============================================================
+CREATE OR REPLACE FUNCTION update_event_with_relations(
+  p_event_id UUID,
+  p_event_type_id UUID,
+  p_title TEXT,
+  p_description TEXT,
+  p_date DATE,
+  p_end_date DATE,
+  p_start_time TIME,
+  p_venue TEXT,
+  p_url TEXT,
+  p_group_ids UUID[],
+  p_member_ids UUID[]
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+BEGIN
+  UPDATE public.orbit_events
+  SET
+    event_type_id = p_event_type_id,
+    title = p_title,
+    description = COALESCE(p_description, ''),
+    date = p_date,
+    end_date = p_end_date,
+    start_time = p_start_time,
+    venue = p_venue,
+    url = p_url
+  WHERE id = p_event_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'event not found: %', p_event_id USING ERRCODE = 'P0002';
+  END IF;
+
+  DELETE FROM public.orbit_event_groups
+  WHERE event_id = p_event_id;
+
+  INSERT INTO public.orbit_event_groups (event_id, group_id)
+  SELECT
+    p_event_id,
+    group_id
+  FROM (
+    SELECT DISTINCT unnest(COALESCE(p_group_ids, ARRAY[]::UUID[])) AS group_id
+  ) AS group_items;
+
+  DELETE FROM public.orbit_event_members
+  WHERE event_id = p_event_id;
+
+  INSERT INTO public.orbit_event_members (event_id, member_id)
+  SELECT
+    p_event_id,
+    member_id
+  FROM (
+    SELECT DISTINCT unnest(COALESCE(p_member_ids, ARRAY[]::UUID[])) AS member_id
+  ) AS member_items;
+END;
+$$;

--- a/docs/orbit-roadmap.md
+++ b/docs/orbit-roadmap.md
@@ -57,19 +57,19 @@
 
 - [x] `GROUP_COLORS` 定数の使用状況確認・整理（P2: 未使用のため削除）
 - [x] `groupRepository`, `eventTypeRepository` の `select("*")` を明示的カラム指定に変更（P2）
-- [ ] Repository update の非アトミック操作を RPC 関数でトランザクション化（P1: create は補償処理済み）
+- [x] Repository update の非アトミック操作を RPC 関数でトランザクション化（Issue #33）
 - [ ] Issue #27 の改善項目（Supabase 共有パッケージ）
 
 ### 残タスク（UI/設定）— Issue #32 → PR #35 / Issue #33
 
 - [x] トップ画面: 日付選択連動（選択日のイベント/なんの日更新 + Today ボタン）— Issue #40 → PR #41
 - [x] `next.config.ts` の `remotePatterns` を自プロジェクトの hostname に限定（Issue #46）
-- [x] メンバー画像バリデーションを Storage object path + 既存 https 互換へ更新（Issue #46）
-- [ ] EventCalendar の月ラベルと MonthSelector の重複表示を解消（P2）
+- [x] メンバー画像バリデーションを Storage object path + 旧Supabase公開URL互換へ更新（Issue #46）
+- [x] EventCalendar の月ラベルと MonthSelector の重複表示を解消（Issue #33）
 - [x] 誕生日ドットの色 `#D946EF` を定数に抽出（P2）
 - [x] Header ナビに「管理」→ `/admin` ハブに変更、「楽曲」リンク追加（Phase 2 で対応）
-- [ ] household-web の MonthSelector に `basePath` prop をバックポート（P2: cross-app 改善）
-- [ ] household-web の MonthSelector Suspense に fallback 追加（P2: cross-app 改善）
+- [x] household-web の MonthSelector に `basePath` prop をバックポート（Issue #33）
+- [x] household-web の MonthSelector Suspense に fallback 追加（Issue #33）
 
 ---
 


### PR DESCRIPTION
## 概要
Issue #33 の未完了だった残タスクを対応しました。

## 変更内容
- EventCalendar の月ラベル重複を解消（MonthSelector 側に表示を集約）
- household-web の MonthSelector に `basePath` prop をバックポート
- household-web の Dashboard の MonthSelector Suspense に fallback を追加
- event update の非アトミック処理を RPC 化
  - `update_event_with_relations` を追加（migration: `015_event_update_transaction_rpc.sql`）
  - `eventRepository.update` は RPC 呼び出しへ変更
- `docs/orbit-roadmap.md` の Issue #33 関連チェックを更新

## 検証
- `pnpm --filter oshikatsu-web typecheck`
- `pnpm --filter oshikatsu-web lint`
- `pnpm --filter household-web typecheck`
- `pnpm --filter household-web lint`

Closes #33
