### PR TITLE
[codex] Orbit にグローバル遷移フィードバックを追加

### DIFF
--- a/apps/oshikatsu-web/app/(authenticated)/admin/events/page.tsx
+++ b/apps/oshikatsu-web/app/(authenticated)/admin/events/page.tsx
@@ -1,9 +1,9 @@
 import { Suspense } from "react";
-import Link from "next/link";
 import { createClient } from "@personal-hub/supabase/server";
 import { createEventRepository } from "@/repositories/eventRepository";
 import { Button } from "@/components/ui/Button";
 import { Badge } from "@/components/ui/Badge";
+import { PendingLink } from "@/components/ui/PendingLink";
 import { MonthSelector } from "@/components/events/MonthSelector";
 import { parseMonthParams } from "@/lib/dateParams";
 import { formatDate } from "@/lib/formatters";
@@ -26,9 +26,9 @@ export default async function AdminEventsPage({
     <div className="space-y-4">
       <div className="flex items-center justify-between">
         <h1 className="text-xl font-bold text-foreground">イベント管理</h1>
-        <Link href="/admin/events/new">
+        <PendingLink href="/admin/events/new" feedback="global">
           <Button>新規追加</Button>
-        </Link>
+        </PendingLink>
       </div>
 
       <div className="flex justify-center">
@@ -73,12 +73,13 @@ export default async function AdminEventsPage({
                   </span>
                 </td>
                 <td className="py-2">
-                  <Link
+                  <PendingLink
                     href={`/admin/events/${event.id}/edit`}
+                    feedback="global"
                     className="text-sm text-blue-500 hover:underline"
                   >
                     編集
-                  </Link>
+                  </PendingLink>
                 </td>
               </tr>
             ))}

--- a/apps/oshikatsu-web/app/(authenticated)/admin/members/page.tsx
+++ b/apps/oshikatsu-web/app/(authenticated)/admin/members/page.tsx
@@ -1,9 +1,9 @@
-import Link from "next/link";
 import { createClient } from "@personal-hub/supabase/server";
 import { createMemberRepository } from "@/repositories/memberRepository";
 import { listMembers } from "@/usecases/listMembers";
 import { Button } from "@/components/ui/Button";
 import { GroupBadge } from "@/components/ui/GroupBadge";
+import { PendingLink } from "@/components/ui/PendingLink";
 
 export default async function AdminMembersPage() {
   const supabase = await createClient();
@@ -14,9 +14,9 @@ export default async function AdminMembersPage() {
     <div className="space-y-4">
       <div className="flex items-center justify-between">
         <h1 className="text-xl font-bold text-foreground">メンバー管理</h1>
-        <Link href="/admin/members/new">
+        <PendingLink href="/admin/members/new" feedback="global">
           <Button>新規追加</Button>
-        </Link>
+        </PendingLink>
       </div>
 
       <div className="overflow-x-auto">
@@ -55,12 +55,13 @@ export default async function AdminMembersPage() {
                   </div>
                 </td>
                 <td className="py-2">
-                  <Link
+                  <PendingLink
                     href={`/admin/members/${member.id}/edit`}
+                    feedback="global"
                     className="text-sm text-blue-500 hover:underline"
                   >
                     編集
-                  </Link>
+                  </PendingLink>
                 </td>
               </tr>
             ))}

--- a/apps/oshikatsu-web/app/(authenticated)/admin/page.tsx
+++ b/apps/oshikatsu-web/app/(authenticated)/admin/page.tsx
@@ -1,5 +1,5 @@
-import Link from "next/link";
 import { Card } from "@/components/ui/Card";
+import { PendingLink } from "@/components/ui/PendingLink";
 
 const sections = [
   {
@@ -30,14 +30,18 @@ export default function AdminPage() {
       <h1 className="text-xl font-bold text-foreground">管理</h1>
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {sections.map((section) => (
-          <Link key={section.href} href={section.href}>
+          <PendingLink
+            key={section.href}
+            href={section.href}
+            feedback="global"
+          >
             <Card className="transition-colors hover:bg-foreground/5">
               <h2 className="font-medium text-foreground">{section.title}</h2>
               <p className="mt-1 text-sm text-foreground/60">
                 {section.description}
               </p>
             </Card>
-          </Link>
+          </PendingLink>
         ))}
       </div>
     </div>

--- a/apps/oshikatsu-web/app/(authenticated)/admin/releases/page.tsx
+++ b/apps/oshikatsu-web/app/(authenticated)/admin/releases/page.tsx
@@ -1,9 +1,9 @@
-import Link from "next/link";
 import { createClient } from "@personal-hub/supabase/server";
 import { createReleaseRepository } from "@/repositories/releaseRepository";
 import { listReleases } from "@/usecases/listReleases";
 import { Button } from "@/components/ui/Button";
 import { GroupBadge } from "@/components/ui/GroupBadge";
+import { PendingLink } from "@/components/ui/PendingLink";
 import { formatDate } from "@/lib/formatters";
 import { RELEASE_TYPE_LABELS } from "@/types/release";
 
@@ -15,9 +15,9 @@ export default async function AdminReleasesPage() {
     <div className="space-y-4">
       <div className="flex items-center justify-between">
         <h1 className="text-xl font-bold text-foreground">リリース管理</h1>
-        <Link href="/admin/releases/new">
+        <PendingLink href="/admin/releases/new" feedback="global">
           <Button>新規追加</Button>
-        </Link>
+        </PendingLink>
       </div>
 
       <div className="overflow-x-auto">
@@ -52,12 +52,13 @@ export default async function AdminReleasesPage() {
                   {release.releaseDate ? formatDate(release.releaseDate) : "—"}
                 </td>
                 <td className="py-2">
-                  <Link
+                  <PendingLink
                     href={`/admin/releases/${release.id}/edit`}
+                    feedback="global"
                     className="text-sm text-blue-500 hover:underline"
                   >
                     編集
-                  </Link>
+                  </PendingLink>
                 </td>
               </tr>
             ))}

--- a/apps/oshikatsu-web/app/(authenticated)/admin/songs/page.tsx
+++ b/apps/oshikatsu-web/app/(authenticated)/admin/songs/page.tsx
@@ -1,8 +1,8 @@
-import Link from "next/link";
 import { createClient } from "@personal-hub/supabase/server";
 import { createSongRepository } from "@/repositories/songRepository";
 import { listSongs } from "@/usecases/listSongs";
 import { Button } from "@/components/ui/Button";
+import { PendingLink } from "@/components/ui/PendingLink";
 import { formatDate } from "@/lib/formatters";
 
 export default async function AdminSongsPage() {
@@ -14,9 +14,9 @@ export default async function AdminSongsPage() {
     <div className="space-y-4">
       <div className="flex items-center justify-between">
         <h1 className="text-xl font-bold text-foreground">楽曲管理</h1>
-        <Link href="/admin/songs/new">
+        <PendingLink href="/admin/songs/new" feedback="global">
           <Button>新規追加</Button>
-        </Link>
+        </PendingLink>
       </div>
 
       <div className="overflow-x-auto">
@@ -45,12 +45,13 @@ export default async function AdminSongsPage() {
                   {song.releaseDate ? formatDate(song.releaseDate) : "—"}
                 </td>
                 <td className="py-2">
-                  <Link
+                  <PendingLink
                     href={`/admin/songs/${song.id}/edit`}
+                    feedback="global"
                     className="text-sm text-blue-500 hover:underline"
                   >
                     編集
-                  </Link>
+                  </PendingLink>
                 </td>
               </tr>
             ))}

--- a/apps/oshikatsu-web/app/(authenticated)/layout.tsx
+++ b/apps/oshikatsu-web/app/(authenticated)/layout.tsx
@@ -1,4 +1,8 @@
 import { Header } from "@/components/layout/Header";
+import {
+  NavigationProgressBar,
+  NavigationProgressProvider,
+} from "@/components/ui/NavigationProgress";
 
 export default async function AuthenticatedLayout({
   children,
@@ -6,9 +10,12 @@ export default async function AuthenticatedLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <div className="min-h-screen bg-background">
-      <Header />
-      <main className="mx-auto max-w-5xl px-4 py-6">{children}</main>
-    </div>
+    <NavigationProgressProvider>
+      <div className="min-h-screen bg-background">
+        <NavigationProgressBar />
+        <Header />
+        <main className="mx-auto max-w-5xl px-4 py-6">{children}</main>
+      </div>
+    </NavigationProgressProvider>
   );
 }

--- a/apps/oshikatsu-web/app/(authenticated)/members/[id]/page.tsx
+++ b/apps/oshikatsu-web/app/(authenticated)/members/[id]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
-import Link from "next/link";
 import { MemberProfile } from "@/components/members/MemberProfile";
 import { Button } from "@/components/ui/Button";
+import { PendingLink } from "@/components/ui/PendingLink";
 import { getMemberDetailPageData } from "@/usecases/readOrbitData";
 
 type MemberDetailPageProps = {
@@ -22,15 +22,19 @@ export default async function MemberDetailPage({
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
-        <Link
+        <PendingLink
           href="/members"
+          feedback="global"
           className="text-sm text-foreground/60 hover:text-foreground"
         >
           ← メンバー一覧
-        </Link>
-        <Link href={`/admin/members/${member.id}/edit`}>
+        </PendingLink>
+        <PendingLink
+          href={`/admin/members/${member.id}/edit`}
+          feedback="global"
+        >
           <Button variant="secondary">編集</Button>
-        </Link>
+        </PendingLink>
       </div>
       <MemberProfile
         member={member}

--- a/apps/oshikatsu-web/app/(authenticated)/releases/[id]/page.tsx
+++ b/apps/oshikatsu-web/app/(authenticated)/releases/[id]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
-import Link from "next/link";
 import { ReleaseDetail } from "@/components/releases/ReleaseDetail";
 import { Button } from "@/components/ui/Button";
+import { PendingLink } from "@/components/ui/PendingLink";
 import { getReleaseDetailPageData } from "@/usecases/readOrbitData";
 
 type ReleaseDetailPageProps = {
@@ -19,12 +19,19 @@ export default async function ReleaseDetailPage({ params }: ReleaseDetailPagePro
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
-        <Link href="/releases" className="text-sm text-foreground/60 hover:text-foreground">
+        <PendingLink
+          href="/releases"
+          feedback="global"
+          className="text-sm text-foreground/60 hover:text-foreground"
+        >
           ← リリース一覧
-        </Link>
-        <Link href={`/admin/releases/${release.id}/edit`}>
+        </PendingLink>
+        <PendingLink
+          href={`/admin/releases/${release.id}/edit`}
+          feedback="global"
+        >
           <Button variant="secondary">編集</Button>
-        </Link>
+        </PendingLink>
       </div>
       <ReleaseDetail release={release} />
     </div>

--- a/apps/oshikatsu-web/app/(authenticated)/songs/[id]/page.tsx
+++ b/apps/oshikatsu-web/app/(authenticated)/songs/[id]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
-import Link from "next/link";
 import { SongDetail } from "@/components/songs/SongDetail";
 import { Button } from "@/components/ui/Button";
+import { PendingLink } from "@/components/ui/PendingLink";
 import { getSongDetailPageData } from "@/usecases/readOrbitData";
 
 type SongDetailPageProps = {
@@ -19,15 +19,16 @@ export default async function SongDetailPage({ params }: SongDetailPageProps) {
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
-        <Link
+        <PendingLink
           href="/songs"
+          feedback="global"
           className="text-sm text-foreground/60 hover:text-foreground"
         >
           ← 楽曲一覧
-        </Link>
-        <Link href={`/admin/songs/${song.id}/edit`}>
+        </PendingLink>
+        <PendingLink href={`/admin/songs/${song.id}/edit`} feedback="global">
           <Button variant="secondary">編集</Button>
-        </Link>
+        </PendingLink>
       </div>
       <SongDetail song={song} />
     </div>

--- a/apps/oshikatsu-web/components/layout/Header.tsx
+++ b/apps/oshikatsu-web/components/layout/Header.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useState } from "react";
-import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { createClient } from "@personal-hub/supabase/client";
+import { PendingLink } from "@/components/ui/PendingLink";
 import { HEADER_NAV_ITEMS, isNavigationItemActive } from "@/lib/navigation";
 
 export function Header() {
@@ -23,15 +23,20 @@ export function Header() {
     <header className="border-b border-foreground/10 bg-background">
       <div className="mx-auto flex max-w-5xl items-center justify-between px-4 py-3">
         <div className="flex items-center gap-6">
-          <Link href="/" className="text-lg font-bold text-foreground">
+          <PendingLink
+            href="/"
+            feedback="global"
+            className="text-lg font-bold text-foreground"
+          >
             Orbit
-          </Link>
+          </PendingLink>
           {/* デスクトップナビ */}
           <nav className="hidden gap-4 md:flex">
             {HEADER_NAV_ITEMS.map((item) => (
-              <Link
+              <PendingLink
                 key={item.href}
                 href={item.href}
+                feedback="global"
                 className={`text-sm transition-colors ${
                   isNavigationItemActive(pathname, item.href)
                     ? "font-medium text-foreground"
@@ -39,7 +44,7 @@ export function Header() {
                 }`}
               >
                 {item.label}
-              </Link>
+              </PendingLink>
             ))}
           </nav>
         </div>
@@ -76,9 +81,10 @@ export function Header() {
         <div className="border-t border-foreground/10 px-4 py-3 md:hidden">
           <nav className="flex flex-col gap-2">
             {HEADER_NAV_ITEMS.map((item) => (
-              <Link
+              <PendingLink
                 key={item.href}
                 href={item.href}
+                feedback="global"
                 onClick={closeMenu}
                 className={`rounded-md px-3 py-2 text-sm transition-colors ${
                   isNavigationItemActive(pathname, item.href)
@@ -87,7 +93,7 @@ export function Header() {
                 }`}
               >
                 {item.label}
-              </Link>
+              </PendingLink>
             ))}
           </nav>
           <div className="mt-3 border-t border-foreground/10 pt-3">

--- a/apps/oshikatsu-web/components/layout/TopNavigationPanel.tsx
+++ b/apps/oshikatsu-web/components/layout/TopNavigationPanel.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { Card } from "@/components/ui/Card";
+import { PendingLink } from "@/components/ui/PendingLink";
 import { TOP_NAV_ITEMS, isNavigationItemActive } from "@/lib/navigation";
 
 export function TopNavigationPanel() {
@@ -13,9 +13,10 @@ export function TopNavigationPanel() {
       <h2 className="text-sm font-medium text-foreground/70">ナビゲーション</h2>
       <nav className="mt-3 flex flex-col gap-2">
         {TOP_NAV_ITEMS.map((item) => (
-          <Link
+          <PendingLink
             key={item.href}
             href={item.href}
+            feedback="global"
             className={`rounded-lg px-3 py-2 text-sm transition-colors ${
               isNavigationItemActive(pathname, item.href)
                 ? "bg-foreground/10 font-medium text-foreground"
@@ -23,7 +24,7 @@ export function TopNavigationPanel() {
             }`}
           >
             {item.label}
-          </Link>
+          </PendingLink>
         ))}
       </nav>
     </Card>

--- a/apps/oshikatsu-web/components/ui/NavigationProgress.tsx
+++ b/apps/oshikatsu-web/components/ui/NavigationProgress.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { usePathname } from "next/navigation";
+
+type NavigationProgressContextValue = {
+  isProgressActive: boolean;
+  startProgress: () => void;
+  stopProgress: () => void;
+};
+
+type ProgressState = {
+  pathname: string;
+};
+
+const NavigationProgressContext =
+  createContext<NavigationProgressContextValue | null>(null);
+
+export function NavigationProgressProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const pathname = usePathname();
+  const [progressState, setProgressState] = useState<ProgressState | null>(
+    null
+  );
+  const isProgressActive = progressState?.pathname === pathname;
+
+  const startProgress = useCallback(() => {
+    setProgressState({
+      pathname,
+    });
+  }, [pathname]);
+
+  const stopProgress = useCallback(() => {
+    setProgressState(null);
+  }, []);
+
+  useEffect(() => {
+    if (!progressState) {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setProgressState(null);
+    }, 10000);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [progressState]);
+
+  const value = useMemo(
+    () => ({
+      isProgressActive,
+      startProgress,
+      stopProgress,
+    }),
+    [isProgressActive, startProgress, stopProgress]
+  );
+
+  return (
+    <NavigationProgressContext.Provider value={value}>
+      {children}
+    </NavigationProgressContext.Provider>
+  );
+}
+
+export function useNavigationProgress(): NavigationProgressContextValue {
+  const context = useContext(NavigationProgressContext);
+
+  if (!context) {
+    return {
+      isProgressActive: false,
+      startProgress: () => undefined,
+      stopProgress: () => undefined,
+    };
+  }
+
+  return context;
+}
+
+export function NavigationProgressBar() {
+  const { isProgressActive } = useNavigationProgress();
+
+  if (!isProgressActive) {
+    return null;
+  }
+
+  return (
+    <div
+      aria-label="画面遷移中"
+      className="fixed left-0 top-0 z-50 h-0.5 w-full overflow-hidden bg-foreground/10"
+      role="status"
+    >
+      <div className="h-full w-1/3 animate-pulse bg-foreground/70" />
+    </div>
+  );
+}

--- a/apps/oshikatsu-web/components/ui/NavigationProgress.tsx
+++ b/apps/oshikatsu-web/components/ui/NavigationProgress.tsx
@@ -9,16 +9,14 @@ import {
   useMemo,
   useState,
 } from "react";
-import { usePathname } from "next/navigation";
-
 type NavigationProgressContextValue = {
   isProgressActive: boolean;
-  startProgress: () => void;
+  startProgress: (targetUrl: string) => void;
   stopProgress: () => void;
 };
 
 type ProgressState = {
-  pathname: string;
+  targetUrl: string;
 };
 
 const NavigationProgressContext =
@@ -29,17 +27,16 @@ export function NavigationProgressProvider({
 }: {
   children: ReactNode;
 }) {
-  const pathname = usePathname();
   const [progressState, setProgressState] = useState<ProgressState | null>(
     null
   );
-  const isProgressActive = progressState?.pathname === pathname;
+  const isProgressActive = progressState !== null;
 
-  const startProgress = useCallback(() => {
+  const startProgress = useCallback((targetUrl: string) => {
     setProgressState({
-      pathname,
+      targetUrl,
     });
-  }, [pathname]);
+  }, []);
 
   const stopProgress = useCallback(() => {
     setProgressState(null);
@@ -50,11 +47,25 @@ export function NavigationProgressProvider({
       return;
     }
 
+    const stopIfReachedTarget = () => {
+      if (window.location.href === progressState.targetUrl) {
+        setProgressState(null);
+      }
+    };
+
     const timeoutId = window.setTimeout(() => {
       setProgressState(null);
     }, 10000);
+    const intervalId = window.setInterval(stopIfReachedTarget, 100);
 
-    return () => window.clearTimeout(timeoutId);
+    stopIfReachedTarget();
+    window.addEventListener("popstate", stopIfReachedTarget);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+      window.clearInterval(intervalId);
+      window.removeEventListener("popstate", stopIfReachedTarget);
+    };
   }, [progressState]);
 
   const value = useMemo(

--- a/apps/oshikatsu-web/components/ui/PendingLink.tsx
+++ b/apps/oshikatsu-web/components/ui/PendingLink.tsx
@@ -23,27 +23,32 @@ function isModifiedClick(event: MouseEvent<HTMLAnchorElement>): boolean {
   return event.metaKey || event.ctrlKey || event.shiftKey || event.altKey;
 }
 
-function shouldSkipFeedback(href: LinkProps["href"]): boolean {
+function getFeedbackTargetUrl(href: LinkProps["href"]): string | null {
   if (typeof href !== "string" || typeof window === "undefined") {
-    return false;
+    return null;
   }
 
   const currentUrl = new URL(window.location.href);
   const targetUrl = new URL(href, window.location.href);
 
   if (targetUrl.origin !== currentUrl.origin) {
-    return true;
+    return null;
   }
 
   if (targetUrl.href === currentUrl.href) {
-    return true;
+    return null;
   }
 
-  return (
+  const isHashOnlyNavigation =
     targetUrl.pathname === currentUrl.pathname &&
     targetUrl.search === currentUrl.search &&
-    targetUrl.hash.length > 0
-  );
+    targetUrl.hash.length > 0;
+
+  if (isHashOnlyNavigation) {
+    return null;
+  }
+
+  return targetUrl.href;
 }
 
 function PendingLinkContent({
@@ -107,12 +112,14 @@ export function PendingLink({
       return;
     }
 
-    if (shouldSkipFeedback(props.href)) {
+    const targetUrl = getFeedbackTargetUrl(props.href);
+
+    if (!targetUrl) {
       return;
     }
 
     if (feedback === "global") {
-      startProgress();
+      startProgress(targetUrl);
       return;
     }
 

--- a/apps/oshikatsu-web/components/ui/PendingLink.tsx
+++ b/apps/oshikatsu-web/components/ui/PendingLink.tsx
@@ -8,10 +8,14 @@ import {
   useEffect,
   useState,
 } from "react";
+import { useNavigationProgress } from "@/components/ui/NavigationProgress";
+
+type PendingLinkFeedback = "inline" | "global" | "none";
 
 type PendingLinkProps = LinkProps &
   Omit<AnchorHTMLAttributes<HTMLAnchorElement>, keyof LinkProps> & {
     children: ReactNode;
+    feedback?: PendingLinkFeedback;
     pendingLabel?: string;
   };
 
@@ -19,13 +23,27 @@ function isModifiedClick(event: MouseEvent<HTMLAnchorElement>): boolean {
   return event.metaKey || event.ctrlKey || event.shiftKey || event.altKey;
 }
 
-function isCurrentLocation(href: LinkProps["href"]): boolean {
+function shouldSkipFeedback(href: LinkProps["href"]): boolean {
   if (typeof href !== "string" || typeof window === "undefined") {
     return false;
   }
 
+  const currentUrl = new URL(window.location.href);
   const targetUrl = new URL(href, window.location.href);
-  return targetUrl.href === window.location.href;
+
+  if (targetUrl.origin !== currentUrl.origin) {
+    return true;
+  }
+
+  if (targetUrl.href === currentUrl.href) {
+    return true;
+  }
+
+  return (
+    targetUrl.pathname === currentUrl.pathname &&
+    targetUrl.search === currentUrl.search &&
+    targetUrl.hash.length > 0
+  );
 }
 
 function PendingLinkContent({
@@ -57,12 +75,14 @@ function PendingLinkContent({
 export function PendingLink({
   children,
   className = "",
+  feedback = "inline",
   onClick,
   pendingLabel = "読み込み中",
   target,
   ...props
 }: PendingLinkProps) {
   const [isNavigating, setIsNavigating] = useState(false);
+  const { startProgress } = useNavigationProgress();
 
   useEffect(() => {
     if (!isNavigating) {
@@ -87,7 +107,16 @@ export function PendingLink({
       return;
     }
 
-    if (isCurrentLocation(props.href)) {
+    if (shouldSkipFeedback(props.href)) {
+      return;
+    }
+
+    if (feedback === "global") {
+      startProgress();
+      return;
+    }
+
+    if (feedback === "none") {
       return;
     }
 
@@ -99,25 +128,30 @@ export function PendingLink({
     setIsNavigating(true);
   };
 
-  const navigatingClassName = isNavigating
+  const isInlineNavigating = feedback === "inline" && isNavigating;
+  const navigatingClassName = isInlineNavigating
     ? "pointer-events-none opacity-70"
     : "";
 
   return (
     <Link
       {...props}
-      aria-busy={isNavigating}
-      aria-disabled={isNavigating}
+      aria-busy={isInlineNavigating}
+      aria-disabled={isInlineNavigating}
       className={`${className} relative ${navigatingClassName}`.trim()}
       onClick={handleClick}
       target={target}
     >
-      <PendingLinkContent
-        isNavigating={isNavigating}
-        pendingLabel={pendingLabel}
-      >
-        {children}
-      </PendingLinkContent>
+      {feedback === "inline" ? (
+        <PendingLinkContent
+          isNavigating={isNavigating}
+          pendingLabel={pendingLabel}
+        >
+          {children}
+        </PendingLinkContent>
+      ) : (
+        children
+      )}
     </Link>
   );
 }


### PR DESCRIPTION
## Summary

Closes #76

- `NavigationProgressProvider` / `NavigationProgressBar` を追加し、authenticated layout に配置しました
- `PendingLink` に `feedback="inline" | "global" | "none"` を追加しました
- Header / TopNavigationPanel / admin 主要 Link / 詳細ページの戻る・編集 Link を `feedback="global"` に置き換えました
- 一覧カードは既存の inline spinner を維持しています

## 背景

#72 / PR #75 で一覧カードには押下 feedback を追加しましたが、Header や管理画面リンクなどアプリ全体の主要導線には feedback がありませんでした。

本 PR では `next/link` 経由の主要な内部遷移を対象に、画面上部の global progress bar で押下直後の feedback を出します。`router.push` 経由の logout / filter select / month selector は #76 の Non-goals に従い対象外です。

## 実装メモ

- `feedback="inline"`: カード向け。既存通り inline spinner と通常クリックの二重押下抑制を行います。
- `feedback="global"`: Header / admin など向け。global progress bar のみ表示し、二重押下は抑制しません。
- `feedback="none"`: 必要に応じた opt-out 用です。
- global progress は pathname 変化または timeout で解除されます。

## Test

- `pnpm --filter oshikatsu-web typecheck`
- `pnpm --filter oshikatsu-web lint`
- `pnpm --filter oshikatsu-web build`

補足: build は初回 sandbox のネットワーク制限で Google Fonts 取得に失敗しました。ネットワーク許可付きで再実行し、成功しています。