### PR TITLE
feat: 日付入力を手入力と選択の両対応に改善

### DIFF
--- a/apps/oshikatsu-web/components/ui/Input.tsx
+++ b/apps/oshikatsu-web/components/ui/Input.tsx
@@ -36,7 +36,6 @@ export function Input({ label, error, id, className = "", ...props }: InputProps
           <input
             {...dateProps}
             id={id}
-            inputMode="numeric"
             placeholder={placeholder ?? "YYYY-MM-DD"}
             className={inputClassName}
             value={dateValue}


### PR DESCRIPTION
## 概要
日付入力コンポーネントを改善し、カレンダー選択を残したままキーボード手入力を可能にしました。

## 変更内容
- 共通 `Input` コンポーネントの `type="date"` 挙動を拡張
- 日付入力時は以下のUIを提供
  - 手入力用 `text` 入力（`YYYY-MM-DD` プレースホルダー）
  - カレンダーを開く `選択` ボタン
  - 同期用の非表示 `date` input（`showPicker` / fallback `click`）
- 既存の `onChange` をそのまま利用するため、フォーム側の呼び出し変更は不要

## 期待効果
- キーボードで直接入力できる
- 従来どおりカレンダー選択も使える

## 動作確認
- `pnpm --filter oshikatsu-web typecheck`
- `pnpm --filter oshikatsu-web lint`
