### PR TITLE
[codex] Orbit 一覧カードに押下フィードバックを追加

### DIFF
--- a/apps/oshikatsu-web/components/members/MemberCard.tsx
+++ b/apps/oshikatsu-web/components/members/MemberCard.tsx
@@ -1,7 +1,7 @@
-import Link from "next/link";
 import Image from "next/image";
 import type { MemberListItem } from "@/types/member";
 import { GroupBadge } from "@/components/ui/GroupBadge";
+import { PendingLink } from "@/components/ui/PendingLink";
 import { resolveMemberImageSrc } from "@/lib/memberImage";
 
 type MemberCardProps = {
@@ -13,7 +13,7 @@ export function MemberCard({ member }: MemberCardProps) {
   const imageSrc = resolveMemberImageSrc(member.imageUrl);
 
   return (
-    <Link
+    <PendingLink
       href={`/members/${member.id}`}
       className="block rounded-lg border border-foreground/10 bg-background p-4 transition-colors hover:bg-foreground/5"
     >
@@ -53,6 +53,6 @@ export function MemberCard({ member }: MemberCardProps) {
           </div>
         </div>
       </div>
-    </Link>
+    </PendingLink>
   );
 }

--- a/apps/oshikatsu-web/components/releases/ReleaseCard.tsx
+++ b/apps/oshikatsu-web/components/releases/ReleaseCard.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link";
+import { PendingLink } from "@/components/ui/PendingLink";
 import type { ReleaseListItem } from "@/types/release";
 import { RELEASE_TYPE_LABELS } from "@/types/release";
 import { formatDate } from "@/lib/formatters";
@@ -9,7 +9,7 @@ type ReleaseCardProps = {
 
 export function ReleaseCard({ release }: ReleaseCardProps) {
   return (
-    <Link
+    <PendingLink
       href={`/releases/${release.id}`}
       className="block rounded-lg border border-foreground/10 bg-background p-4 transition-colors hover:bg-foreground/5"
     >
@@ -22,6 +22,6 @@ export function ReleaseCard({ release }: ReleaseCardProps) {
       {release.releaseDate && (
         <p className="mt-1 text-xs text-foreground/50">{formatDate(release.releaseDate)}</p>
       )}
-    </Link>
+    </PendingLink>
   );
 }

--- a/apps/oshikatsu-web/components/songs/SongCard.tsx
+++ b/apps/oshikatsu-web/components/songs/SongCard.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link";
+import { PendingLink } from "@/components/ui/PendingLink";
 import type { SongListItem } from "@/types/song";
 import { formatDate } from "@/lib/formatters";
 
@@ -8,7 +8,7 @@ type SongCardProps = {
 
 export function SongCard({ song }: SongCardProps) {
   return (
-    <Link
+    <PendingLink
       href={`/songs/${song.id}`}
       className="block rounded-lg border border-foreground/10 bg-background p-4 transition-colors hover:bg-foreground/5"
     >
@@ -26,6 +26,6 @@ export function SongCard({ song }: SongCardProps) {
           初回リリース: {formatDate(song.firstReleaseDate)}
         </p>
       )}
-    </Link>
+    </PendingLink>
   );
 }

--- a/apps/oshikatsu-web/components/ui/PendingLink.tsx
+++ b/apps/oshikatsu-web/components/ui/PendingLink.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import Link, { type LinkProps, useLinkStatus } from "next/link";
+import {
+  type AnchorHTMLAttributes,
+  type MouseEvent,
+  type ReactNode,
+  useState,
+} from "react";
+
+type PendingLinkProps = LinkProps &
+  Omit<AnchorHTMLAttributes<HTMLAnchorElement>, keyof LinkProps> & {
+    children: ReactNode;
+    pendingLabel?: string;
+  };
+
+function isModifiedClick(event: MouseEvent<HTMLAnchorElement>): boolean {
+  return event.metaKey || event.ctrlKey || event.shiftKey || event.altKey;
+}
+
+function PendingLinkContent({
+  children,
+  isNavigating,
+  pendingLabel,
+}: {
+  children: ReactNode;
+  isNavigating: boolean;
+  pendingLabel: string;
+}) {
+  const { pending } = useLinkStatus();
+  const isPending = pending || isNavigating;
+
+  return (
+    <>
+      {children}
+      {isPending && (
+        <span
+          aria-label={pendingLabel}
+          className="absolute right-3 top-3 h-3 w-3 animate-spin rounded-full border border-foreground/20 border-t-foreground/70"
+          role="status"
+        />
+      )}
+    </>
+  );
+}
+
+export function PendingLink({
+  children,
+  className = "",
+  onClick,
+  pendingLabel = "読み込み中",
+  target,
+  ...props
+}: PendingLinkProps) {
+  const [isNavigating, setIsNavigating] = useState(false);
+
+  const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
+    onClick?.(event);
+
+    if (
+      event.defaultPrevented ||
+      isModifiedClick(event) ||
+      target === "_blank"
+    ) {
+      return;
+    }
+
+    if (isNavigating) {
+      event.preventDefault();
+      return;
+    }
+
+    setIsNavigating(true);
+  };
+
+  const navigatingClassName = isNavigating
+    ? "pointer-events-none opacity-70"
+    : "";
+
+  return (
+    <Link
+      {...props}
+      aria-busy={isNavigating}
+      aria-disabled={isNavigating}
+      className={`${className} relative ${navigatingClassName}`.trim()}
+      onClick={handleClick}
+      target={target}
+    >
+      <PendingLinkContent
+        isNavigating={isNavigating}
+        pendingLabel={pendingLabel}
+      >
+        {children}
+      </PendingLinkContent>
+    </Link>
+  );
+}

--- a/apps/oshikatsu-web/components/ui/PendingLink.tsx
+++ b/apps/oshikatsu-web/components/ui/PendingLink.tsx
@@ -5,6 +5,7 @@ import {
   type AnchorHTMLAttributes,
   type MouseEvent,
   type ReactNode,
+  useEffect,
   useState,
 } from "react";
 
@@ -16,6 +17,15 @@ type PendingLinkProps = LinkProps &
 
 function isModifiedClick(event: MouseEvent<HTMLAnchorElement>): boolean {
   return event.metaKey || event.ctrlKey || event.shiftKey || event.altKey;
+}
+
+function isCurrentLocation(href: LinkProps["href"]): boolean {
+  if (typeof href !== "string" || typeof window === "undefined") {
+    return false;
+  }
+
+  const targetUrl = new URL(href, window.location.href);
+  return targetUrl.href === window.location.href;
 }
 
 function PendingLinkContent({
@@ -54,6 +64,18 @@ export function PendingLink({
 }: PendingLinkProps) {
   const [isNavigating, setIsNavigating] = useState(false);
 
+  useEffect(() => {
+    if (!isNavigating) {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setIsNavigating(false);
+    }, 10000);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [isNavigating]);
+
   const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
     onClick?.(event);
 
@@ -62,6 +84,10 @@ export function PendingLink({
       isModifiedClick(event) ||
       target === "_blank"
     ) {
+      return;
+    }
+
+    if (isCurrentLocation(props.href)) {
       return;
     }
 


### PR DESCRIPTION
## Summary

Closes #72

- Orbit の一覧カードリンク向けに `PendingLink` を追加しました
- `/members` `/songs` `/releases` のカードリンクを `PendingLink` に置き換えました
- リンク押下後にスピナー表示、opacity 変更、`aria-busy` / `aria-disabled` を付与し、通常クリックの二重押下を抑制します

## 背景

一覧カードを押して詳細画面へ遷移するまで視覚的な変化がなく、押下が反映されたか分かりにくい状態でした。Next.js 16 の `next/link` が提供する `useLinkStatus` を使い、リンク単位で pending 状態を表示します。

## Test

- `pnpm --filter oshikatsu-web typecheck`
- `pnpm --filter oshikatsu-web lint`
- `pnpm --filter oshikatsu-web build`

補足: build は初回 sandbox のネットワーク制限で Google Fonts 取得に失敗しました。ネットワーク許可付きで再実行し、成功しています。

## Notes

- `gh auth status` はローカルの GitHub CLI トークン無効を返しましたが、PR 作成は GitHub コネクタで実施しています。