### PR TITLE
[codex] 坂道グループ楽曲seedデータを追加

### DIFF
--- a/apps/oshikatsu-web/supabase/seeds/030_seed_sakamichi_release_tracks_starter.sql
+++ b/apps/oshikatsu-web/supabase/seeds/030_seed_sakamichi_release_tracks_starter.sql
@@ -1,0 +1,345 @@
+-- ============================================================
+-- Orbit starter seed: Sakamichi releases + lead/representative tracks
+-- ============================================================
+-- Scope:
+-- - Major singles and studio albums for 乃木坂46 / 櫻坂46 / 日向坂46 / 欅坂46 / けやき坂46.
+-- - One or more lead/representative tracks per release.
+-- - Participant rows are approximated from orbit_member_groups by active membership on release_date.
+--
+-- Notes:
+-- - This seed assumes migrations through 026_add_track_group_and_v2_track_rpcs.sql are applied.
+-- - It is intentionally idempotent by natural keys because the current music tables do not have
+--   unique constraints on release or track titles.
+-- - Duration, composer, arranger, and MV URL are set only when confidently known.
+-- - Coupling/full-edition tracklists should be expanded in a later curated pass.
+--
+-- Main sources checked:
+-- - Nogizaka46 discography, Sakurazaka46/Keyakizaka46 discography, Hinatazaka46 discography
+-- - Individual pages/snippets for recent releases such as My Respect, Addiction, Love yourself!,
+--   Cliffhanger, The growing up train, and 2026 release list pages.
+-- ============================================================
+
+BEGIN;
+SET CONSTRAINTS ALL DEFERRED;
+
+CREATE TEMP TABLE orbit_seed_music_items (
+  release_group_name TEXT NOT NULL,
+  release_title TEXT NOT NULL,
+  release_type TEXT NOT NULL,
+  numbering INT,
+  release_date DATE,
+  track_group_name TEXT,
+  track_title TEXT,
+  track_number INT,
+  duration_seconds INT,
+  lyrics_by TEXT,
+  music_by TEXT,
+  arrangement_by TEXT,
+  mv_url TEXT
+) ON COMMIT DROP;
+
+INSERT INTO orbit_seed_music_items (
+  release_group_name,
+  release_title,
+  release_type,
+  numbering,
+  release_date,
+  track_group_name,
+  track_title,
+  track_number,
+  duration_seconds,
+  lyrics_by,
+  music_by,
+  arrangement_by,
+  mv_url
+)
+VALUES
+  -- 乃木坂46 singles
+  ('乃木坂46', 'ぐるぐるカーテン', 'single', 1, '2012-02-22', '乃木坂46', 'ぐるぐるカーテン', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', 'おいでシャンプー', 'single', 2, '2012-05-02', '乃木坂46', 'おいでシャンプー', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', '走れ!Bicycle', 'single', 3, '2012-08-22', '乃木坂46', '走れ!Bicycle', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', '制服のマネキン', 'single', 4, '2012-12-19', '乃木坂46', '制服のマネキン', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', '君の名は希望', 'single', 5, '2013-03-13', '乃木坂46', '君の名は希望', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', 'ガールズルール', 'single', 6, '2013-07-03', '乃木坂46', 'ガールズルール', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', 'バレッタ', 'single', 7, '2013-11-27', '乃木坂46', 'バレッタ', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', '気づいたら片想い', 'single', 8, '2014-04-02', '乃木坂46', '気づいたら片想い', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', '夏のFree&Easy', 'single', 9, '2014-07-09', '乃木坂46', '夏のFree&Easy', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', '何度目の青空か?', 'single', 10, '2014-10-08', '乃木坂46', '何度目の青空か?', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', '命は美しい', 'single', 11, '2015-03-18', '乃木坂46', '命は美しい', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', '太陽ノック', 'single', 12, '2015-07-22', '乃木坂46', '太陽ノック', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', '今、話したい誰かがいる', 'single', 13, '2015-10-28', '乃木坂46', '今、話したい誰かがいる', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', 'ハルジオンが咲く頃', 'single', 14, '2016-03-23', '乃木坂46', 'ハルジオンが咲く頃', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', '裸足でSummer', 'single', 15, '2016-07-27', '乃木坂46', '裸足でSummer', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', 'サヨナラの意味', 'single', 16, '2016-11-09', '乃木坂46', 'サヨナラの意味', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', 'インフルエンサー', 'single', 17, '2017-03-22', '乃木坂46', 'インフルエンサー', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', '逃げ水', 'single', 18, '2017-08-09', '乃木坂46', '逃げ水', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', 'いつかできるから今日できる', 'single', 19, '2017-10-11', '乃木坂46', 'いつかできるから今日できる', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', 'シンクロニシティ', 'single', 20, '2018-04-25', '乃木坂46', 'シンクロニシティ', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', 'ジコチューで行こう!', 'single', 21, '2018-08-08', '乃木坂46', 'ジコチューで行こう!', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', '帰り道は遠回りしたくなる', 'single', 22, '2018-11-14', '乃木坂46', '帰り道は遠回りしたくなる', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', 'Sing Out!', 'single', 23, '2019-05-29', '乃木坂46', 'Sing Out!', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', '夜明けまで強がらなくてもいい', 'single', 24, '2019-09-04', '乃木坂46', '夜明けまで強がらなくてもいい', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', 'しあわせの保護色', 'single', 25, '2020-03-25', '乃木坂46', 'しあわせの保護色', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', '僕は僕を好きになる', 'single', 26, '2021-01-27', '乃木坂46', '僕は僕を好きになる', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', 'ごめんねFingers crossed', 'single', 27, '2021-06-09', '乃木坂46', 'ごめんねFingers crossed', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', '君に叱られた', 'single', 28, '2021-09-22', '乃木坂46', '君に叱られた', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', 'Actually...', 'single', 29, '2022-03-23', '乃木坂46', 'Actually...', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', '好きというのはロックだぜ!', 'single', 30, '2022-08-31', '乃木坂46', '好きというのはロックだぜ!', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', 'ここにはないもの', 'single', 31, '2022-12-07', '乃木坂46', 'ここにはないもの', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', '人は夢を二度見る', 'single', 32, '2023-03-29', '乃木坂46', '人は夢を二度見る', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', 'おひとりさま天国', 'single', 33, '2023-08-23', '乃木坂46', 'おひとりさま天国', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', 'Monopoly', 'single', 34, '2023-12-06', '乃木坂46', 'Monopoly', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', 'チャンスは平等', 'single', 35, '2024-04-10', '乃木坂46', 'チャンスは平等', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', 'チートデイ', 'single', 36, '2024-08-21', '乃木坂46', 'チートデイ', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', '歩道橋', 'single', 37, '2024-12-11', '乃木坂46', '歩道橋', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', 'ネーブルオレンジ', 'single', 38, '2025-03-26', '乃木坂46', 'ネーブルオレンジ', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', 'Same numbers', 'single', 39, '2025-07-30', '乃木坂46', 'Same numbers', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', 'ビリヤニ', 'single', 40, '2025-11-26', '乃木坂46', 'ビリヤニ', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', '最後に階段を駆け上がったのはいつだ?', 'single', 41, '2026-04-08', '乃木坂46', '最後に階段を駆け上がったのはいつだ?', 1, NULL, '秋元康', '古川貴浩', NULL, NULL),
+
+  -- 乃木坂46 albums
+  ('乃木坂46', '透明な色', 'album', 1, '2015-01-07', '乃木坂46', '僕がいる場所', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', 'それぞれの椅子', 'album', 2, '2016-05-25', '乃木坂46', 'きっかけ', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', '生まれてから初めて見た夢', 'album', 3, '2017-05-24', '乃木坂46', 'スカイダイビング', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', '今が思い出になるまで', 'album', 4, '2019-04-17', '乃木坂46', 'ありがちな恋愛', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', 'My respect', 'album', 5, '2026-01-14', '乃木坂46', 'My respect', 1, NULL, '秋元康', NULL, NULL, NULL),
+
+  -- 欅坂46 singles/albums
+  ('欅坂46', 'サイレントマジョリティー', 'single', 1, '2016-04-06', '欅坂46', 'サイレントマジョリティー', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('欅坂46', '世界には愛しかない', 'single', 2, '2016-08-10', '欅坂46', '世界には愛しかない', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('欅坂46', '二人セゾン', 'single', 3, '2016-11-30', '欅坂46', '二人セゾン', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('欅坂46', '不協和音', 'single', 4, '2017-04-05', '欅坂46', '不協和音', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('欅坂46', '風に吹かれても', 'single', 5, '2017-10-25', '欅坂46', '風に吹かれても', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('欅坂46', 'ガラスを割れ!', 'single', 6, '2018-03-07', '欅坂46', 'ガラスを割れ!', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('欅坂46', 'アンビバレント', 'single', 7, '2018-08-15', '欅坂46', 'アンビバレント', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('欅坂46', '黒い羊', 'single', 8, '2019-02-27', '欅坂46', '黒い羊', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('欅坂46', '誰がその鐘を鳴らすのか?', 'digital_single', NULL, '2020-08-21', '欅坂46', '誰がその鐘を鳴らすのか?', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('欅坂46', '真っ白なものは汚したくなる', 'album', 1, '2017-07-19', '欅坂46', '月曜日の朝、スカートを切られた', 1, NULL, '秋元康', NULL, NULL, NULL),
+
+  -- 櫻坂46 singles/albums
+  ('櫻坂46', 'Nobody''s fault', 'single', 1, '2020-12-09', '櫻坂46', 'Nobody''s fault', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('櫻坂46', 'BAN', 'single', 2, '2021-04-14', '櫻坂46', 'BAN', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('櫻坂46', '流れ弾', 'single', 3, '2021-10-13', '櫻坂46', '流れ弾', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('櫻坂46', '五月雨よ', 'single', 4, '2022-04-06', '櫻坂46', '五月雨よ', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('櫻坂46', '桜月', 'single', 5, '2023-02-15', '櫻坂46', '桜月', 1, 282, '秋元康', 'NAZCA', NULL, NULL),
+  ('櫻坂46', 'Start over!', 'single', 6, '2023-06-28', '櫻坂46', 'Start over!', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('櫻坂46', '承認欲求', 'single', 7, '2023-10-18', '櫻坂46', '承認欲求', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('櫻坂46', '何歳の頃に戻りたいのか?', 'single', 8, '2024-02-21', '櫻坂46', '何歳の頃に戻りたいのか?', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('櫻坂46', '自業自得', 'single', 9, '2024-06-26', '櫻坂46', '自業自得', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('櫻坂46', 'I want tomorrow to come', 'single', 10, '2024-10-23', '櫻坂46', 'I want tomorrow to come', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('櫻坂46', 'UDAGAWA GENERATION', 'single', 11, '2025-02-19', '櫻坂46', 'UDAGAWA GENERATION', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('櫻坂46', 'Make or Break', 'single', 12, '2025-06-25', '櫻坂46', 'Make or Break', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('櫻坂46', 'Unhappy birthday構文', 'single', 13, '2025-10-29', '櫻坂46', 'Unhappy birthday構文', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('櫻坂46', 'The growing up train', 'single', 14, '2026-03-11', '櫻坂46', 'The growing up train', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('櫻坂46', 'Lonesome rabbit/What''s "KAZOKU"?', 'single', 15, '2026-06-10', '櫻坂46', 'Lonesome rabbit', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('櫻坂46', 'Lonesome rabbit/What''s "KAZOKU"?', 'single', 15, '2026-06-10', '櫻坂46', 'What''s "KAZOKU"?', 2, NULL, '秋元康', NULL, NULL, NULL),
+  ('櫻坂46', 'As you know?', 'album', 1, '2022-08-03', '櫻坂46', '摩擦係数', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('櫻坂46', 'Addiction', 'album', 2, '2025-04-30', '櫻坂46', 'Addiction', 1, NULL, '秋元康', NULL, NULL, NULL),
+
+  -- けやき坂46 album and representative songs from 欅坂46 releases
+  ('けやき坂46', '走り出す瞬間', 'album', 1, '2018-06-20', 'けやき坂46', '期待していない自分', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('欅坂46', '世界には愛しかない', 'single', 2, '2016-08-10', 'けやき坂46', 'ひらがなけやき', 2, NULL, '秋元康', NULL, NULL, NULL),
+  ('欅坂46', '二人セゾン', 'single', 3, '2016-11-30', 'けやき坂46', '誰よりも高く跳べ!', 2, NULL, '秋元康', NULL, NULL, NULL),
+  ('欅坂46', '不協和音', 'single', 4, '2017-04-05', 'けやき坂46', '僕たちは付き合っている', 2, NULL, '秋元康', NULL, NULL, NULL),
+  ('欅坂46', '風に吹かれても', 'single', 5, '2017-10-25', 'けやき坂46', 'それでも歩いてる', 2, NULL, '秋元康', NULL, NULL, NULL),
+
+  -- 日向坂46 singles/albums
+  ('日向坂46', 'キュン', 'single', 1, '2019-03-27', '日向坂46', 'キュン', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('日向坂46', 'ドレミソラシド', 'single', 2, '2019-07-17', '日向坂46', 'ドレミソラシド', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('日向坂46', 'こんなに好きになっちゃっていいの?', 'single', 3, '2019-10-02', '日向坂46', 'こんなに好きになっちゃっていいの?', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('日向坂46', 'ソンナコトナイヨ', 'single', 4, '2020-02-19', '日向坂46', 'ソンナコトナイヨ', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('日向坂46', '君しか勝たん', 'single', 5, '2021-05-26', '日向坂46', '君しか勝たん', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('日向坂46', 'ってか', 'single', 6, '2021-10-27', '日向坂46', 'ってか', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('日向坂46', '僕なんか', 'single', 7, '2022-06-01', '日向坂46', '僕なんか', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('日向坂46', '月と星が踊るMidnight', 'single', 8, '2022-10-26', '日向坂46', '月と星が踊るMidnight', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('日向坂46', 'One choice', 'single', 9, '2023-04-19', '日向坂46', 'One choice', 1, 284, '秋元康', NULL, NULL, NULL),
+  ('日向坂46', 'Am I ready?', 'single', 10, '2023-07-26', '日向坂46', 'Am I ready?', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('日向坂46', '君はハニーデュー', 'single', 11, '2024-05-08', '日向坂46', '君はハニーデュー', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('日向坂46', '絶対的第六感', 'single', 12, '2024-09-18', '日向坂46', '絶対的第六感', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('日向坂46', '卒業写真だけが知ってる', 'single', 13, '2025-01-29', '日向坂46', '卒業写真だけが知ってる', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('日向坂46', 'Love yourself!', 'single', 14, '2025-05-21', '日向坂46', 'Love yourself!', 1, 260, '秋元康', '川口進 / 草川瞬 / 佐原康太', NULL, NULL),
+  ('日向坂46', 'お願いバッハ!', 'single', 15, '2025-09-17', '日向坂46', 'お願いバッハ!', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('日向坂46', 'クリフハンガー', 'single', 16, '2026-01-28', '日向坂46', 'クリフハンガー', 1, NULL, '秋元康', '杉山勝彦', '杉山勝彦 / 谷地学', NULL),
+  ('日向坂46', 'Kind of love', 'single', 17, '2026-05-20', '日向坂46', 'Kind of love', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('日向坂46', 'ひなたざか', 'album', 1, '2020-09-23', '日向坂46', 'アザトカワイイ', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('日向坂46', '脈打つ感情', 'album', 2, '2023-11-08', '日向坂46', '君は0から1になれ', 1, NULL, '秋元康', NULL, NULL, NULL);
+
+-- Releases
+INSERT INTO public.orbit_releases (
+  title,
+  group_id,
+  release_type,
+  numbering,
+  release_date
+)
+SELECT DISTINCT
+  seed.release_title,
+  release_group.id,
+  seed.release_type,
+  seed.numbering,
+  seed.release_date
+FROM orbit_seed_music_items seed
+JOIN public.orbit_groups release_group
+  ON release_group.name_ja = seed.release_group_name
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM public.orbit_releases existing
+  WHERE existing.title = seed.release_title
+    AND existing.group_id = release_group.id
+    AND existing.release_type = seed.release_type
+    AND COALESCE(existing.numbering, -1) = COALESCE(seed.numbering, -1)
+);
+
+-- Tracks
+INSERT INTO public.orbit_tracks (
+  title,
+  group_id,
+  duration_seconds
+)
+SELECT DISTINCT
+  seed.track_title,
+  track_group.id,
+  seed.duration_seconds
+FROM orbit_seed_music_items seed
+JOIN public.orbit_groups track_group
+  ON track_group.name_ja = seed.track_group_name
+WHERE seed.track_title IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1
+    FROM public.orbit_tracks existing
+    WHERE existing.title = seed.track_title
+      AND existing.group_id = track_group.id
+  );
+
+-- Release-track links
+INSERT INTO public.orbit_release_tracks (
+  release_id,
+  track_id,
+  track_number
+)
+SELECT
+  release.id,
+  track.id,
+  seed.track_number
+FROM orbit_seed_music_items seed
+JOIN public.orbit_groups release_group
+  ON release_group.name_ja = seed.release_group_name
+JOIN public.orbit_releases release
+  ON release.title = seed.release_title
+  AND release.group_id = release_group.id
+  AND release.release_type = seed.release_type
+  AND COALESCE(release.numbering, -1) = COALESCE(seed.numbering, -1)
+JOIN public.orbit_groups track_group
+  ON track_group.name_ja = seed.track_group_name
+JOIN public.orbit_tracks track
+  ON track.title = seed.track_title
+  AND track.group_id = track_group.id
+WHERE seed.track_title IS NOT NULL
+  AND seed.track_number IS NOT NULL
+ON CONFLICT (release_id, track_number) DO NOTHING;
+
+-- People
+WITH raw_people AS (
+  SELECT lyrics_by AS names FROM orbit_seed_music_items
+  UNION ALL
+  SELECT music_by AS names FROM orbit_seed_music_items
+  UNION ALL
+  SELECT arrangement_by AS names FROM orbit_seed_music_items
+),
+people AS (
+  SELECT DISTINCT NULLIF(BTRIM(person_name), '') AS display_name
+  FROM raw_people
+  CROSS JOIN LATERAL regexp_split_to_table(COALESCE(raw_people.names, ''), '\s*/\s*|、') AS person_name
+)
+INSERT INTO public.orbit_people (display_name)
+SELECT display_name
+FROM people
+WHERE display_name IS NOT NULL
+ON CONFLICT (display_name) DO NOTHING;
+
+-- Credits
+WITH credit_source AS (
+  SELECT seed.track_title, seed.track_group_name, 'lyrics'::TEXT AS credit_role, seed.lyrics_by AS names
+  FROM orbit_seed_music_items seed
+  UNION ALL
+  SELECT seed.track_title, seed.track_group_name, 'music'::TEXT AS credit_role, seed.music_by AS names
+  FROM orbit_seed_music_items seed
+  UNION ALL
+  SELECT seed.track_title, seed.track_group_name, 'arrangement'::TEXT AS credit_role, seed.arrangement_by AS names
+  FROM orbit_seed_music_items seed
+),
+credit_people AS (
+  SELECT
+    credit_source.track_title,
+    credit_source.track_group_name,
+    credit_source.credit_role,
+    NULLIF(BTRIM(person_name), '') AS display_name,
+    (ordinality - 1)::INT AS sort_order
+  FROM credit_source
+  CROSS JOIN LATERAL regexp_split_to_table(COALESCE(credit_source.names, ''), '\s*/\s*|、') WITH ORDINALITY AS split(person_name, ordinality)
+)
+INSERT INTO public.orbit_track_credits (
+  track_id,
+  credit_role,
+  person_id,
+  sort_order
+)
+SELECT DISTINCT
+  track.id,
+  credit_people.credit_role,
+  person.id,
+  credit_people.sort_order
+FROM credit_people
+JOIN public.orbit_groups track_group
+  ON track_group.name_ja = credit_people.track_group_name
+JOIN public.orbit_tracks track
+  ON track.title = credit_people.track_title
+  AND track.group_id = track_group.id
+JOIN public.orbit_people person
+  ON person.display_name = credit_people.display_name
+WHERE credit_people.display_name IS NOT NULL
+ON CONFLICT (track_id, credit_role, person_id) DO NOTHING;
+
+-- MV links
+INSERT INTO public.orbit_track_mvs (
+  track_id,
+  mv_url
+)
+SELECT DISTINCT
+  track.id,
+  seed.mv_url
+FROM orbit_seed_music_items seed
+JOIN public.orbit_groups track_group
+  ON track_group.name_ja = seed.track_group_name
+JOIN public.orbit_tracks track
+  ON track.title = seed.track_title
+  AND track.group_id = track_group.id
+WHERE seed.mv_url IS NOT NULL
+ON CONFLICT (track_id) DO UPDATE
+SET mv_url = EXCLUDED.mv_url;
+
+-- Approximate release participants from member group history.
+-- This uses all members who belonged to the release group on release_date.
+INSERT INTO public.orbit_release_members (
+  release_id,
+  member_id
+)
+SELECT DISTINCT
+  release.id,
+  member_group.member_id
+FROM orbit_seed_music_items seed
+JOIN public.orbit_groups release_group
+  ON release_group.name_ja = seed.release_group_name
+JOIN public.orbit_releases release
+  ON release.title = seed.release_title
+  AND release.group_id = release_group.id
+  AND release.release_type = seed.release_type
+  AND COALESCE(release.numbering, -1) = COALESCE(seed.numbering, -1)
+JOIN public.orbit_member_groups member_group
+  ON member_group.group_id = release_group.id
+WHERE seed.release_date IS NOT NULL
+  AND (member_group.joined_at IS NULL OR member_group.joined_at <= seed.release_date)
+  AND (member_group.graduated_at IS NULL OR member_group.graduated_at >= seed.release_date)
+ON CONFLICT (release_id, member_id) DO NOTHING;
+
+COMMIT;

--- a/apps/oshikatsu-web/supabase/seeds/030_seed_sakamichi_release_tracks_starter.sql
+++ b/apps/oshikatsu-web/supabase/seeds/030_seed_sakamichi_release_tracks_starter.sql
@@ -19,8 +19,11 @@
 --   Cliffhanger, The growing up train, and 2026 release list pages.
 -- ============================================================
 
-BEGIN;
+DO $seed$
+BEGIN
 SET CONSTRAINTS ALL DEFERRED;
+
+DROP TABLE IF EXISTS orbit_seed_music_items;
 
 CREATE TEMP TABLE orbit_seed_music_items (
   release_group_name TEXT NOT NULL,
@@ -36,7 +39,7 @@ CREATE TEMP TABLE orbit_seed_music_items (
   music_by TEXT,
   arrangement_by TEXT,
   mv_url TEXT
-) ON COMMIT DROP;
+) ON COMMIT PRESERVE ROWS;
 
 INSERT INTO orbit_seed_music_items (
   release_group_name,
@@ -342,4 +345,7 @@ WHERE seed.release_date IS NOT NULL
   AND (member_group.graduated_at IS NULL OR member_group.graduated_at >= seed.release_date)
 ON CONFLICT (release_id, member_id) DO NOTHING;
 
-COMMIT;
+DROP TABLE IF EXISTS orbit_seed_music_items;
+
+END;
+$seed$;

--- a/apps/oshikatsu-web/supabase/seeds/031_seed_sakamichi_tracks_expanded.sql
+++ b/apps/oshikatsu-web/supabase/seeds/031_seed_sakamichi_tracks_expanded.sql
@@ -1,0 +1,322 @@
+-- ============================================================
+-- Orbit starter seed: Sakamichi tracks
+-- ============================================================
+-- Scope:
+-- - Lead/representative tracks for releases inserted by
+--   030_seed_sakamichi_release_tracks_starter.sql or equivalent release seed.
+-- - A small set of important coupling/album lead tracks.
+--
+-- Notes:
+-- - This file does not create releases. It only inserts tracks and release-track links
+--   for releases already present in public.orbit_releases.
+-- - orbit_tracks has a deferred constraint requiring at least one release link.
+--   To avoid orphan tracks, this seed inserts tracks only when the target release exists
+--   and the target track_number is not already occupied by a different track.
+-- - Durations, composer/arranger, and MV URLs are intentionally sparse.
+--   NULL means "not curated yet", not "does not exist".
+-- ============================================================
+
+BEGIN;
+SET CONSTRAINTS ALL DEFERRED;
+
+CREATE TEMP TABLE orbit_seed_track_items (
+  release_group_name TEXT NOT NULL,
+  release_title TEXT NOT NULL,
+  release_type TEXT NOT NULL,
+  release_numbering INT,
+  track_group_name TEXT NOT NULL,
+  track_title TEXT NOT NULL,
+  track_number INT NOT NULL,
+  duration_seconds INT,
+  lyrics_by TEXT,
+  music_by TEXT,
+  arrangement_by TEXT,
+  mv_url TEXT
+) ON COMMIT DROP;
+
+INSERT INTO orbit_seed_track_items (
+  release_group_name,
+  release_title,
+  release_type,
+  release_numbering,
+  track_group_name,
+  track_title,
+  track_number,
+  duration_seconds,
+  lyrics_by,
+  music_by,
+  arrangement_by,
+  mv_url
+)
+VALUES
+  -- 乃木坂46: singles
+  ('乃木坂46', 'ぐるぐるカーテン', 'single', 1, '乃木坂46', 'ぐるぐるカーテン', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', 'ぐるぐるカーテン', 'single', 1, '乃木坂46', '乃木坂の詩', 2, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', 'おいでシャンプー', 'single', 2, '乃木坂46', 'おいでシャンプー', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', '走れ!Bicycle', 'single', 3, '乃木坂46', '走れ!Bicycle', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', '制服のマネキン', 'single', 4, '乃木坂46', '制服のマネキン', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', '君の名は希望', 'single', 5, '乃木坂46', '君の名は希望', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', '君の名は希望', 'single', 5, '乃木坂46', '13日の金曜日', 2, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', 'ガールズルール', 'single', 6, '乃木坂46', 'ガールズルール', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', 'バレッタ', 'single', 7, '乃木坂46', 'バレッタ', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', '気づいたら片想い', 'single', 8, '乃木坂46', '気づいたら片想い', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', '夏のFree&Easy', 'single', 9, '乃木坂46', '夏のFree&Easy', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', '何度目の青空か?', 'single', 10, '乃木坂46', '何度目の青空か?', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', '命は美しい', 'single', 11, '乃木坂46', '命は美しい', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', '太陽ノック', 'single', 12, '乃木坂46', '太陽ノック', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', '今、話したい誰かがいる', 'single', 13, '乃木坂46', '今、話したい誰かがいる', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', 'ハルジオンが咲く頃', 'single', 14, '乃木坂46', 'ハルジオンが咲く頃', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', '裸足でSummer', 'single', 15, '乃木坂46', '裸足でSummer', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', 'サヨナラの意味', 'single', 16, '乃木坂46', 'サヨナラの意味', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', 'インフルエンサー', 'single', 17, '乃木坂46', 'インフルエンサー', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', '逃げ水', 'single', 18, '乃木坂46', '逃げ水', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', 'いつかできるから今日できる', 'single', 19, '乃木坂46', 'いつかできるから今日できる', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', 'シンクロニシティ', 'single', 20, '乃木坂46', 'シンクロニシティ', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', 'ジコチューで行こう!', 'single', 21, '乃木坂46', 'ジコチューで行こう!', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', '帰り道は遠回りしたくなる', 'single', 22, '乃木坂46', '帰り道は遠回りしたくなる', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', 'Sing Out!', 'single', 23, '乃木坂46', 'Sing Out!', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', '夜明けまで強がらなくてもいい', 'single', 24, '乃木坂46', '夜明けまで強がらなくてもいい', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', 'しあわせの保護色', 'single', 25, '乃木坂46', 'しあわせの保護色', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', '僕は僕を好きになる', 'single', 26, '乃木坂46', '僕は僕を好きになる', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', 'ごめんねFingers crossed', 'single', 27, '乃木坂46', 'ごめんねFingers crossed', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', '君に叱られた', 'single', 28, '乃木坂46', '君に叱られた', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', 'Actually...', 'single', 29, '乃木坂46', 'Actually...', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', '好きというのはロックだぜ!', 'single', 30, '乃木坂46', '好きというのはロックだぜ!', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', 'ここにはないもの', 'single', 31, '乃木坂46', 'ここにはないもの', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', '人は夢を二度見る', 'single', 32, '乃木坂46', '人は夢を二度見る', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', 'おひとりさま天国', 'single', 33, '乃木坂46', 'おひとりさま天国', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', 'Monopoly', 'single', 34, '乃木坂46', 'Monopoly', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', 'チャンスは平等', 'single', 35, '乃木坂46', 'チャンスは平等', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', 'チートデイ', 'single', 36, '乃木坂46', 'チートデイ', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', '歩道橋', 'single', 37, '乃木坂46', '歩道橋', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', 'ネーブルオレンジ', 'single', 38, '乃木坂46', 'ネーブルオレンジ', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', 'Same numbers', 'single', 39, '乃木坂46', 'Same numbers', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', 'ビリヤニ', 'single', 40, '乃木坂46', 'ビリヤニ', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', '最後に階段を駆け上がったのはいつだ?', 'single', 41, '乃木坂46', '最後に階段を駆け上がったのはいつだ?', 1, NULL, '秋元康', '古川貴浩', NULL, NULL),
+
+  -- 乃木坂46: albums / digital representative songs
+  ('乃木坂46', '透明な色', 'album', 1, '乃木坂46', '僕がいる場所', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', 'それぞれの椅子', 'album', 2, '乃木坂46', 'きっかけ', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', '生まれてから初めて見た夢', 'album', 3, '乃木坂46', 'スカイダイビング', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', '今が思い出になるまで', 'album', 4, '乃木坂46', 'ありがちな恋愛', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('乃木坂46', 'My respect', 'album', 5, '乃木坂46', 'My respect', 1, NULL, '秋元康', NULL, NULL, NULL),
+
+  -- 欅坂46
+  ('欅坂46', 'サイレントマジョリティー', 'single', 1, '欅坂46', 'サイレントマジョリティー', 1, NULL, '秋元康', 'バグベア', NULL, NULL),
+  ('欅坂46', 'サイレントマジョリティー', 'single', 1, '欅坂46', '手を繋いで帰ろうか', 2, NULL, '秋元康', NULL, NULL, NULL),
+  ('欅坂46', '世界には愛しかない', 'single', 2, '欅坂46', '世界には愛しかない', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('欅坂46', '世界には愛しかない', 'single', 2, 'けやき坂46', 'ひらがなけやき', 2, NULL, '秋元康', NULL, NULL, NULL),
+  ('欅坂46', '二人セゾン', 'single', 3, '欅坂46', '二人セゾン', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('欅坂46', '二人セゾン', 'single', 3, 'けやき坂46', '誰よりも高く跳べ!', 2, NULL, '秋元康', NULL, NULL, NULL),
+  ('欅坂46', '不協和音', 'single', 4, '欅坂46', '不協和音', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('欅坂46', '不協和音', 'single', 4, 'けやき坂46', '僕たちは付き合っている', 2, NULL, '秋元康', NULL, NULL, NULL),
+  ('欅坂46', '風に吹かれても', 'single', 5, '欅坂46', '風に吹かれても', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('欅坂46', '風に吹かれても', 'single', 5, 'けやき坂46', 'それでも歩いてる', 2, NULL, '秋元康', NULL, NULL, NULL),
+  ('欅坂46', 'ガラスを割れ!', 'single', 6, '欅坂46', 'ガラスを割れ!', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('欅坂46', 'アンビバレント', 'single', 7, '欅坂46', 'アンビバレント', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('欅坂46', '黒い羊', 'single', 8, '欅坂46', '黒い羊', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('欅坂46', '誰がその鐘を鳴らすのか?', 'digital_single', NULL, '欅坂46', '誰がその鐘を鳴らすのか?', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('欅坂46', '真っ白なものは汚したくなる', 'album', 1, '欅坂46', '月曜日の朝、スカートを切られた', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('欅坂46', '真っ白なものは汚したくなる', 'album', 1, 'けやき坂46', '沈黙した恋人よ', 2, NULL, '秋元康', NULL, NULL, NULL),
+
+  -- けやき坂46
+  ('けやき坂46', '走り出す瞬間', 'album', 1, 'けやき坂46', '期待していない自分', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('けやき坂46', '走り出す瞬間', 'album', 1, 'けやき坂46', 'ハッピーオーラ', 2, NULL, '秋元康', NULL, NULL, NULL),
+  ('けやき坂46', '走り出す瞬間', 'album', 1, 'けやき坂46', '半分の記憶', 3, NULL, '秋元康', NULL, NULL, NULL),
+
+  -- 櫻坂46
+  ('櫻坂46', 'Nobody''s fault', 'single', 1, '櫻坂46', 'Nobody''s fault', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('櫻坂46', 'Nobody''s fault', 'single', 1, '櫻坂46', 'なぜ 恋をして来なかったんだろう?', 2, NULL, '秋元康', NULL, NULL, NULL),
+  ('櫻坂46', 'Nobody''s fault', 'single', 1, '櫻坂46', 'Buddies', 3, NULL, '秋元康', NULL, NULL, NULL),
+  ('櫻坂46', 'BAN', 'single', 2, '櫻坂46', 'BAN', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('櫻坂46', 'BAN', 'single', 2, '櫻坂46', '偶然の答え', 2, NULL, '秋元康', NULL, NULL, NULL),
+  ('櫻坂46', '流れ弾', 'single', 3, '櫻坂46', '流れ弾', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('櫻坂46', '流れ弾', 'single', 3, '櫻坂46', '無言の宇宙', 2, NULL, '秋元康', NULL, NULL, NULL),
+  ('櫻坂46', '五月雨よ', 'single', 4, '櫻坂46', '五月雨よ', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('櫻坂46', '桜月', 'single', 5, '櫻坂46', '桜月', 1, 282, '秋元康', 'NAZCA', NULL, NULL),
+  ('櫻坂46', '桜月', 'single', 5, '櫻坂46', '夏の近道', 2, NULL, '秋元康', NULL, NULL, NULL),
+  ('櫻坂46', 'Start over!', 'single', 6, '櫻坂46', 'Start over!', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('櫻坂46', 'Start over!', 'single', 6, '櫻坂46', '静寂の暴力', 2, NULL, '秋元康', NULL, NULL, NULL),
+  ('櫻坂46', '承認欲求', 'single', 7, '櫻坂46', '承認欲求', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('櫻坂46', '何歳の頃に戻りたいのか?', 'single', 8, '櫻坂46', '何歳の頃に戻りたいのか?', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('櫻坂46', '自業自得', 'single', 9, '櫻坂46', '自業自得', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('櫻坂46', 'I want tomorrow to come', 'single', 10, '櫻坂46', 'I want tomorrow to come', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('櫻坂46', 'UDAGAWA GENERATION', 'single', 11, '櫻坂46', 'UDAGAWA GENERATION', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('櫻坂46', 'Make or Break', 'single', 12, '櫻坂46', 'Make or Break', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('櫻坂46', 'Unhappy birthday構文', 'single', 13, '櫻坂46', 'Unhappy birthday構文', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('櫻坂46', 'The growing up train', 'single', 14, '櫻坂46', 'The growing up train', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('櫻坂46', 'Lonesome rabbit/What''s "KAZOKU"?', 'single', 15, '櫻坂46', 'Lonesome rabbit', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('櫻坂46', 'Lonesome rabbit/What''s "KAZOKU"?', 'single', 15, '櫻坂46', 'What''s "KAZOKU"?', 2, NULL, '秋元康', NULL, NULL, NULL),
+  ('櫻坂46', 'As you know?', 'album', 1, '櫻坂46', '摩擦係数', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('櫻坂46', 'Addiction', 'album', 2, '櫻坂46', 'Addiction', 1, NULL, '秋元康', NULL, NULL, NULL),
+
+  -- 日向坂46
+  ('日向坂46', 'キュン', 'single', 1, '日向坂46', 'キュン', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('日向坂46', 'キュン', 'single', 1, '日向坂46', 'JOYFUL LOVE', 2, NULL, '秋元康', NULL, NULL, NULL),
+  ('日向坂46', 'ドレミソラシド', 'single', 2, '日向坂46', 'ドレミソラシド', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('日向坂46', 'ドレミソラシド', 'single', 2, '日向坂46', 'キツネ', 2, NULL, '秋元康', NULL, NULL, NULL),
+  ('日向坂46', 'こんなに好きになっちゃっていいの?', 'single', 3, '日向坂46', 'こんなに好きになっちゃっていいの?', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('日向坂46', 'こんなに好きになっちゃっていいの?', 'single', 3, '日向坂46', 'ホントの時間', 2, NULL, '秋元康', NULL, NULL, NULL),
+  ('日向坂46', 'ソンナコトナイヨ', 'single', 4, '日向坂46', 'ソンナコトナイヨ', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('日向坂46', 'ソンナコトナイヨ', 'single', 4, '日向坂46', '青春の馬', 2, NULL, '秋元康', NULL, NULL, NULL),
+  ('日向坂46', '君しか勝たん', 'single', 5, '日向坂46', '君しか勝たん', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('日向坂46', 'ってか', 'single', 6, '日向坂46', 'ってか', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('日向坂46', '僕なんか', 'single', 7, '日向坂46', '僕なんか', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('日向坂46', '僕なんか', 'single', 7, '日向坂46', '飛行機雲ができる理由', 2, NULL, '秋元康', NULL, NULL, NULL),
+  ('日向坂46', '月と星が踊るMidnight', 'single', 8, '日向坂46', '月と星が踊るMidnight', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('日向坂46', '月と星が踊るMidnight', 'single', 8, '日向坂46', 'ブルーベリー&ラズベリー', 2, NULL, '秋元康', NULL, NULL, NULL),
+  ('日向坂46', 'One choice', 'single', 9, '日向坂46', 'One choice', 1, 284, '秋元康', NULL, NULL, NULL),
+  ('日向坂46', 'One choice', 'single', 9, '日向坂46', '恋は逃げ足が早い', 2, 244, '秋元康', NULL, NULL, NULL),
+  ('日向坂46', 'Am I ready?', 'single', 10, '日向坂46', 'Am I ready?', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('日向坂46', 'Am I ready?', 'single', 10, '日向坂46', '見たことない魔物', 2, NULL, '秋元康', NULL, NULL, NULL),
+  ('日向坂46', '君はハニーデュー', 'single', 11, '日向坂46', '君はハニーデュー', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('日向坂46', '絶対的第六感', 'single', 12, '日向坂46', '絶対的第六感', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('日向坂46', '卒業写真だけが知ってる', 'single', 13, '日向坂46', '卒業写真だけが知ってる', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('日向坂46', 'Love yourself!', 'single', 14, '日向坂46', 'Love yourself!', 1, 260, '秋元康', '川口進 / 草川瞬 / 佐原康太', NULL, NULL),
+  ('日向坂46', 'Love yourself!', 'single', 14, '日向坂46', 'German Iris', 2, NULL, '秋元康', NULL, NULL, NULL),
+  ('日向坂46', 'お願いバッハ!', 'single', 15, '日向坂46', 'お願いバッハ!', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('日向坂46', 'クリフハンガー', 'single', 16, '日向坂46', 'クリフハンガー', 1, NULL, '秋元康', '杉山勝彦', '杉山勝彦 / 谷地学', NULL),
+  ('日向坂46', 'クリフハンガー', 'single', 16, '日向坂46', '涙目の太陽', 2, NULL, '松田好花', NULL, NULL, NULL),
+  ('日向坂46', 'Kind of love', 'single', 17, '日向坂46', 'Kind of love', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('日向坂46', 'ひなたざか', 'album', 1, '日向坂46', 'アザトカワイイ', 1, NULL, '秋元康', NULL, NULL, NULL),
+  ('日向坂46', '脈打つ感情', 'album', 2, '日向坂46', '君は0から1になれ', 1, NULL, '秋元康', NULL, NULL, NULL);
+
+CREATE TEMP TABLE orbit_seed_resolved_track_items ON COMMIT DROP AS
+SELECT
+  seed.*,
+  release.id AS release_id,
+  track_group.id AS track_group_id
+FROM orbit_seed_track_items seed
+JOIN public.orbit_groups release_group
+  ON release_group.name_ja = seed.release_group_name
+JOIN public.orbit_releases release
+  ON release.title = seed.release_title
+  AND release.group_id = release_group.id
+  AND release.release_type = seed.release_type
+  AND release.numbering IS NOT DISTINCT FROM seed.release_numbering
+JOIN public.orbit_groups track_group
+  ON track_group.name_ja = seed.track_group_name
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM public.orbit_release_tracks existing_release_track
+  JOIN public.orbit_tracks existing_track
+    ON existing_track.id = existing_release_track.track_id
+  WHERE existing_release_track.release_id = release.id
+    AND existing_release_track.track_number = seed.track_number
+    AND (
+      existing_track.title <> seed.track_title
+      OR existing_track.group_id <> track_group.id
+    )
+);
+
+-- Tracks
+INSERT INTO public.orbit_tracks (
+  title,
+  group_id,
+  duration_seconds
+)
+SELECT DISTINCT
+  seed.track_title,
+  seed.track_group_id,
+  seed.duration_seconds
+FROM orbit_seed_resolved_track_items seed
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM public.orbit_tracks existing
+  WHERE existing.title = seed.track_title
+    AND existing.group_id = seed.track_group_id
+);
+
+-- Release-track links
+INSERT INTO public.orbit_release_tracks (
+  release_id,
+  track_id,
+  track_number
+)
+SELECT DISTINCT
+  seed.release_id,
+  track.id,
+  seed.track_number
+FROM orbit_seed_resolved_track_items seed
+JOIN public.orbit_tracks track
+  ON track.title = seed.track_title
+  AND track.group_id = seed.track_group_id
+ON CONFLICT (release_id, track_id) DO NOTHING;
+
+-- People
+WITH raw_people AS (
+  SELECT lyrics_by AS names FROM orbit_seed_resolved_track_items
+  UNION ALL
+  SELECT music_by AS names FROM orbit_seed_resolved_track_items
+  UNION ALL
+  SELECT arrangement_by AS names FROM orbit_seed_resolved_track_items
+),
+people AS (
+  SELECT DISTINCT NULLIF(BTRIM(person_name), '') AS display_name
+  FROM raw_people
+  CROSS JOIN LATERAL regexp_split_to_table(COALESCE(raw_people.names, ''), '[[:space:]]*/[[:space:]]*|、') AS person_name
+)
+INSERT INTO public.orbit_people (display_name)
+SELECT display_name
+FROM people
+WHERE display_name IS NOT NULL
+ON CONFLICT (display_name) DO NOTHING;
+
+-- Credits
+WITH credit_source AS (
+  SELECT track_title, track_group_id, 'lyrics'::TEXT AS credit_role, lyrics_by AS names
+  FROM orbit_seed_resolved_track_items
+  UNION ALL
+  SELECT track_title, track_group_id, 'music'::TEXT AS credit_role, music_by AS names
+  FROM orbit_seed_resolved_track_items
+  UNION ALL
+  SELECT track_title, track_group_id, 'arrangement'::TEXT AS credit_role, arrangement_by AS names
+  FROM orbit_seed_resolved_track_items
+),
+credit_people AS (
+  SELECT
+    credit_source.track_title,
+    credit_source.track_group_id,
+    credit_source.credit_role,
+    NULLIF(BTRIM(person_name), '') AS display_name,
+    (ordinality - 1)::INT AS sort_order
+  FROM credit_source
+  CROSS JOIN LATERAL regexp_split_to_table(COALESCE(credit_source.names, ''), '[[:space:]]*/[[:space:]]*|、') WITH ORDINALITY AS split(person_name, ordinality)
+)
+INSERT INTO public.orbit_track_credits (
+  track_id,
+  credit_role,
+  person_id,
+  sort_order
+)
+SELECT DISTINCT
+  track.id,
+  credit_people.credit_role,
+  person.id,
+  credit_people.sort_order
+FROM credit_people
+JOIN public.orbit_tracks track
+  ON track.title = credit_people.track_title
+  AND track.group_id = credit_people.track_group_id
+JOIN public.orbit_people person
+  ON person.display_name = credit_people.display_name
+WHERE credit_people.display_name IS NOT NULL
+ON CONFLICT (track_id, credit_role, person_id) DO NOTHING;
+
+-- MV links
+INSERT INTO public.orbit_track_mvs (
+  track_id,
+  mv_url
+)
+SELECT DISTINCT
+  track.id,
+  seed.mv_url
+FROM orbit_seed_resolved_track_items seed
+JOIN public.orbit_tracks track
+  ON track.title = seed.track_title
+  AND track.group_id = seed.track_group_id
+WHERE seed.mv_url IS NOT NULL
+ON CONFLICT (track_id) DO UPDATE
+SET mv_url = EXCLUDED.mv_url;
+
+COMMIT;

--- a/apps/oshikatsu-web/supabase/seeds/031_seed_sakamichi_tracks_expanded.sql
+++ b/apps/oshikatsu-web/supabase/seeds/031_seed_sakamichi_tracks_expanded.sql
@@ -16,8 +16,12 @@
 --   NULL means "not curated yet", not "does not exist".
 -- ============================================================
 
-BEGIN;
+DO $seed$
+BEGIN
 SET CONSTRAINTS ALL DEFERRED;
+
+DROP TABLE IF EXISTS orbit_seed_resolved_track_items;
+DROP TABLE IF EXISTS orbit_seed_track_items;
 
 CREATE TEMP TABLE orbit_seed_track_items (
   release_group_name TEXT NOT NULL,
@@ -32,7 +36,7 @@ CREATE TEMP TABLE orbit_seed_track_items (
   music_by TEXT,
   arrangement_by TEXT,
   mv_url TEXT
-) ON COMMIT DROP;
+) ON COMMIT PRESERVE ROWS;
 
 INSERT INTO orbit_seed_track_items (
   release_group_name,
@@ -181,7 +185,7 @@ VALUES
   ('日向坂46', 'ひなたざか', 'album', 1, '日向坂46', 'アザトカワイイ', 1, NULL, '秋元康', NULL, NULL, NULL),
   ('日向坂46', '脈打つ感情', 'album', 2, '日向坂46', '君は0から1になれ', 1, NULL, '秋元康', NULL, NULL, NULL);
 
-CREATE TEMP TABLE orbit_seed_resolved_track_items ON COMMIT DROP AS
+CREATE TEMP TABLE orbit_seed_resolved_track_items ON COMMIT PRESERVE ROWS AS
 SELECT
   seed.*,
   release.id AS release_id,
@@ -319,4 +323,8 @@ WHERE seed.mv_url IS NOT NULL
 ON CONFLICT (track_id) DO UPDATE
 SET mv_url = EXCLUDED.mv_url;
 
-COMMIT;
+DROP TABLE IF EXISTS orbit_seed_resolved_track_items;
+DROP TABLE IF EXISTS orbit_seed_track_items;
+
+END;
+$seed$;

--- a/apps/oshikatsu-web/supabase/seeds/032_seed_sakamichi_single_tracks_expanded.sql
+++ b/apps/oshikatsu-web/supabase/seeds/032_seed_sakamichi_single_tracks_expanded.sql
@@ -24,8 +24,13 @@
 --   I want tomorrow to come, Unhappy birthday構文, Love yourself!, クリフハンガー.
 -- ============================================================
 
-BEGIN;
+DO $seed$
+BEGIN
 SET CONSTRAINTS ALL DEFERRED;
+
+DROP TABLE IF EXISTS orbit_seed_resolved_single_tracks;
+DROP TABLE IF EXISTS orbit_seed_single_tracks;
+DROP TABLE IF EXISTS orbit_seed_single_track_groups;
 
 CREATE TEMP TABLE orbit_seed_single_track_groups (
   release_group_name TEXT NOT NULL,
@@ -34,7 +39,7 @@ CREATE TEMP TABLE orbit_seed_single_track_groups (
   release_numbering INT,
   track_group_name TEXT NOT NULL,
   track_titles TEXT[] NOT NULL
-) ON COMMIT DROP;
+) ON COMMIT PRESERVE ROWS;
 
 INSERT INTO orbit_seed_single_track_groups (
   release_group_name,
@@ -142,7 +147,7 @@ VALUES
   ('日向坂46', 'クリフハンガー', 'single', 16, '日向坂46', ARRAY['クリフハンガー', '涙目の太陽', 'Surf''s Up Girl', '好きになるクレッシェンド']),
   ('日向坂46', 'Kind of love', 'single', 17, '日向坂46', ARRAY['Kind of love']);
 
-CREATE TEMP TABLE orbit_seed_single_tracks ON COMMIT DROP AS
+CREATE TEMP TABLE orbit_seed_single_tracks ON COMMIT PRESERVE ROWS AS
 SELECT
   groups.release_group_name,
   groups.release_title,
@@ -154,7 +159,7 @@ SELECT
 FROM orbit_seed_single_track_groups groups
 CROSS JOIN LATERAL unnest(groups.track_titles) WITH ORDINALITY AS tracks(track_title, track_order);
 
-CREATE TEMP TABLE orbit_seed_resolved_single_tracks ON COMMIT DROP AS
+CREATE TEMP TABLE orbit_seed_resolved_single_tracks ON COMMIT PRESERVE ROWS AS
 SELECT
   seed.*,
   release.id AS release_id,
@@ -234,4 +239,9 @@ SELECT
 FROM numbered_links
 ON CONFLICT (release_id, track_id) DO NOTHING;
 
-COMMIT;
+DROP TABLE IF EXISTS orbit_seed_resolved_single_tracks;
+DROP TABLE IF EXISTS orbit_seed_single_tracks;
+DROP TABLE IF EXISTS orbit_seed_single_track_groups;
+
+END;
+$seed$;

--- a/apps/oshikatsu-web/supabase/seeds/032_seed_sakamichi_single_tracks_expanded.sql
+++ b/apps/oshikatsu-web/supabase/seeds/032_seed_sakamichi_single_tracks_expanded.sql
@@ -1,0 +1,237 @@
+-- ============================================================
+-- Orbit starter seed: expanded Sakamichi single track lists
+-- ============================================================
+-- Scope:
+-- - CD single song tracks for 乃木坂46 / 欅坂46 / 櫻坂46 / 日向坂46.
+-- - Off vocal / instrumental tracks are intentionally excluded.
+-- - This is a "fill missing tracks" seed. Existing release-track links are not deleted.
+--
+-- Run after:
+-- - 030_seed_sakamichi_release_tracks_starter.sql
+-- - 031_seed_sakamichi_tracks_expanded.sql (optional)
+--
+-- Behavior:
+-- - If a release exists, tracks in track_titles are inserted when missing.
+-- - If a track is not yet linked to the release, it is appended after the current max track_number.
+-- - This avoids conflicts with earlier starter seeds, while still bringing most singles
+--   up to the usual 6-7 song tracks per release.
+--
+-- Main source patterns checked:
+-- - Official discography / special sites where available.
+-- - Wikipedia single pages and discography pages for B-side listings.
+-- - Recent releases checked explicitly: ネーブルオレンジ, Same numbers, ビリヤニ,
+--   最後に階段を駆け上がったのはいつだ?, Make or Break, UDAGAWA GENERATION,
+--   I want tomorrow to come, Unhappy birthday構文, Love yourself!, クリフハンガー.
+-- ============================================================
+
+BEGIN;
+SET CONSTRAINTS ALL DEFERRED;
+
+CREATE TEMP TABLE orbit_seed_single_track_groups (
+  release_group_name TEXT NOT NULL,
+  release_title TEXT NOT NULL,
+  release_type TEXT NOT NULL,
+  release_numbering INT,
+  track_group_name TEXT NOT NULL,
+  track_titles TEXT[] NOT NULL
+) ON COMMIT DROP;
+
+INSERT INTO orbit_seed_single_track_groups (
+  release_group_name,
+  release_title,
+  release_type,
+  release_numbering,
+  track_group_name,
+  track_titles
+)
+VALUES
+  -- 乃木坂46
+  ('乃木坂46', 'ぐるぐるカーテン', 'single', 1, '乃木坂46', ARRAY['ぐるぐるカーテン', '左胸の勇気', '乃木坂の詩', '会いたかったかもしれない', '失いたくないから', '白い雲にのって']),
+  ('乃木坂46', 'おいでシャンプー', 'single', 2, '乃木坂46', ARRAY['おいでシャンプー', '心の薬', '偶然を言い訳にして', '水玉模様', '狼に口笛を', 'ハウス!']),
+  ('乃木坂46', '走れ!Bicycle', 'single', 3, '乃木坂46', ARRAY['走れ!Bicycle', 'せっかちなかたつむり', '涙がまだ悲しみだった頃', '人はなぜ走るのか?', '音が出ないギター', '海流の島よ']),
+  ('乃木坂46', '制服のマネキン', 'single', 4, '乃木坂46', ARRAY['制服のマネキン', '指望遠鏡', 'やさしさなら間に合ってる', 'ここじゃないどこか', '春のメロディー', '渋谷ブルース']),
+  ('乃木坂46', '君の名は希望', 'single', 5, '乃木坂46', ARRAY['君の名は希望', 'シャキイズム', 'ロマンティックいか焼き', '13日の金曜日', 'でこぴん', 'サイコキネシスの可能性']),
+  ('乃木坂46', 'ガールズルール', 'single', 6, '乃木坂46', ARRAY['ガールズルール', '世界で一番 孤独なLover', 'コウモリよ', '扇風機', '他の星から', '人間という楽器']),
+  ('乃木坂46', 'バレッタ', 'single', 7, '乃木坂46', ARRAY['バレッタ', '月の大きさ', 'そんなバカな...', '私のために 誰かのために', '初恋の人を今でも', 'やさしさとは']),
+  ('乃木坂46', '気づいたら片想い', 'single', 8, '乃木坂46', ARRAY['気づいたら片想い', 'ロマンスのスタート', '吐息のメソッド', '孤独兄弟', '生まれたままで', 'ダンケシェーン']),
+  ('乃木坂46', '夏のFree&Easy', 'single', 9, '乃木坂46', ARRAY['夏のFree&Easy', '何もできずにそばにいる', 'その先の出口', '無口なライオン', 'ここにいる理由', '僕が行かなきゃ誰が行くんだ?']),
+  ('乃木坂46', '何度目の青空か?', 'single', 10, '乃木坂46', ARRAY['何度目の青空か?', '遠回りの愛情', '転がった鐘を鳴らせ!', '私、起きる。', 'あの日 僕は咄嗟に嘘をついた', 'Tender days']),
+  ('乃木坂46', '命は美しい', 'single', 11, '乃木坂46', ARRAY['命は美しい', 'あらかじめ語られるロマンス', '立ち直り中', 'ごめんね ずっと...', '君は僕と会わない方がよかったのかな', 'ボーダー']),
+  ('乃木坂46', '太陽ノック', 'single', 12, '乃木坂46', ARRAY['太陽ノック', 'もう少しの夢', '魚たちのLOVE SONG', '無表情', '別れ際、もっと好きになる', '制服を脱いでサヨナラを...', '羽根の記憶']),
+  ('乃木坂46', '今、話したい誰かがいる', 'single', 13, '乃木坂46', ARRAY['今、話したい誰かがいる', '嫉妬の権利', 'ポピパッパパー', '大人への近道', '悲しみの忘れ方', '隙間']),
+  ('乃木坂46', 'ハルジオンが咲く頃', 'single', 14, '乃木坂46', ARRAY['ハルジオンが咲く頃', '遥かなるブータン', '強がる蕾', '急斜面', '釣り堀', '不等号', '憂鬱と風船ガム']),
+  ('乃木坂46', '裸足でSummer', 'single', 15, '乃木坂46', ARRAY['裸足でSummer', '僕だけの光', 'オフショアガール', '命の真実 ミュージカル「林檎売りとカメムシ」', '白米様', 'シークレットグラフィティー', '行くあてのない僕たち']),
+  ('乃木坂46', 'サヨナラの意味', 'single', 16, '乃木坂46', ARRAY['サヨナラの意味', '孤独な青空', 'あの教室', 'ブランコ', '2度目のキスから', '君に贈る花がない', 'ないものねだり']),
+  ('乃木坂46', 'インフルエンサー', 'single', 17, '乃木坂46', ARRAY['インフルエンサー', '人生を考えたくなる', '意外BREAK', 'Another Ghost', '風船は生きている', '三番目の風', '当たり障りのない話']),
+  ('乃木坂46', '逃げ水', 'single', 18, '乃木坂46', ARRAY['逃げ水', '女は一人じゃ眠れない', 'ひと夏の長さより...', 'アンダー', 'ライブ神', '未来の答え', '泣いたっていいじゃないか?']),
+  ('乃木坂46', 'いつかできるから今日できる', 'single', 19, '乃木坂46', ARRAY['いつかできるから今日できる', '不眠症', 'まあいいか?', '失恋お掃除人', 'My rule', '僕の衝動', '新しい花粉 ミュージカル「見知らぬ世界」より']),
+  ('乃木坂46', 'シンクロニシティ', 'single', 20, '乃木坂46', ARRAY['シンクロニシティ', 'Against', '雲になればいい', '新しい世界', 'スカウトマン', 'トキトキメキメキ', '言霊砲']),
+  ('乃木坂46', 'ジコチューで行こう!', 'single', 21, '乃木坂46', ARRAY['ジコチューで行こう!', '空扉', '三角の空き地', '自分じゃない感じ', '心のモノローグ', '地球が丸いなら', 'あんなに好きだったのに...']),
+  ('乃木坂46', '帰り道は遠回りしたくなる', 'single', 22, '乃木坂46', ARRAY['帰り道は遠回りしたくなる', 'キャラバンは眠らない', 'つづく', '日常', '告白の順番', 'ショパンの嘘つき', '知りたいこと']),
+  ('乃木坂46', 'Sing Out!', 'single', 23, '乃木坂46', ARRAY['Sing Out!', '滑走路', 'のような存在', 'Am I Loving?', '平行線', '4番目の光', '曖昧']),
+  ('乃木坂46', '夜明けまで強がらなくてもいい', 'single', 24, '乃木坂46', ARRAY['夜明けまで強がらなくてもいい', '僕のこと、知ってる?', '路面電車の街', '図書室の君へ', '時々 思い出してください', '～Do my best～じゃ意味はない', '僕の思い込み']),
+  ('乃木坂46', 'しあわせの保護色', 'single', 25, '乃木坂46', ARRAY['しあわせの保護色', 'サヨナラ Stay with me', 'じゃあね。', 'アナスターシャ', '毎日がBrand new day', 'I see...', 'ファンタスティック三色パン']),
+  ('乃木坂46', '僕は僕を好きになる', 'single', 26, '乃木坂46', ARRAY['僕は僕を好きになる', '明日がある理由', 'Wilderness world', '口ほどにもないKISS', '冷たい水の中', 'Out of the blue', '友情ピアス']),
+  ('乃木坂46', 'ごめんねFingers crossed', 'single', 27, '乃木坂46', ARRAY['ごめんねFingers crossed', '全部 夢のまま', '大人たちには指示されない', 'ざぶんざざぶん', 'さ～ゆ～Ready?', '錆びたコンパス', '猫舌カモミールティー']),
+  ('乃木坂46', '君に叱られた', 'single', 28, '乃木坂46', ARRAY['君に叱られた', 'やさしいだけなら', 'マシンガンレイン', 'もしも心が透明なら', '私の色', '泥だらけ', '他人のそら似']),
+  ('乃木坂46', 'Actually...', 'single', 29, '乃木坂46', ARRAY['Actually...', '深読み', '価値あるもの', '忘れないといいな', '届かなくたって...', '絶望の一秒前', '好きになってみた']),
+  ('乃木坂46', '好きというのはロックだぜ!', 'single', 30, '乃木坂46', ARRAY['好きというのはロックだぜ!', 'Under''s Love', '僕が手を叩く方へ', 'ジャンピングジョーカーフラッシュ', 'バンドエイド剥がすような別れ方', 'パッションフルーツの食べ方', '夢を見る筋肉']),
+  ('乃木坂46', 'ここにはないもの', 'single', 31, '乃木坂46', ARRAY['ここにはないもの', '悪い成分', 'これから', '銭湯ラプソディー', 'アトノマツリ', '甘いエビデンス', '17分間']),
+  ('乃木坂46', '人は夢を二度見る', 'single', 32, '乃木坂46', ARRAY['人は夢を二度見る', '僕たちのサヨナラ', '心にもないこと', '黄昏はいつも', 'Never say never', 'さざ波は戻らない', '涙の滑り台']),
+  ('乃木坂46', 'おひとりさま天国', 'single', 33, '乃木坂46', ARRAY['おひとりさま天国', '踏んでしまった', '誰かの肩', 'マグカップとシンク', '考えないようにする', 'お別れタコス', '命の冒涜']),
+  ('乃木坂46', 'Monopoly', 'single', 34, '乃木坂46', ARRAY['Monopoly', '思い出が止まらなくなる', '助手席をずっと空けていた', '羊飼いよ', '手ごねハンバーグ', 'スタイリッシュ', 'いつの日にか、あの歌を...']),
+  ('乃木坂46', 'チャンスは平等', 'single', 35, '乃木坂46', ARRAY['チャンスは平等', '車道側', '「じゃあね」が切ない', 'あと7曲', 'ぶんぶくちゃがま', 'サルビアの花を覚えているかい?', '夏桜']),
+  ('乃木坂46', 'チートデイ', 'single', 36, '乃木坂46', ARRAY['チートデイ', 'あの光', '落とし物', '君にDitto', '懐かない仔猫', 'Keep in touch', '熱狂の捌け口']),
+  ('乃木坂46', '歩道橋', 'single', 37, '乃木坂46', ARRAY['歩道橋', 'それまでの猶予', '相対性理論に異議を唱える', '世界一のダイヤモンド', '夕陽は何色か?', '乃木坂饅頭', '雪が降る日にまた会おう']),
+  ('乃木坂46', 'ネーブルオレンジ', 'single', 38, '乃木坂46', ARRAY['ネーブルオレンジ', '懐かしさの先', '交感神経優位', 'タイムリミット片想い', '天空の豆の木', '100日目', 'キスのシルエット']),
+  ('乃木坂46', 'Same numbers', 'single', 39, '乃木坂46', ARRAY['Same numbers', '真夏日よ', 'なぜ 僕たちは走るのか?', 'あの頃におかえり', '不道徳な夏', 'ってかさ', '君と猫']),
+  ('乃木坂46', 'ビリヤニ', 'single', 40, '乃木坂46', ARRAY['ビリヤニ', '市営ダンスホール', '純粋とは何か?', '新宿バックオフ', 'Spark a revolution!', '夢の匂い', 'ぐるぐるカーテン（6期生ver.）']),
+  ('乃木坂46', '最後に階段を駆け上がったのはいつだ?', 'single', 41, '乃木坂46', ARRAY['最後に階段を駆け上がったのはいつだ?', '愛って羨ましい', '桜橋を教えてくれた', '君ばかり', '年齢の境界線', 'パシフィック・リーグに連れてって', 'もう一つの太陽']),
+
+  -- 欅坂46
+  ('欅坂46', 'サイレントマジョリティー', 'single', 1, '欅坂46', ARRAY['サイレントマジョリティー', '手を繋いで帰ろうか', '山手線', '渋谷川', '乗り遅れたバス', 'キミガイナイ']),
+  ('欅坂46', '世界には愛しかない', 'single', 2, '欅坂46', ARRAY['世界には愛しかない', '語るなら未来を...', '渋谷からPARCOが消えた日', 'また会ってください', '青空が違う', 'ボブディランは返さない']),
+  ('欅坂46', '世界には愛しかない', 'single', 2, 'けやき坂46', ARRAY['ひらがなけやき']),
+  ('欅坂46', '二人セゾン', 'single', 3, '欅坂46', ARRAY['二人セゾン', '大人は信じてくれない', '制服と太陽', '僕たちの戦争', '夕陽1/3']),
+  ('欅坂46', '二人セゾン', 'single', 3, 'けやき坂46', ARRAY['誰よりも高く跳べ!']),
+  ('欅坂46', '不協和音', 'single', 4, '欅坂46', ARRAY['不協和音', 'W-KEYAKIZAKAの詩', '微笑みが悲しい', 'チューニング', '割れたスマホ', 'エキセントリック']),
+  ('欅坂46', '不協和音', 'single', 4, 'けやき坂46', ARRAY['僕たちは付き合っている']),
+  ('欅坂46', '風に吹かれても', 'single', 5, '欅坂46', ARRAY['風に吹かれても', '結局、じゃあねしか言えない', '避雷針', '波打ち際を走らないか?', '再生する細胞']),
+  ('欅坂46', '風に吹かれても', 'single', 5, 'けやき坂46', ARRAY['それでも歩いてる', 'NO WAR in the future']),
+  ('欅坂46', 'ガラスを割れ!', 'single', 6, '欅坂46', ARRAY['ガラスを割れ!', 'もう森へ帰ろうか?', '夜明けの孤独', 'ゼンマイ仕掛けの夢', 'バスルームトラベル']),
+  ('欅坂46', 'ガラスを割れ!', 'single', 6, 'けやき坂46', ARRAY['イマニミテイロ', '半分の記憶']),
+  ('欅坂46', 'アンビバレント', 'single', 7, '欅坂46', ARRAY['アンビバレント', 'Student Dance', 'I''m out', '302号室', '音楽室に片想い', '日が昇るまで']),
+  ('欅坂46', 'アンビバレント', 'single', 7, 'けやき坂46', ARRAY['ハッピーオーラ']),
+  ('欅坂46', '黒い羊', 'single', 8, '欅坂46', ARRAY['黒い羊', 'Nobody', 'ヒールの高さ', 'ごめんね クリスマス', '否定した未来']),
+  ('欅坂46', '黒い羊', 'single', 8, 'けやき坂46', ARRAY['君に話しておきたいこと', '抱きしめてやる']),
+  ('欅坂46', '誰がその鐘を鳴らすのか?', 'digital_single', NULL, '欅坂46', ARRAY['誰がその鐘を鳴らすのか?']),
+
+  -- 櫻坂46
+  ('櫻坂46', 'Nobody''s fault', 'single', 1, '櫻坂46', ARRAY['Nobody''s fault', 'なぜ 恋をして来なかったんだろう?', '半信半疑', 'Plastic regret', '最終の地下鉄に乗って', 'Buddies', 'ブルームーンキス']),
+  ('櫻坂46', 'BAN', 'single', 2, '櫻坂46', ARRAY['BAN', '偶然の答え', 'それが愛なのね', '君と僕と洗濯物', 'Microscope', '思ったよりも寂しくない', '櫻坂の詩']),
+  ('櫻坂46', '流れ弾', 'single', 3, '櫻坂46', ARRAY['流れ弾', 'Dead end', 'ソニア', 'ジャマイカビール', 'On my way', '無言の宇宙', '美しきNervous']),
+  ('櫻坂46', '五月雨よ', 'single', 4, '櫻坂46', ARRAY['五月雨よ', '僕のジレンマ', 'I''m in', '断絶', '制服の人魚', '車間距離', '恋が絶滅する日']),
+  ('櫻坂46', '桜月', 'single', 5, '櫻坂46', ARRAY['桜月', 'Cool', '無念', 'もしかしたら真実', '魂のLiar', '夏の近道', 'その日まで']),
+  ('櫻坂46', 'Start over!', 'single', 6, '櫻坂46', ARRAY['Start over!', '静寂の暴力', '風の音', 'コンビナート', 'Anthem time', '一瞬の馬', 'ドローン旋回中']),
+  ('櫻坂46', '承認欲求', 'single', 7, '櫻坂46', ARRAY['承認欲求', 'マモリビト', '確信的クロワッサン', '僕たちの La vie en rose', 'マンホールの蓋の上', '隙間風よ', 'Don''t cut in line!']),
+  ('櫻坂46', '何歳の頃に戻りたいのか?', 'single', 8, '櫻坂46', ARRAY['何歳の頃に戻りたいのか?', '何度 LOVE SONGの歌詞を読み返しただろう', '油を注せ!', '真夏に何か起きるのかしら', '心の影絵', '恋は向いてない', '泣かせて Hold me tight!']),
+  ('櫻坂46', '自業自得', 'single', 9, '櫻坂46', ARRAY['自業自得', '引きこもる時間はない', '愛し合いなさい', 'イザベルについて', '縁起担ぎ', '標識', 'もう一曲 欲しいのかい?']),
+  ('櫻坂46', 'I want tomorrow to come', 'single', 10, '櫻坂46', ARRAY['I want tomorrow to come', '本質的なこと', '僕は僕を好きになれない', '今さらSuddenly', '嵐の前、世界の終わり', '19歳のガレット', 'TOKYO SNOW']),
+  ('櫻坂46', 'UDAGAWA GENERATION', 'single', 11, '櫻坂46', ARRAY['UDAGAWA GENERATION', 'Nightmare症候群', 'Nothing special', '紋白蝶が確か飛んでた', '行かないで', 'ULTRAVIOLET', 'やるしかないじゃん']),
+  ('櫻坂46', 'Make or Break', 'single', 12, '櫻坂46', ARRAY['Make or Break', '死んだふり', '港区パセリ', '恋愛無双', '真夏の大統領', '君のことを想いながら', 'ノンアルコール']),
+  ('櫻坂46', 'Unhappy birthday構文', 'single', 13, '櫻坂46', ARRAY['Unhappy birthday構文', 'Alter ego', '木枯らしは泣かない', '青空が見えるまで', 'I will be', 'Buddies (English Version)', '夜空で一番輝いてる星の名前を僕は知らない']),
+  ('櫻坂46', 'The growing up train', 'single', 14, '櫻坂46', ARRAY['The growing up train', '光源', 'ドライフルーツ', 'キスが苦い', 'くらげらしく', 'Sunny side up', '僕は向いてない']),
+  ('櫻坂46', 'Lonesome rabbit/What''s "KAZOKU"?', 'single', 15, '櫻坂46', ARRAY['Lonesome rabbit', 'What''s "KAZOKU"?']),
+
+  -- 日向坂46
+  ('日向坂46', 'キュン', 'single', 1, '日向坂46', ARRAY['キュン', 'JOYFUL LOVE', '耳に落ちる涙', 'Footsteps', 'ときめき草', '沈黙が愛なら']),
+  ('日向坂46', 'ドレミソラシド', 'single', 2, '日向坂46', ARRAY['ドレミソラシド', 'キツネ', 'My god', 'Cage', 'やさしさが邪魔をする', 'Dash&Rush']),
+  ('日向坂46', 'こんなに好きになっちゃっていいの?', 'single', 3, '日向坂46', ARRAY['こんなに好きになっちゃっていいの?', 'ホントの時間', 'まさか 偶然...', '一番好きだとみんなに言っていた小説のタイトルを思い出せない', 'ママのドレス', '川は流れる']),
+  ('日向坂46', 'ソンナコトナイヨ', 'single', 4, '日向坂46', ARRAY['ソンナコトナイヨ', '青春の馬', '好きということは...', '窓を開けなくても', 'ナゼー', '君のため何ができるだろう']),
+  ('日向坂46', '君しか勝たん', 'single', 5, '日向坂46', ARRAY['君しか勝たん', '声の足跡', '嘆きのDelete', 'Right?', 'どうする?どうする?どうする?', '世界にはThank you!が溢れている', '膨大な夢に押し潰されて']),
+  ('日向坂46', 'ってか', 'single', 6, '日向坂46', ARRAY['ってか', '何度でも何度でも', '思いがけないダブルレインボー', '夢は何歳まで?', 'あくびLetter', '酸っぱい自己嫌悪', 'アディショナルタイム']),
+  ('日向坂46', '僕なんか', 'single', 7, '日向坂46', ARRAY['僕なんか', '飛行機雲ができる理由', 'もうこんなに好きになれない', 'ゴーフルと君', '真夜中の懺悔大会', '恋した魚は空を飛ぶ', '知らないうちに愛されていた']),
+  ('日向坂46', '月と星が踊るMidnight', 'single', 8, '日向坂46', ARRAY['月と星が踊るMidnight', 'HEY!OHISAMA!', '孤独な瞬間', '10秒天使', 'その他大勢タイプ', 'ブルーベリー&ラズベリー', '一生一度の夏']),
+  ('日向坂46', 'One choice', 'single', 9, '日向坂46', ARRAY['One choice', '恋は逃げ足が早い', '愛はこっちのものだ', 'You''re in my way', 'パクチー ピーマン グリーンピース', 'シーラカンス', '友よ 一番星だ']),
+  ('日向坂46', 'Am I ready?', 'single', 10, '日向坂46', ARRAY['Am I ready?', '見たことない魔物', '接触と感情', '骨組みだらけの夏休み', '君は逆立ちできるか?', '愛のひきこもり', 'ガラス窓が汚れてる']),
+  ('日向坂46', '君はハニーデュー', 'single', 11, '日向坂46', ARRAY['君はハニーデュー', '錆つかない剣を持て!', 'どこまでが道なんだ?', '恋とあんバター', '夜明けのスピード', '雨が降ったって', '僕に続け']),
+  ('日向坂46', '絶対的第六感', 'single', 12, '日向坂46', ARRAY['絶対的第六感', '君を覚えてない', '永遠のソフィア', '夕陽Dance', '妄想コスモス', '雪は降る 心の世界に', '君のために何ができるだろう']),
+  ('日向坂46', '卒業写真だけが知ってる', 'single', 13, '日向坂46', ARRAY['卒業写真だけが知ってる', 'SUZUKA', '孤独たちよ', 'あの娘にグイグイ', '43年待ちのコロッケ', 'Instead of you', '足の小指を箪笥の角にぶつけた']),
+  ('日向坂46', 'Love yourself!', 'single', 14, '日向坂46', ARRAY['Love yourself!', 'German Iris', 'You are forever', 'やらかした', 'What you like!', 'あのね そのね', '海風とわがまま']),
+  ('日向坂46', 'お願いバッハ!', 'single', 15, '日向坂46', ARRAY['お願いバッハ!', '空飛ぶ車', 'ただがむしゃらに', '君のしか勝たんのだ', 'キレイになりたい', 'まさかのConfession', '言葉は限りなく不自由だ']),
+  ('日向坂46', 'クリフハンガー', 'single', 16, '日向坂46', ARRAY['クリフハンガー', '涙目の太陽', 'Surf''s Up Girl', '好きになるクレッシェンド']),
+  ('日向坂46', 'Kind of love', 'single', 17, '日向坂46', ARRAY['Kind of love']);
+
+CREATE TEMP TABLE orbit_seed_single_tracks ON COMMIT DROP AS
+SELECT
+  groups.release_group_name,
+  groups.release_title,
+  groups.release_type,
+  groups.release_numbering,
+  groups.track_group_name,
+  track_title,
+  track_order::INT
+FROM orbit_seed_single_track_groups groups
+CROSS JOIN LATERAL unnest(groups.track_titles) WITH ORDINALITY AS tracks(track_title, track_order);
+
+CREATE TEMP TABLE orbit_seed_resolved_single_tracks ON COMMIT DROP AS
+SELECT
+  seed.*,
+  release.id AS release_id,
+  track_group.id AS track_group_id
+FROM orbit_seed_single_tracks seed
+JOIN public.orbit_groups release_group
+  ON release_group.name_ja = seed.release_group_name
+JOIN public.orbit_releases release
+  ON release.title = seed.release_title
+  AND release.group_id = release_group.id
+  AND release.release_type = seed.release_type
+  AND release.numbering IS NOT DISTINCT FROM seed.release_numbering
+JOIN public.orbit_groups track_group
+  ON track_group.name_ja = seed.track_group_name;
+
+INSERT INTO public.orbit_tracks (
+  title,
+  group_id
+)
+SELECT DISTINCT
+  seed.track_title,
+  seed.track_group_id
+FROM orbit_seed_resolved_single_tracks seed
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM public.orbit_tracks existing
+  WHERE existing.title = seed.track_title
+    AND existing.group_id = seed.track_group_id
+);
+
+WITH missing_links AS (
+  SELECT
+    seed.release_id,
+    track.id AS track_id,
+    seed.track_order,
+    seed.track_title
+  FROM orbit_seed_resolved_single_tracks seed
+  JOIN public.orbit_tracks track
+    ON track.title = seed.track_title
+    AND track.group_id = seed.track_group_id
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM public.orbit_release_tracks existing
+    WHERE existing.release_id = seed.release_id
+      AND existing.track_id = track.id
+  )
+),
+current_max AS (
+  SELECT
+    release_id,
+    MAX(track_number) AS max_track_number
+  FROM public.orbit_release_tracks
+  GROUP BY release_id
+),
+numbered_links AS (
+  SELECT
+    missing.release_id,
+    missing.track_id,
+    COALESCE(current_max.max_track_number, 0)
+      + ROW_NUMBER() OVER (
+          PARTITION BY missing.release_id
+          ORDER BY missing.track_order, missing.track_title
+        ) AS track_number
+  FROM missing_links missing
+  LEFT JOIN current_max
+    ON current_max.release_id = missing.release_id
+)
+INSERT INTO public.orbit_release_tracks (
+  release_id,
+  track_id,
+  track_number
+)
+SELECT
+  release_id,
+  track_id,
+  track_number::INT
+FROM numbered_links
+ON CONFLICT (release_id, track_id) DO NOTHING;
+
+COMMIT;

--- a/apps/oshikatsu-web/supabase/seeds/033_fix_hinata_recent_single_tracks.sql
+++ b/apps/oshikatsu-web/supabase/seeds/033_fix_hinata_recent_single_tracks.sql
@@ -5,14 +5,21 @@
 -- Safe to run even if 032 has not been executed.
 -- ============================================================
 
-BEGIN;
+DO $seed$
+BEGIN
 SET CONSTRAINTS ALL DEFERRED;
+
+DROP TABLE IF EXISTS orbit_seed_resolved_correct_hinata_tracks;
+DROP TABLE IF EXISTS orbit_seed_correct_hinata_tracks;
+DROP TABLE IF EXISTS orbit_seed_correct_hinata_track_groups;
+DROP TABLE IF EXISTS orbit_seed_deleted_track_ids;
+DROP TABLE IF EXISTS orbit_seed_wrong_hinata_tracks;
 
 CREATE TEMP TABLE orbit_seed_wrong_hinata_tracks (
   release_title TEXT NOT NULL,
   release_numbering INT NOT NULL,
   track_title TEXT NOT NULL
-) ON COMMIT DROP;
+) ON COMMIT PRESERVE ROWS;
 
 INSERT INTO orbit_seed_wrong_hinata_tracks (
   release_title,
@@ -29,7 +36,7 @@ VALUES
 
 CREATE TEMP TABLE orbit_seed_deleted_track_ids (
   track_id UUID PRIMARY KEY
-) ON COMMIT DROP;
+) ON COMMIT PRESERVE ROWS;
 
 WITH targets AS (
   SELECT
@@ -74,7 +81,7 @@ CREATE TEMP TABLE orbit_seed_correct_hinata_track_groups (
   release_title TEXT NOT NULL,
   release_numbering INT NOT NULL,
   track_titles TEXT[] NOT NULL
-) ON COMMIT DROP;
+) ON COMMIT PRESERVE ROWS;
 
 INSERT INTO orbit_seed_correct_hinata_track_groups (
   release_title,
@@ -110,7 +117,7 @@ VALUES
     'Second Jump'
   ]);
 
-CREATE TEMP TABLE orbit_seed_correct_hinata_tracks ON COMMIT DROP AS
+CREATE TEMP TABLE orbit_seed_correct_hinata_tracks ON COMMIT PRESERVE ROWS AS
 SELECT
   groups.release_title,
   groups.release_numbering,
@@ -119,7 +126,7 @@ SELECT
 FROM orbit_seed_correct_hinata_track_groups groups
 CROSS JOIN LATERAL unnest(groups.track_titles) WITH ORDINALITY AS tracks(track_title, track_order);
 
-CREATE TEMP TABLE orbit_seed_resolved_correct_hinata_tracks ON COMMIT DROP AS
+CREATE TEMP TABLE orbit_seed_resolved_correct_hinata_tracks ON COMMIT PRESERVE ROWS AS
 SELECT
   seed.*,
   release.id AS release_id,
@@ -199,4 +206,11 @@ SELECT
 FROM numbered_links
 ON CONFLICT (release_id, track_id) DO NOTHING;
 
-COMMIT;
+DROP TABLE IF EXISTS orbit_seed_resolved_correct_hinata_tracks;
+DROP TABLE IF EXISTS orbit_seed_correct_hinata_tracks;
+DROP TABLE IF EXISTS orbit_seed_correct_hinata_track_groups;
+DROP TABLE IF EXISTS orbit_seed_deleted_track_ids;
+DROP TABLE IF EXISTS orbit_seed_wrong_hinata_tracks;
+
+END;
+$seed$;

--- a/apps/oshikatsu-web/supabase/seeds/033_fix_hinata_recent_single_tracks.sql
+++ b/apps/oshikatsu-web/supabase/seeds/033_fix_hinata_recent_single_tracks.sql
@@ -1,0 +1,202 @@
+-- ============================================================
+-- Orbit seed fix: Hinatazaka46 recent single track corrections
+-- ============================================================
+-- Corrects provisional rows from 032_seed_sakamichi_single_tracks_expanded.sql.
+-- Safe to run even if 032 has not been executed.
+-- ============================================================
+
+BEGIN;
+SET CONSTRAINTS ALL DEFERRED;
+
+CREATE TEMP TABLE orbit_seed_wrong_hinata_tracks (
+  release_title TEXT NOT NULL,
+  release_numbering INT NOT NULL,
+  track_title TEXT NOT NULL
+) ON COMMIT DROP;
+
+INSERT INTO orbit_seed_wrong_hinata_tracks (
+  release_title,
+  release_numbering,
+  track_title
+)
+VALUES
+  ('絶対的第六感', 12, '君のために何ができるだろう'),
+  ('お願いバッハ!', 15, 'ただがむしゃらに'),
+  ('お願いバッハ!', 15, '君のしか勝たんのだ'),
+  ('お願いバッハ!', 15, 'キレイになりたい'),
+  ('お願いバッハ!', 15, 'まさかのConfession'),
+  ('お願いバッハ!', 15, '言葉は限りなく不自由だ');
+
+CREATE TEMP TABLE orbit_seed_deleted_track_ids (
+  track_id UUID PRIMARY KEY
+) ON COMMIT DROP;
+
+WITH targets AS (
+  SELECT
+    release.id AS release_id,
+    track.id AS track_id
+  FROM orbit_seed_wrong_hinata_tracks wrong
+  JOIN public.orbit_groups release_group
+    ON release_group.name_ja = '日向坂46'
+  JOIN public.orbit_releases release
+    ON release.title = wrong.release_title
+    AND release.group_id = release_group.id
+    AND release.release_type = 'single'
+    AND release.numbering = wrong.release_numbering
+  JOIN public.orbit_groups track_group
+    ON track_group.name_ja = '日向坂46'
+  JOIN public.orbit_tracks track
+    ON track.title = wrong.track_title
+    AND track.group_id = track_group.id
+),
+deleted_links AS (
+  DELETE FROM public.orbit_release_tracks release_track
+  USING targets
+  WHERE release_track.release_id = targets.release_id
+    AND release_track.track_id = targets.track_id
+  RETURNING release_track.track_id
+)
+INSERT INTO orbit_seed_deleted_track_ids (track_id)
+SELECT DISTINCT track_id
+FROM deleted_links
+ON CONFLICT DO NOTHING;
+
+DELETE FROM public.orbit_tracks track
+USING orbit_seed_deleted_track_ids deleted
+WHERE track.id = deleted.track_id
+  AND NOT EXISTS (
+    SELECT 1
+    FROM public.orbit_release_tracks release_track
+    WHERE release_track.track_id = track.id
+  );
+
+CREATE TEMP TABLE orbit_seed_correct_hinata_track_groups (
+  release_title TEXT NOT NULL,
+  release_numbering INT NOT NULL,
+  track_titles TEXT[] NOT NULL
+) ON COMMIT DROP;
+
+INSERT INTO orbit_seed_correct_hinata_track_groups (
+  release_title,
+  release_numbering,
+  track_titles
+)
+VALUES
+  ('絶対的第六感', 12, ARRAY[
+    '絶対的第六感',
+    '君を覚えてない',
+    '永遠のソフィア',
+    'どっちが先に言う?',
+    '妄想コスモス',
+    '雪は降る 心の世界に',
+    '夕陽Dance'
+  ]),
+  ('お願いバッハ!', 15, ARRAY[
+    'お願いバッハ!',
+    '空飛ぶ車',
+    'ライバル多すぎ問題',
+    '愛はこっちのものだ 2025',
+    '言葉の限界',
+    'ハロウィンのカボチャが割れた 2025',
+    'Expected value'
+  ]),
+  ('クリフハンガー', 16, ARRAY[
+    'クリフハンガー',
+    '君と生きる',
+    '好きになるクレッシェンド',
+    'Surf''s Up Girl',
+    '涙目の太陽',
+    '恋と慣性の法則',
+    'Second Jump'
+  ]);
+
+CREATE TEMP TABLE orbit_seed_correct_hinata_tracks ON COMMIT DROP AS
+SELECT
+  groups.release_title,
+  groups.release_numbering,
+  track_title,
+  track_order::INT
+FROM orbit_seed_correct_hinata_track_groups groups
+CROSS JOIN LATERAL unnest(groups.track_titles) WITH ORDINALITY AS tracks(track_title, track_order);
+
+CREATE TEMP TABLE orbit_seed_resolved_correct_hinata_tracks ON COMMIT DROP AS
+SELECT
+  seed.*,
+  release.id AS release_id,
+  track_group.id AS track_group_id
+FROM orbit_seed_correct_hinata_tracks seed
+JOIN public.orbit_groups release_group
+  ON release_group.name_ja = '日向坂46'
+JOIN public.orbit_releases release
+  ON release.title = seed.release_title
+  AND release.group_id = release_group.id
+  AND release.release_type = 'single'
+  AND release.numbering = seed.release_numbering
+JOIN public.orbit_groups track_group
+  ON track_group.name_ja = '日向坂46';
+
+INSERT INTO public.orbit_tracks (
+  title,
+  group_id
+)
+SELECT DISTINCT
+  seed.track_title,
+  seed.track_group_id
+FROM orbit_seed_resolved_correct_hinata_tracks seed
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM public.orbit_tracks existing
+  WHERE existing.title = seed.track_title
+    AND existing.group_id = seed.track_group_id
+);
+
+WITH missing_links AS (
+  SELECT
+    seed.release_id,
+    track.id AS track_id,
+    seed.track_order,
+    seed.track_title
+  FROM orbit_seed_resolved_correct_hinata_tracks seed
+  JOIN public.orbit_tracks track
+    ON track.title = seed.track_title
+    AND track.group_id = seed.track_group_id
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM public.orbit_release_tracks existing
+    WHERE existing.release_id = seed.release_id
+      AND existing.track_id = track.id
+  )
+),
+current_max AS (
+  SELECT
+    release_id,
+    MAX(track_number) AS max_track_number
+  FROM public.orbit_release_tracks
+  GROUP BY release_id
+),
+numbered_links AS (
+  SELECT
+    missing.release_id,
+    missing.track_id,
+    COALESCE(current_max.max_track_number, 0)
+      + ROW_NUMBER() OVER (
+          PARTITION BY missing.release_id
+          ORDER BY missing.track_order, missing.track_title
+        ) AS track_number
+  FROM missing_links missing
+  LEFT JOIN current_max
+    ON current_max.release_id = missing.release_id
+)
+INSERT INTO public.orbit_release_tracks (
+  release_id,
+  track_id,
+  track_number
+)
+SELECT
+  release_id,
+  track_id,
+  track_number::INT
+FROM numbered_links
+ON CONFLICT (release_id, track_id) DO NOTHING;
+
+COMMIT;


### PR DESCRIPTION
## 概要

坂道グループのリリース・楽曲データを投入するための seed SQL を追加します。

- 乃木坂46 / 櫻坂46 / 日向坂46 / 欅坂46 / けやき坂46 の主要リリースと代表曲 seed を追加
- 既存 seed を拡張する追加トラック seed を追加
- 日向坂46 の直近シングルに関する補正 seed を追加
- 同一SQLの再実行時に制約エラーが出ないことを確認

Refs #58

## 検証

- 一時 Supabase Postgres コンテナで `apps/oshikatsu-web/supabase/migrations/*.sql` を全件適用
- 追加 seed SQL 4本を順番に適用し成功
- 追加 seed SQL 4本を再実行し成功
- 適用後の確認:
  - `orbit_releases`: 93
  - `orbit_tracks`: 551
  - `orbit_release_tracks`: 553
  - release-track の重複位置: 0
  - release-track の重複ペア: 0

## 未実行

- `pnpm --filter oshikatsu-web typecheck`
- `pnpm --filter oshikatsu-web lint`

ローカルシェルで `pnpm` / `node` が見つからず実行できませんでした。`npm` は Windows 側の `/mnt/c/Program Files/nodejs//npm` を参照しており、Corepack も実行不可でした。