### PR TITLE
[codex] 詳細から一覧へ戻る導線で一覧状態を保持

### DIFF
--- a/apps/oshikatsu-web/app/(authenticated)/members/[id]/page.tsx
+++ b/apps/oshikatsu-web/app/(authenticated)/members/[id]/page.tsx
@@ -3,6 +3,7 @@ import { MemberProfile } from "@/components/members/MemberProfile";
 import { Button } from "@/components/ui/Button";
 import { ListBackButton } from "@/components/ui/ListBackButton";
 import { PendingLink } from "@/components/ui/PendingLink";
+import { APP_ROUTES } from "@/lib/routes";
 import { getMemberDetailPageData } from "@/usecases/readOrbitData";
 
 type MemberDetailPageProps = {
@@ -24,7 +25,7 @@ export default async function MemberDetailPage({
     <div className="space-y-4">
       <div className="flex items-center justify-between">
         <ListBackButton
-          fallbackHref="/members"
+          fallbackHref={APP_ROUTES.members}
           className="text-sm text-foreground/60 hover:text-foreground"
         >
           ← メンバー一覧

--- a/apps/oshikatsu-web/app/(authenticated)/members/[id]/page.tsx
+++ b/apps/oshikatsu-web/app/(authenticated)/members/[id]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
 import { MemberProfile } from "@/components/members/MemberProfile";
 import { Button } from "@/components/ui/Button";
+import { ListBackButton } from "@/components/ui/ListBackButton";
 import { PendingLink } from "@/components/ui/PendingLink";
 import { getMemberDetailPageData } from "@/usecases/readOrbitData";
 
@@ -22,13 +23,12 @@ export default async function MemberDetailPage({
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
-        <PendingLink
-          href="/members"
-          feedback="global"
+        <ListBackButton
+          fallbackHref="/members"
           className="text-sm text-foreground/60 hover:text-foreground"
         >
           ← メンバー一覧
-        </PendingLink>
+        </ListBackButton>
         <PendingLink
           href={`/admin/members/${member.id}/edit`}
           feedback="global"

--- a/apps/oshikatsu-web/app/(authenticated)/releases/[id]/page.tsx
+++ b/apps/oshikatsu-web/app/(authenticated)/releases/[id]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
 import { ReleaseDetail } from "@/components/releases/ReleaseDetail";
 import { Button } from "@/components/ui/Button";
+import { ListBackButton } from "@/components/ui/ListBackButton";
 import { PendingLink } from "@/components/ui/PendingLink";
 import { getReleaseDetailPageData } from "@/usecases/readOrbitData";
 
@@ -19,13 +20,12 @@ export default async function ReleaseDetailPage({ params }: ReleaseDetailPagePro
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
-        <PendingLink
-          href="/releases"
-          feedback="global"
+        <ListBackButton
+          fallbackHref="/releases"
           className="text-sm text-foreground/60 hover:text-foreground"
         >
           ← リリース一覧
-        </PendingLink>
+        </ListBackButton>
         <PendingLink
           href={`/admin/releases/${release.id}/edit`}
           feedback="global"

--- a/apps/oshikatsu-web/app/(authenticated)/releases/[id]/page.tsx
+++ b/apps/oshikatsu-web/app/(authenticated)/releases/[id]/page.tsx
@@ -3,6 +3,7 @@ import { ReleaseDetail } from "@/components/releases/ReleaseDetail";
 import { Button } from "@/components/ui/Button";
 import { ListBackButton } from "@/components/ui/ListBackButton";
 import { PendingLink } from "@/components/ui/PendingLink";
+import { APP_ROUTES } from "@/lib/routes";
 import { getReleaseDetailPageData } from "@/usecases/readOrbitData";
 
 type ReleaseDetailPageProps = {
@@ -21,7 +22,7 @@ export default async function ReleaseDetailPage({ params }: ReleaseDetailPagePro
     <div className="space-y-4">
       <div className="flex items-center justify-between">
         <ListBackButton
-          fallbackHref="/releases"
+          fallbackHref={APP_ROUTES.releases}
           className="text-sm text-foreground/60 hover:text-foreground"
         >
           ← リリース一覧

--- a/apps/oshikatsu-web/app/(authenticated)/songs/[id]/page.tsx
+++ b/apps/oshikatsu-web/app/(authenticated)/songs/[id]/page.tsx
@@ -3,6 +3,7 @@ import { SongDetail } from "@/components/songs/SongDetail";
 import { Button } from "@/components/ui/Button";
 import { ListBackButton } from "@/components/ui/ListBackButton";
 import { PendingLink } from "@/components/ui/PendingLink";
+import { APP_ROUTES } from "@/lib/routes";
 import { getSongDetailPageData } from "@/usecases/readOrbitData";
 
 type SongDetailPageProps = {
@@ -21,7 +22,7 @@ export default async function SongDetailPage({ params }: SongDetailPageProps) {
     <div className="space-y-4">
       <div className="flex items-center justify-between">
         <ListBackButton
-          fallbackHref="/songs"
+          fallbackHref={APP_ROUTES.songs}
           className="text-sm text-foreground/60 hover:text-foreground"
         >
           ← 楽曲一覧

--- a/apps/oshikatsu-web/app/(authenticated)/songs/[id]/page.tsx
+++ b/apps/oshikatsu-web/app/(authenticated)/songs/[id]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
 import { SongDetail } from "@/components/songs/SongDetail";
 import { Button } from "@/components/ui/Button";
+import { ListBackButton } from "@/components/ui/ListBackButton";
 import { PendingLink } from "@/components/ui/PendingLink";
 import { getSongDetailPageData } from "@/usecases/readOrbitData";
 
@@ -19,13 +20,12 @@ export default async function SongDetailPage({ params }: SongDetailPageProps) {
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
-        <PendingLink
-          href="/songs"
-          feedback="global"
+        <ListBackButton
+          fallbackHref="/songs"
           className="text-sm text-foreground/60 hover:text-foreground"
         >
           ← 楽曲一覧
-        </PendingLink>
+        </ListBackButton>
         <PendingLink href={`/admin/songs/${song.id}/edit`} feedback="global">
           <Button variant="secondary">編集</Button>
         </PendingLink>

--- a/apps/oshikatsu-web/components/members/MemberCard.tsx
+++ b/apps/oshikatsu-web/components/members/MemberCard.tsx
@@ -16,6 +16,7 @@ export function MemberCard({ member }: MemberCardProps) {
     <PendingLink
       href={`/members/${member.id}`}
       className="block rounded-lg border border-foreground/10 bg-background p-4 transition-colors hover:bg-foreground/5"
+      listBackFallbackHref="/members"
     >
       <div className="flex items-start gap-3">
         {imageSrc ? (

--- a/apps/oshikatsu-web/components/members/MemberCard.tsx
+++ b/apps/oshikatsu-web/components/members/MemberCard.tsx
@@ -3,6 +3,7 @@ import type { MemberListItem } from "@/types/member";
 import { GroupBadge } from "@/components/ui/GroupBadge";
 import { PendingLink } from "@/components/ui/PendingLink";
 import { resolveMemberImageSrc } from "@/lib/memberImage";
+import { APP_ROUTES } from "@/lib/routes";
 
 type MemberCardProps = {
   member: MemberListItem;
@@ -16,7 +17,7 @@ export function MemberCard({ member }: MemberCardProps) {
     <PendingLink
       href={`/members/${member.id}`}
       className="block rounded-lg border border-foreground/10 bg-background p-4 transition-colors hover:bg-foreground/5"
-      listBackFallbackHref="/members"
+      listBackFallbackHref={APP_ROUTES.members}
     >
       <div className="flex items-start gap-3">
         {imageSrc ? (

--- a/apps/oshikatsu-web/components/releases/ReleaseCard.tsx
+++ b/apps/oshikatsu-web/components/releases/ReleaseCard.tsx
@@ -2,6 +2,7 @@ import { PendingLink } from "@/components/ui/PendingLink";
 import type { ReleaseListItem } from "@/types/release";
 import { RELEASE_TYPE_LABELS } from "@/types/release";
 import { formatDate } from "@/lib/formatters";
+import { APP_ROUTES } from "@/lib/routes";
 
 type ReleaseCardProps = {
   release: ReleaseListItem;
@@ -12,7 +13,7 @@ export function ReleaseCard({ release }: ReleaseCardProps) {
     <PendingLink
       href={`/releases/${release.id}`}
       className="block rounded-lg border border-foreground/10 bg-background p-4 transition-colors hover:bg-foreground/5"
-      listBackFallbackHref="/releases"
+      listBackFallbackHref={APP_ROUTES.releases}
     >
       <p className="text-sm font-medium text-foreground">{release.title}</p>
       <p className="mt-1 text-xs text-foreground/50">

--- a/apps/oshikatsu-web/components/releases/ReleaseCard.tsx
+++ b/apps/oshikatsu-web/components/releases/ReleaseCard.tsx
@@ -12,6 +12,7 @@ export function ReleaseCard({ release }: ReleaseCardProps) {
     <PendingLink
       href={`/releases/${release.id}`}
       className="block rounded-lg border border-foreground/10 bg-background p-4 transition-colors hover:bg-foreground/5"
+      listBackFallbackHref="/releases"
     >
       <p className="text-sm font-medium text-foreground">{release.title}</p>
       <p className="mt-1 text-xs text-foreground/50">

--- a/apps/oshikatsu-web/components/songs/SongCard.tsx
+++ b/apps/oshikatsu-web/components/songs/SongCard.tsx
@@ -11,6 +11,7 @@ export function SongCard({ song }: SongCardProps) {
     <PendingLink
       href={`/songs/${song.id}`}
       className="block rounded-lg border border-foreground/10 bg-background p-4 transition-colors hover:bg-foreground/5"
+      listBackFallbackHref="/songs"
     >
       <p className="text-sm font-medium text-foreground">{song.title}</p>
       {song.groupNameJa && (

--- a/apps/oshikatsu-web/components/songs/SongCard.tsx
+++ b/apps/oshikatsu-web/components/songs/SongCard.tsx
@@ -1,6 +1,7 @@
 import { PendingLink } from "@/components/ui/PendingLink";
 import type { SongListItem } from "@/types/song";
 import { formatDate } from "@/lib/formatters";
+import { APP_ROUTES } from "@/lib/routes";
 
 type SongCardProps = {
   song: SongListItem;
@@ -11,7 +12,7 @@ export function SongCard({ song }: SongCardProps) {
     <PendingLink
       href={`/songs/${song.id}`}
       className="block rounded-lg border border-foreground/10 bg-background p-4 transition-colors hover:bg-foreground/5"
-      listBackFallbackHref="/songs"
+      listBackFallbackHref={APP_ROUTES.songs}
     >
       <p className="text-sm font-medium text-foreground">{song.title}</p>
       {song.groupNameJa && (

--- a/apps/oshikatsu-web/components/ui/ListBackButton.tsx
+++ b/apps/oshikatsu-web/components/ui/ListBackButton.tsx
@@ -29,9 +29,15 @@ export function ListBackButton({
 }: ListBackButtonProps) {
   const router = useRouter();
   const canReturnToListRef = useRef(false);
+  const hasConsumedRef = useRef(false);
   const { startProgress } = useNavigationProgress();
 
   useEffect(() => {
+    if (hasConsumedRef.current) {
+      return;
+    }
+
+    hasConsumedRef.current = true;
     canReturnToListRef.current = consumeListBackNavigation({
       currentHref: window.location.href,
       fallbackHref,

--- a/apps/oshikatsu-web/components/ui/ListBackButton.tsx
+++ b/apps/oshikatsu-web/components/ui/ListBackButton.tsx
@@ -5,8 +5,11 @@ import {
   type ButtonHTMLAttributes,
   type MouseEvent,
   type ReactNode,
+  useEffect,
+  useRef,
 } from "react";
 import { useNavigationProgress } from "@/components/ui/NavigationProgress";
+import { consumeListBackNavigation } from "@/components/ui/listBackNavigation";
 
 type ListBackButtonProps = Omit<
   ButtonHTMLAttributes<HTMLButtonElement>,
@@ -17,20 +20,6 @@ type ListBackButtonProps = Omit<
   onClick?: ButtonHTMLAttributes<HTMLButtonElement>["onClick"];
 };
 
-type NextHistoryState = {
-  idx?: unknown;
-};
-
-function hasBackHistory(): boolean {
-  const state = window.history.state as NextHistoryState | null;
-
-  if (typeof state?.idx === "number") {
-    return state.idx > 0;
-  }
-
-  return window.history.length > 1;
-}
-
 export function ListBackButton({
   children,
   className = "",
@@ -39,7 +28,15 @@ export function ListBackButton({
   ...props
 }: ListBackButtonProps) {
   const router = useRouter();
+  const canReturnToListRef = useRef(false);
   const { startProgress } = useNavigationProgress();
+
+  useEffect(() => {
+    canReturnToListRef.current = consumeListBackNavigation({
+      currentHref: window.location.href,
+      fallbackHref,
+    });
+  }, [fallbackHref]);
 
   const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
     onClick?.(event);
@@ -48,7 +45,7 @@ export function ListBackButton({
       return;
     }
 
-    if (hasBackHistory()) {
+    if (canReturnToListRef.current) {
       router.back();
       return;
     }

--- a/apps/oshikatsu-web/components/ui/ListBackButton.tsx
+++ b/apps/oshikatsu-web/components/ui/ListBackButton.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import {
+  type ButtonHTMLAttributes,
+  type MouseEvent,
+  type ReactNode,
+} from "react";
+import { useNavigationProgress } from "@/components/ui/NavigationProgress";
+
+type ListBackButtonProps = Omit<
+  ButtonHTMLAttributes<HTMLButtonElement>,
+  "children" | "onClick" | "type"
+> & {
+  children: ReactNode;
+  fallbackHref: string;
+  onClick?: ButtonHTMLAttributes<HTMLButtonElement>["onClick"];
+};
+
+type NextHistoryState = {
+  idx?: unknown;
+};
+
+function hasBackHistory(): boolean {
+  const state = window.history.state as NextHistoryState | null;
+
+  if (typeof state?.idx === "number") {
+    return state.idx > 0;
+  }
+
+  return window.history.length > 1;
+}
+
+export function ListBackButton({
+  children,
+  className = "",
+  fallbackHref,
+  onClick,
+  ...props
+}: ListBackButtonProps) {
+  const router = useRouter();
+  const { startProgress } = useNavigationProgress();
+
+  const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
+    onClick?.(event);
+
+    if (event.defaultPrevented) {
+      return;
+    }
+
+    if (hasBackHistory()) {
+      router.back();
+      return;
+    }
+
+    const targetUrl = new URL(fallbackHref, window.location.href).href;
+    startProgress(targetUrl);
+    router.push(fallbackHref);
+  };
+
+  return (
+    <button
+      {...props}
+      className={`${className} cursor-pointer bg-transparent p-0`.trim()}
+      onClick={handleClick}
+      type="button"
+    >
+      {children}
+    </button>
+  );
+}

--- a/apps/oshikatsu-web/components/ui/PendingLink.tsx
+++ b/apps/oshikatsu-web/components/ui/PendingLink.tsx
@@ -9,6 +9,7 @@ import {
   useState,
 } from "react";
 import { useNavigationProgress } from "@/components/ui/NavigationProgress";
+import { registerListBackNavigation } from "@/components/ui/listBackNavigation";
 
 type PendingLinkFeedback = "inline" | "global" | "none";
 
@@ -16,6 +17,7 @@ type PendingLinkProps = LinkProps &
   Omit<AnchorHTMLAttributes<HTMLAnchorElement>, keyof LinkProps> & {
     children: ReactNode;
     feedback?: PendingLinkFeedback;
+    listBackFallbackHref?: string;
     pendingLabel?: string;
   };
 
@@ -81,6 +83,7 @@ export function PendingLink({
   children,
   className = "",
   feedback = "inline",
+  listBackFallbackHref,
   onClick,
   pendingLabel = "読み込み中",
   target,
@@ -116,6 +119,13 @@ export function PendingLink({
 
     if (!targetUrl) {
       return;
+    }
+
+    if (listBackFallbackHref) {
+      registerListBackNavigation({
+        fallbackHref: listBackFallbackHref,
+        targetHref: targetUrl,
+      });
     }
 
     if (feedback === "global") {

--- a/apps/oshikatsu-web/components/ui/listBackNavigation.ts
+++ b/apps/oshikatsu-web/components/ui/listBackNavigation.ts
@@ -1,0 +1,127 @@
+const LIST_BACK_NAVIGATION_KEY = "oshikatsu-web:list-back-navigation";
+const LIST_BACK_NAVIGATION_MAX_AGE_MS = 30 * 60 * 1000;
+
+type ListBackNavigationState = {
+  createdAt: number;
+  fallbackPathname: string;
+  targetPath: string;
+};
+
+type RegisterListBackNavigationOptions = {
+  fallbackHref: string;
+  targetHref: string;
+};
+
+type ConsumeListBackNavigationOptions = {
+  currentHref: string;
+  fallbackHref: string;
+};
+
+function toPath(url: URL): string {
+  return `${url.pathname}${url.search}`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function parseListBackNavigationState(
+  rawValue: string | null
+): ListBackNavigationState | null {
+  if (!rawValue) {
+    return null;
+  }
+
+  try {
+    const value: unknown = JSON.parse(rawValue);
+
+    if (
+      !isRecord(value) ||
+      typeof value.createdAt !== "number" ||
+      typeof value.fallbackPathname !== "string" ||
+      typeof value.targetPath !== "string"
+    ) {
+      return null;
+    }
+
+    return {
+      createdAt: value.createdAt,
+      fallbackPathname: value.fallbackPathname,
+      targetPath: value.targetPath,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function readSessionValue(): string | null {
+  try {
+    return window.sessionStorage.getItem(LIST_BACK_NAVIGATION_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function removeSessionValue(): void {
+  try {
+    window.sessionStorage.removeItem(LIST_BACK_NAVIGATION_KEY);
+  } catch {
+    return;
+  }
+}
+
+export function registerListBackNavigation({
+  fallbackHref,
+  targetHref,
+}: RegisterListBackNavigationOptions): void {
+  const currentUrl = new URL(window.location.href);
+  const targetUrl = new URL(targetHref, currentUrl);
+  const fallbackUrl = new URL(fallbackHref, currentUrl);
+
+  if (
+    targetUrl.origin !== currentUrl.origin ||
+    fallbackUrl.origin !== currentUrl.origin
+  ) {
+    return;
+  }
+
+  const state: ListBackNavigationState = {
+    createdAt: Date.now(),
+    fallbackPathname: fallbackUrl.pathname,
+    targetPath: toPath(targetUrl),
+  };
+
+  try {
+    window.sessionStorage.setItem(
+      LIST_BACK_NAVIGATION_KEY,
+      JSON.stringify(state)
+    );
+  } catch {
+    return;
+  }
+}
+
+export function consumeListBackNavigation({
+  currentHref,
+  fallbackHref,
+}: ConsumeListBackNavigationOptions): boolean {
+  const rawValue = readSessionValue();
+  removeSessionValue();
+
+  const state = parseListBackNavigationState(rawValue);
+
+  if (!state) {
+    return false;
+  }
+
+  const currentUrl = new URL(currentHref);
+  const fallbackUrl = new URL(fallbackHref, currentUrl);
+  const isExpired =
+    Date.now() - state.createdAt > LIST_BACK_NAVIGATION_MAX_AGE_MS;
+
+  return (
+    !isExpired &&
+    state.targetPath === toPath(currentUrl) &&
+    state.fallbackPathname === fallbackUrl.pathname
+  );
+}

--- a/apps/oshikatsu-web/lib/navigation.ts
+++ b/apps/oshikatsu-web/lib/navigation.ts
@@ -1,18 +1,20 @@
+import { APP_ROUTES } from "@/lib/routes";
+
 export type AppNavigationItem = {
   href: string;
   label: string;
 };
 
 export const HEADER_NAV_ITEMS: AppNavigationItem[] = [
-  { href: "/members", label: "メンバー" },
-  { href: "/songs", label: "楽曲" },
-  { href: "/releases", label: "リリース" },
-  { href: "/admin", label: "管理" },
+  { href: APP_ROUTES.members, label: "メンバー" },
+  { href: APP_ROUTES.songs, label: "楽曲" },
+  { href: APP_ROUTES.releases, label: "リリース" },
+  { href: APP_ROUTES.admin, label: "管理" },
 ];
 
 export const TOP_NAV_ITEMS: AppNavigationItem[] = [
   ...HEADER_NAV_ITEMS,
-  { href: "/people", label: "制作陣" },
+  { href: APP_ROUTES.people, label: "制作陣" },
 ];
 
 export function isNavigationItemActive(pathname: string, href: string): boolean {

--- a/apps/oshikatsu-web/lib/routes.ts
+++ b/apps/oshikatsu-web/lib/routes.ts
@@ -1,0 +1,7 @@
+export const APP_ROUTES = {
+  admin: "/admin",
+  members: "/members",
+  people: "/people",
+  releases: "/releases",
+  songs: "/songs",
+} as const;


### PR DESCRIPTION
## 概要
- `/members` / `/songs` / `/releases` の詳細画面に共通の `ListBackButton` を追加
- 一覧から詳細へ遷移した履歴がある場合は `router.back()` で戻り、URL クエリに載ったフィルタ状態を保持
- 直リンク等で戻り先がない場合は各一覧 URL へフォールバック

## 背景
詳細画面の「一覧に戻る」導線が固定 URL だったため、一覧側のフィルタ/ソート状態を表すクエリが失われていました。既存の一覧 URL 状態を活かすため、戻る導線だけを履歴ベースに変更しています。

Closes #73

## 検証
- `pnpm --filter oshikatsu-web typecheck`
- `pnpm --filter oshikatsu-web lint`