### PR TITLE
[codex] メンバー/楽曲一覧をグループごとに表示

### DIFF
--- a/apps/oshikatsu-web/app/(authenticated)/members/page.tsx
+++ b/apps/oshikatsu-web/app/(authenticated)/members/page.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from "react";
 import { MemberGrid } from "@/components/members/MemberGrid";
 import { MemberFilters } from "@/components/members/MemberFilters";
+import { MemberSectionList } from "@/components/members/MemberSectionList";
 import type { MemberFilters as MemberFiltersType } from "@/types/member";
 import { getMembersPageData } from "@/usecases/readOrbitData";
 
@@ -17,7 +18,8 @@ export default async function MembersPage({ searchParams }: MembersPageProps) {
     generation: params.generation,
   };
 
-  const { members, groups } = await getMembersPageData(filters);
+  const { members, groups, memberSections } = await getMembersPageData(filters);
+  const isGroupFiltered = Boolean(filters.groupId);
 
   return (
     <div className="space-y-4">
@@ -28,7 +30,11 @@ export default async function MembersPage({ searchParams }: MembersPageProps) {
       <Suspense fallback={<div className="h-10" />}>
         <MemberFilters groups={groups} />
       </Suspense>
-      <MemberGrid members={members} />
+      {isGroupFiltered ? (
+        <MemberGrid members={members} />
+      ) : (
+        <MemberSectionList sections={memberSections} />
+      )}
     </div>
   );
 }

--- a/apps/oshikatsu-web/app/(authenticated)/songs/page.tsx
+++ b/apps/oshikatsu-web/app/(authenticated)/songs/page.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from "react";
 import { SongFilters } from "@/components/songs/SongFilters";
-import { SongCard } from "@/components/songs/SongCard";
+import { SongGrid } from "@/components/songs/SongGrid";
+import { SongSectionList } from "@/components/songs/SongSectionList";
 import type { SongFilters as SongFiltersType } from "@/types/song";
 import { getSongsPageData } from "@/usecases/readOrbitData";
 
@@ -15,7 +16,8 @@ export default async function SongsPage({ searchParams }: SongsPageProps) {
     groupId: params.groupId,
   };
 
-  const { songs, groups } = await getSongsPageData(filters);
+  const { songs, groups, songSections } = await getSongsPageData(filters);
+  const isGroupFiltered = Boolean(filters.groupId);
 
   return (
     <div className="space-y-4">
@@ -26,16 +28,10 @@ export default async function SongsPage({ searchParams }: SongsPageProps) {
       <Suspense fallback={<div className="h-10" />}>
         <SongFilters groups={groups} />
       </Suspense>
-      {songs.length === 0 ? (
-        <p className="py-12 text-center text-sm text-foreground/50">
-          楽曲が見つかりません
-        </p>
+      {isGroupFiltered ? (
+        <SongGrid songs={songs} />
       ) : (
-        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-          {songs.map((song) => (
-            <SongCard key={song.id} song={song} />
-          ))}
-        </div>
+        <SongSectionList sections={songSections} />
       )}
     </div>
   );

--- a/apps/oshikatsu-web/components/members/MemberSectionList.tsx
+++ b/apps/oshikatsu-web/components/members/MemberSectionList.tsx
@@ -1,0 +1,30 @@
+import { MemberGrid } from "@/components/members/MemberGrid";
+import { GroupSectionHeading } from "@/components/ui/GroupSectionHeading";
+import type { MemberSection } from "@/types/member";
+
+type MemberSectionListProps = {
+  sections: MemberSection[];
+};
+
+export function MemberSectionList({ sections }: MemberSectionListProps) {
+  if (sections.length === 0) {
+    return <MemberGrid members={[]} />;
+  }
+
+  return (
+    <div className="space-y-6">
+      {sections.map((section) => (
+        <section
+          key={section.group?.id ?? "ungrouped"}
+          className="space-y-3"
+        >
+          <GroupSectionHeading
+            color={section.group?.color ?? "#9ca3af"}
+            name={section.group?.nameJa ?? "未所属"}
+          />
+          <MemberGrid members={section.members} />
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/apps/oshikatsu-web/components/members/MemberSectionList.tsx
+++ b/apps/oshikatsu-web/components/members/MemberSectionList.tsx
@@ -19,7 +19,7 @@ export function MemberSectionList({ sections }: MemberSectionListProps) {
           className="space-y-3"
         >
           <GroupSectionHeading
-            color={section.group?.color ?? "#9ca3af"}
+            color={section.group?.color}
             name={section.group?.nameJa ?? "未所属"}
           />
           <MemberGrid members={section.members} />

--- a/apps/oshikatsu-web/components/songs/SongCard.tsx
+++ b/apps/oshikatsu-web/components/songs/SongCard.tsx
@@ -4,10 +4,11 @@ import { formatDate } from "@/lib/formatters";
 import { APP_ROUTES } from "@/lib/routes";
 
 type SongCardProps = {
+  showGroupName?: boolean;
   song: SongListItem;
 };
 
-export function SongCard({ song }: SongCardProps) {
+export function SongCard({ showGroupName = true, song }: SongCardProps) {
   return (
     <PendingLink
       href={`/songs/${song.id}`}
@@ -15,7 +16,7 @@ export function SongCard({ song }: SongCardProps) {
       listBackFallbackHref={APP_ROUTES.songs}
     >
       <p className="text-sm font-medium text-foreground">{song.title}</p>
-      {song.groupNameJa && (
+      {showGroupName && song.groupNameJa && (
         <p className="mt-1 text-xs text-foreground/50">
           {song.groupNameJa}
         </p>

--- a/apps/oshikatsu-web/components/songs/SongGrid.tsx
+++ b/apps/oshikatsu-web/components/songs/SongGrid.tsx
@@ -1,0 +1,24 @@
+import { SongCard } from "@/components/songs/SongCard";
+import type { SongListItem } from "@/types/song";
+
+type SongGridProps = {
+  songs: SongListItem[];
+};
+
+export function SongGrid({ songs }: SongGridProps) {
+  if (songs.length === 0) {
+    return (
+      <p className="py-12 text-center text-sm text-foreground/50">
+        楽曲が見つかりません
+      </p>
+    );
+  }
+
+  return (
+    <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+      {songs.map((song) => (
+        <SongCard key={song.id} song={song} />
+      ))}
+    </div>
+  );
+}

--- a/apps/oshikatsu-web/components/songs/SongGrid.tsx
+++ b/apps/oshikatsu-web/components/songs/SongGrid.tsx
@@ -2,10 +2,11 @@ import { SongCard } from "@/components/songs/SongCard";
 import type { SongListItem } from "@/types/song";
 
 type SongGridProps = {
+  showGroupName?: boolean;
   songs: SongListItem[];
 };
 
-export function SongGrid({ songs }: SongGridProps) {
+export function SongGrid({ showGroupName = true, songs }: SongGridProps) {
   if (songs.length === 0) {
     return (
       <p className="py-12 text-center text-sm text-foreground/50">
@@ -17,7 +18,7 @@ export function SongGrid({ songs }: SongGridProps) {
   return (
     <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
       {songs.map((song) => (
-        <SongCard key={song.id} song={song} />
+        <SongCard key={song.id} showGroupName={showGroupName} song={song} />
       ))}
     </div>
   );

--- a/apps/oshikatsu-web/components/songs/SongSectionList.tsx
+++ b/apps/oshikatsu-web/components/songs/SongSectionList.tsx
@@ -1,0 +1,30 @@
+import { SongGrid } from "@/components/songs/SongGrid";
+import { GroupSectionHeading } from "@/components/ui/GroupSectionHeading";
+import type { SongSection } from "@/types/song";
+
+type SongSectionListProps = {
+  sections: SongSection[];
+};
+
+export function SongSectionList({ sections }: SongSectionListProps) {
+  if (sections.length === 0) {
+    return <SongGrid songs={[]} />;
+  }
+
+  return (
+    <div className="space-y-6">
+      {sections.map((section) => (
+        <section
+          key={section.group?.id ?? "ungrouped"}
+          className="space-y-3"
+        >
+          <GroupSectionHeading
+            color={section.group?.color ?? "#9ca3af"}
+            name={section.group?.nameJa ?? "未所属"}
+          />
+          <SongGrid songs={section.songs} />
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/apps/oshikatsu-web/components/songs/SongSectionList.tsx
+++ b/apps/oshikatsu-web/components/songs/SongSectionList.tsx
@@ -19,10 +19,10 @@ export function SongSectionList({ sections }: SongSectionListProps) {
           className="space-y-3"
         >
           <GroupSectionHeading
-            color={section.group?.color ?? "#9ca3af"}
-            name={section.group?.nameJa ?? "未所属"}
+            color={section.group?.color}
+            name={section.group?.nameJa ?? "その他"}
           />
-          <SongGrid songs={section.songs} />
+          <SongGrid showGroupName={false} songs={section.songs} />
         </section>
       ))}
     </div>

--- a/apps/oshikatsu-web/components/ui/GroupSectionHeading.tsx
+++ b/apps/oshikatsu-web/components/ui/GroupSectionHeading.tsx
@@ -1,0 +1,17 @@
+type GroupSectionHeadingProps = {
+  color: string;
+  name: string;
+};
+
+export function GroupSectionHeading({ color, name }: GroupSectionHeadingProps) {
+  return (
+    <h2 className="flex items-center gap-2 text-sm font-semibold text-foreground">
+      <span
+        aria-hidden="true"
+        className="h-5 w-1 rounded-full"
+        style={{ backgroundColor: color }}
+      />
+      <span>{name}</span>
+    </h2>
+  );
+}

--- a/apps/oshikatsu-web/components/ui/GroupSectionHeading.tsx
+++ b/apps/oshikatsu-web/components/ui/GroupSectionHeading.tsx
@@ -1,7 +1,9 @@
 type GroupSectionHeadingProps = {
-  color: string;
+  color?: string;
   name: string;
 };
+
+const DEFAULT_GROUP_SECTION_COLOR = "#9ca3af";
 
 export function GroupSectionHeading({ color, name }: GroupSectionHeadingProps) {
   return (
@@ -9,7 +11,7 @@ export function GroupSectionHeading({ color, name }: GroupSectionHeadingProps) {
       <span
         aria-hidden="true"
         className="h-5 w-1 rounded-full"
-        style={{ backgroundColor: color }}
+        style={{ backgroundColor: color ?? DEFAULT_GROUP_SECTION_COLOR }}
       />
       <span>{name}</span>
     </h2>

--- a/apps/oshikatsu-web/types/member.ts
+++ b/apps/oshikatsu-web/types/member.ts
@@ -1,4 +1,5 @@
 import type { SnsType } from "@/lib/constants";
+import type { Group } from "@/types/group";
 
 export type Member = {
   id: string;
@@ -42,6 +43,11 @@ export type MemberListItem = Pick<
   "id" | "imageUrl" | "nameJa" | "nameKana"
 > & {
   groups: MemberGroup[];
+};
+
+export type MemberSection = {
+  group: Group | null;
+  members: MemberListItem[];
 };
 
 export type MemberOption = {

--- a/apps/oshikatsu-web/types/song.ts
+++ b/apps/oshikatsu-web/types/song.ts
@@ -1,4 +1,5 @@
 import type { ReleaseType } from "@/types/release";
+import type { Group } from "@/types/group";
 
 export type SongCreditRole = "lyrics" | "music" | "arrangement" | "choreography";
 
@@ -70,6 +71,11 @@ export type SongListItem = {
   groupColor: string;
   releaseCount: number;
   firstReleaseDate: string | null;
+};
+
+export type SongSection = {
+  group: Group | null;
+  songs: SongListItem[];
 };
 
 export type SongOption = {

--- a/apps/oshikatsu-web/usecases/groupListSections.ts
+++ b/apps/oshikatsu-web/usecases/groupListSections.ts
@@ -76,6 +76,18 @@ function getOrCreateUngroupedBucket<TItem>(
   return bucket;
 }
 
+function getSectionSortOrder<TItem>(bucket: SectionBucket<TItem>): number {
+  return bucket.group?.sortOrder ?? UNKNOWN_GROUP_SORT_ORDER;
+}
+
+function toSortedSectionBuckets<TItem>(
+  buckets: Map<string, SectionBucket<TItem>>
+): SectionBucket<TItem>[] {
+  return [...buckets.values()]
+    .filter((bucket) => bucket.items.length > 0)
+    .sort((a, b) => getSectionSortOrder(a) - getSectionSortOrder(b));
+}
+
 export function createMemberSections(
   members: MemberListItem[],
   groups: Group[]
@@ -92,7 +104,7 @@ export function createMemberSections(
     bucket.items.push(member);
   });
 
-  return [...buckets.values()]
+  return toSortedSectionBuckets(buckets)
     .map((bucket) => ({
       group: bucket.group,
       members: bucket.items
@@ -108,8 +120,7 @@ export function createMemberSections(
           return a.index - b.index;
         })
         .map(({ member }) => member),
-    }))
-    .filter((section) => section.members.length > 0);
+    }));
 }
 
 export function createSongSections(
@@ -124,10 +135,9 @@ export function createSongSections(
     bucket.items.push(song);
   });
 
-  return [...buckets.values()]
+  return toSortedSectionBuckets(buckets)
     .map((bucket) => ({
       group: bucket.group,
       songs: bucket.items,
-    }))
-    .filter((section) => section.songs.length > 0);
+    }));
 }

--- a/apps/oshikatsu-web/usecases/groupListSections.ts
+++ b/apps/oshikatsu-web/usecases/groupListSections.ts
@@ -1,0 +1,133 @@
+import type { Group } from "@/types/group";
+import type { MemberListItem, MemberSection } from "@/types/member";
+import type { SongListItem, SongSection } from "@/types/song";
+
+type SectionBucket<TItem> = {
+  group: Group | null;
+  items: TItem[];
+};
+
+const UNKNOWN_GROUP_SORT_ORDER = Number.MAX_SAFE_INTEGER;
+
+function createGroupSortOrderMap(groups: Group[]): Map<string, number> {
+  return new Map(groups.map((group) => [group.id, group.sortOrder]));
+}
+
+function getGroupSortOrder(
+  groupId: string,
+  groupSortOrderMap: Map<string, number>
+): number {
+  return groupSortOrderMap.get(groupId) ?? UNKNOWN_GROUP_SORT_ORDER;
+}
+
+function isActiveMember(member: MemberListItem): boolean {
+  return member.groups.some((group) => group.graduatedAt === null);
+}
+
+function resolvePrimaryMemberGroupId(
+  member: MemberListItem,
+  groupSortOrderMap: Map<string, number>
+): string | null {
+  const [primaryGroup] = [...member.groups].sort((a, b) => {
+    const aActiveRank = a.graduatedAt === null ? 0 : 1;
+    const bActiveRank = b.graduatedAt === null ? 0 : 1;
+
+    if (aActiveRank !== bActiveRank) {
+      return aActiveRank - bActiveRank;
+    }
+
+    return (
+      getGroupSortOrder(a.groupId, groupSortOrderMap) -
+      getGroupSortOrder(b.groupId, groupSortOrderMap)
+    );
+  });
+
+  return primaryGroup?.groupId ?? null;
+}
+
+function createSectionBuckets<TItem>(
+  groups: Group[]
+): Map<string, SectionBucket<TItem>> {
+  return new Map(
+    groups.map((group) => [
+      group.id,
+      {
+        group,
+        items: [],
+      },
+    ])
+  );
+}
+
+function getOrCreateUngroupedBucket<TItem>(
+  buckets: Map<string, SectionBucket<TItem>>
+): SectionBucket<TItem> {
+  const existingBucket = buckets.get("");
+
+  if (existingBucket) {
+    return existingBucket;
+  }
+
+  const bucket: SectionBucket<TItem> = {
+    group: null,
+    items: [],
+  };
+  buckets.set("", bucket);
+  return bucket;
+}
+
+export function createMemberSections(
+  members: MemberListItem[],
+  groups: Group[]
+): MemberSection[] {
+  const groupSortOrderMap = createGroupSortOrderMap(groups);
+  const buckets = createSectionBuckets<MemberListItem>(groups);
+
+  members.forEach((member) => {
+    const groupId = resolvePrimaryMemberGroupId(member, groupSortOrderMap);
+    const bucket = groupId
+      ? buckets.get(groupId) ?? getOrCreateUngroupedBucket(buckets)
+      : getOrCreateUngroupedBucket(buckets);
+
+    bucket.items.push(member);
+  });
+
+  return [...buckets.values()]
+    .map((bucket) => ({
+      group: bucket.group,
+      members: bucket.items
+        .map((member, index) => ({ index, member }))
+        .sort((a, b) => {
+          const aActiveRank = isActiveMember(a.member) ? 0 : 1;
+          const bActiveRank = isActiveMember(b.member) ? 0 : 1;
+
+          if (aActiveRank !== bActiveRank) {
+            return aActiveRank - bActiveRank;
+          }
+
+          return a.index - b.index;
+        })
+        .map(({ member }) => member),
+    }))
+    .filter((section) => section.members.length > 0);
+}
+
+export function createSongSections(
+  songs: SongListItem[],
+  groups: Group[]
+): SongSection[] {
+  const buckets = createSectionBuckets<SongListItem>(groups);
+
+  songs.forEach((song) => {
+    const bucket =
+      buckets.get(song.groupId) ?? getOrCreateUngroupedBucket(buckets);
+    bucket.items.push(song);
+  });
+
+  return [...buckets.values()]
+    .map((bucket) => ({
+      group: bucket.group,
+      songs: bucket.items,
+    }))
+    .filter((section) => section.songs.length > 0);
+}

--- a/apps/oshikatsu-web/usecases/readOrbitData.ts
+++ b/apps/oshikatsu-web/usecases/readOrbitData.ts
@@ -16,6 +16,10 @@ import { getMember } from "@/usecases/getMember";
 import { getRelease } from "@/usecases/getRelease";
 import { getSong } from "@/usecases/getSong";
 import { getTopPageContent } from "@/usecases/getTopPageContent";
+import {
+  createMemberSections,
+  createSongSections,
+} from "@/usecases/groupListSections";
 import { listPublicMembers } from "@/usecases/listPublicMembers";
 import { listPublicReleases } from "@/usecases/listPublicReleases";
 import { listPublicSongs } from "@/usecases/listPublicSongs";
@@ -89,6 +93,7 @@ const loadMembersPageData = createSharedReadLoader(
 
       return {
         groups,
+        memberSections: createMemberSections(members, groups),
         members,
       };
     })
@@ -157,6 +162,7 @@ const loadSongsPageData = createSharedReadLoader(
 
       return {
         groups,
+        songSections: createSongSections(songs, groups),
         songs,
       };
     })


### PR DESCRIPTION
## 概要
- `/members` と `/songs` の groupId 未指定時に、グループごとのセクション表示を追加
- UseCase 層で `memberSections` / `songSections` を整形し、既存の `members` / `songs` は維持
- グループ見出しとして縦バー + groupColor + グループ名を表示
- groupId フィルタ適用時は従来通りのフラットなグリッド表示を維持

## 実装メモ
- メンバーの主グループは、現役所属のうち `sortOrder` 最上、現役所属が無い場合は卒業所属のうち `sortOrder` 最上で判定
- セクション内のメンバー順は現役 -> 卒業を明示的に保証し、同じ状態内では既存一覧順を維持
- 未所属または未知のグループは末尾の「未所属」セクションに寄せ、件数表示と表示件数がずれないようにしています

Closes #74

## 検証
- `pnpm --filter oshikatsu-web typecheck`
- `pnpm --filter oshikatsu-web lint`
- `pnpm --filter oshikatsu-web build`

補足: build は sandbox のネットワーク制限で Google Fonts 取得に失敗したため、ネットワーク許可付きで再実行して成功しています。