### PR TITLE
fix: 詳細→一覧の戻りで絞り込みが画面に反映されない不具合を修正

### DIFF
--- a/apps/oshikatsu-web/app/(authenticated)/members/page.tsx
+++ b/apps/oshikatsu-web/app/(authenticated)/members/page.tsx
@@ -1,36 +1,17 @@
+import { Suspense } from "react";
 import { MemberBrowser } from "@/components/members/MemberBrowser";
 import { getMembersPageData } from "@/usecases/readOrbitData";
-import type { MemberStatus } from "@/usecases/memberFilters";
 
-type MembersPageProps = {
-  searchParams: Promise<Record<string, string | undefined>>;
-};
-
-const MEMBER_STATUSES: MemberStatus[] = ["all", "active", "graduated"];
-
-function toMemberStatus(value: string | undefined): MemberStatus {
-  return MEMBER_STATUSES.includes(value as MemberStatus)
-    ? (value as MemberStatus)
-    : "active";
-}
-
-export default async function MembersPage({ searchParams }: MembersPageProps) {
-  const params = await searchParams;
-  const initialGroupId = params.groupId ?? "";
-  const initialStatus = toMemberStatus(params.status);
-
+export default async function MembersPage() {
   // 絞り込みはクライアント側で行うため、卒業含む全件を取得する
   const { members, groups } = await getMembersPageData({ status: "all" });
 
   return (
     <div className="space-y-4">
       <h1 className="text-xl font-bold text-foreground">メンバー</h1>
-      <MemberBrowser
-        groups={groups}
-        initialGroupId={initialGroupId}
-        initialStatus={initialStatus}
-        members={members}
-      />
+      <Suspense fallback={<div className="h-10" />}>
+        <MemberBrowser groups={groups} members={members} />
+      </Suspense>
     </div>
   );
 }

--- a/apps/oshikatsu-web/app/(authenticated)/releases/page.tsx
+++ b/apps/oshikatsu-web/app/(authenticated)/releases/page.tsx
@@ -1,31 +1,17 @@
+import { Suspense } from "react";
 import { ReleaseBrowser } from "@/components/releases/ReleaseBrowser";
-import { isReleaseType, type ReleaseType } from "@/types/release";
 import { getReleasesPageData } from "@/usecases/readOrbitData";
 
-type ReleasesPageProps = {
-  searchParams: Promise<Record<string, string | undefined>>;
-};
-
-export default async function ReleasesPage({ searchParams }: ReleasesPageProps) {
-  const params = await searchParams;
-  const initialGroupId = params.groupId ?? "";
-  const initialReleaseType: ReleaseType | "" =
-    params.releaseType && isReleaseType(params.releaseType)
-      ? params.releaseType
-      : "";
-
+export default async function ReleasesPage() {
   // 絞り込みはクライアント側で行うため、常に全件取得する
   const { releases, groups } = await getReleasesPageData({});
 
   return (
     <div className="space-y-4">
       <h1 className="text-xl font-bold text-foreground">リリース</h1>
-      <ReleaseBrowser
-        groups={groups}
-        initialGroupId={initialGroupId}
-        initialReleaseType={initialReleaseType}
-        releases={releases}
-      />
+      <Suspense fallback={<div className="h-10" />}>
+        <ReleaseBrowser groups={groups} releases={releases} />
+      </Suspense>
     </div>
   );
 }

--- a/apps/oshikatsu-web/app/(authenticated)/songs/page.tsx
+++ b/apps/oshikatsu-web/app/(authenticated)/songs/page.tsx
@@ -1,26 +1,17 @@
+import { Suspense } from "react";
 import { SongBrowser } from "@/components/songs/SongBrowser";
 import { getSongsPageData } from "@/usecases/readOrbitData";
 
-type SongsPageProps = {
-  searchParams: Promise<Record<string, string | undefined>>;
-};
-
-export default async function SongsPage({ searchParams }: SongsPageProps) {
-  const params = await searchParams;
-  const initialGroupId = params.groupId ?? "";
-
+export default async function SongsPage() {
   // 絞り込みはクライアント側で行うため、常に全件取得する
   const { songs, groups, songSections } = await getSongsPageData({});
 
   return (
     <div className="space-y-4">
       <h1 className="text-xl font-bold text-foreground">楽曲</h1>
-      <SongBrowser
-        groups={groups}
-        initialGroupId={initialGroupId}
-        songs={songs}
-        songSections={songSections}
-      />
+      <Suspense fallback={<div className="h-10" />}>
+        <SongBrowser groups={groups} songs={songs} songSections={songSections} />
+      </Suspense>
     </div>
   );
 }

--- a/apps/oshikatsu-web/components/members/MemberBrowser.tsx
+++ b/apps/oshikatsu-web/components/members/MemberBrowser.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
+import { useSearchParams } from "next/navigation";
 import { MemberGrid } from "@/components/members/MemberGrid";
 import { MemberSectionList } from "@/components/members/MemberSectionList";
 import { replaceListFilterParams } from "@/lib/listFilterUrl";
@@ -15,8 +16,6 @@ import { createMemberSections } from "@/usecases/groupListSections";
 
 type MemberBrowserProps = {
   groups: Group[];
-  initialGroupId: string;
-  initialStatus: MemberStatus;
   members: MemberListItem[];
 };
 
@@ -26,14 +25,16 @@ const STATUS_OPTIONS: { label: string; value: MemberStatus }[] = [
   { label: "卒業", value: "graduated" },
 ];
 
-export function MemberBrowser({
-  groups,
-  initialGroupId,
-  initialStatus,
-  members,
-}: MemberBrowserProps) {
-  const [groupId, setGroupId] = useState(initialGroupId);
-  const [status, setStatus] = useState<MemberStatus>(initialStatus);
+function toMemberStatus(value: string | null): MemberStatus {
+  // 既定は現役（URL に status が無い場合）
+  return value === "all" || value === "graduated" ? value : "active";
+}
+
+export function MemberBrowser({ groups, members }: MemberBrowserProps) {
+  // 絞り込みは URL を真実源にする（詳細→戻りでも URL から復元される）
+  const searchParams = useSearchParams();
+  const groupId = searchParams.get("groupId") ?? "";
+  const status = toMemberStatus(searchParams.get("status"));
 
   const isGroupFiltered = groupId !== "";
 
@@ -55,14 +56,14 @@ export function MemberBrowser({
   );
 
   const handleGroupChange = (nextGroupId: string) => {
-    setGroupId(nextGroupId);
     replaceListFilterParams({ groupId: nextGroupId });
   };
 
   const handleStatusChange = (nextStatus: MemberStatus) => {
-    setStatus(nextStatus);
     // 既定（現役）に戻す場合は URL から status を外す
-    replaceListFilterParams({ status: nextStatus === "active" ? "" : nextStatus });
+    replaceListFilterParams({
+      status: nextStatus === "active" ? "" : nextStatus,
+    });
   };
 
   return (

--- a/apps/oshikatsu-web/components/releases/ReleaseBrowser.tsx
+++ b/apps/oshikatsu-web/components/releases/ReleaseBrowser.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
+import { useSearchParams } from "next/navigation";
 import { ReleaseGrid } from "@/components/releases/ReleaseGrid";
 import { ReleaseSectionList } from "@/components/releases/ReleaseSectionList";
 import { replaceListFilterParams } from "@/lib/listFilterUrl";
@@ -8,6 +9,7 @@ import type { Group } from "@/types/group";
 import {
   RELEASE_TYPES,
   RELEASE_TYPE_LABELS,
+  isReleaseType,
   type ReleaseListItem,
   type ReleaseType,
 } from "@/types/release";
@@ -19,21 +21,18 @@ import { createReleaseSections } from "@/usecases/groupListSections";
 
 type ReleaseBrowserProps = {
   groups: Group[];
-  initialGroupId: string;
-  initialReleaseType: ReleaseType | "";
   releases: ReleaseListItem[];
 };
 
-export function ReleaseBrowser({
-  groups,
-  initialGroupId,
-  initialReleaseType,
-  releases,
-}: ReleaseBrowserProps) {
-  const [groupId, setGroupId] = useState(initialGroupId);
-  const [releaseType, setReleaseType] = useState<ReleaseType | "">(
-    initialReleaseType
-  );
+function toReleaseType(value: string | null): ReleaseType | "" {
+  return value && isReleaseType(value) ? value : "";
+}
+
+export function ReleaseBrowser({ groups, releases }: ReleaseBrowserProps) {
+  // 絞り込みは URL を真実源にする（詳細→戻りでも URL から復元される）
+  const searchParams = useSearchParams();
+  const groupId = searchParams.get("groupId") ?? "";
+  const releaseType = toReleaseType(searchParams.get("releaseType"));
 
   const isGroupFiltered = groupId !== "";
 
@@ -55,12 +54,10 @@ export function ReleaseBrowser({
   );
 
   const handleGroupChange = (nextGroupId: string) => {
-    setGroupId(nextGroupId);
     replaceListFilterParams({ groupId: nextGroupId });
   };
 
   const handleReleaseTypeChange = (nextReleaseType: ReleaseType | "") => {
-    setReleaseType(nextReleaseType);
     replaceListFilterParams({ releaseType: nextReleaseType });
   };
 

--- a/apps/oshikatsu-web/components/songs/SongBrowser.tsx
+++ b/apps/oshikatsu-web/components/songs/SongBrowser.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { useSearchParams } from "next/navigation";
 import { SongGrid } from "@/components/songs/SongGrid";
 import { SongSectionList } from "@/components/songs/SongSectionList";
 import { replaceListFilterParams } from "@/lib/listFilterUrl";
@@ -14,18 +15,15 @@ import {
 
 type SongBrowserProps = {
   groups: Group[];
-  initialGroupId: string;
   songs: SongListItem[];
   songSections: SongSection[];
 };
 
-export function SongBrowser({
-  groups,
-  initialGroupId,
-  songs,
-  songSections,
-}: SongBrowserProps) {
-  const [groupId, setGroupId] = useState(initialGroupId);
+export function SongBrowser({ groups, songs, songSections }: SongBrowserProps) {
+  // グループ絞り込みは URL を真実源にする（詳細→戻りでも URL から復元される）
+  const searchParams = useSearchParams();
+  const groupId = searchParams.get("groupId") ?? "";
+  // タイトル検索は URL 非同期の一時状態
   const [query, setQuery] = useState("");
 
   const isGroupFiltered = groupId !== "";
@@ -43,7 +41,6 @@ export function SongBrowser({
   );
 
   const handleGroupChange = (nextGroupId: string) => {
-    setGroupId(nextGroupId);
     replaceListFilterParams({ groupId: nextGroupId });
   };
 

--- a/docs/orbit-roadmap.md
+++ b/docs/orbit-roadmap.md
@@ -208,6 +208,8 @@
   - [x] `MemberBrowser` に統合、`usecases/memberFilters.ts` を追加、`MemberFilters` を撤去
 - [x] リリース一覧の絞り込みをクライアント側フィルタ化（Issue #90）
   - [x] 全件取得し、グループ/リリースタイプを in-memory フィルタ。`ReleaseBrowser` に統合、`usecases/releaseFilters.ts` を追加、`ReleaseFilters` を撤去
+- [x] 不具合修正: 詳細→一覧へ戻った際に URL の絞り込みが画面へ反映されない（3一覧共通）
+  - [x] フィルタ state の初期化元をサーバー prop から `useSearchParams`（URL）へ変更し、URL を真実源化。Router Cache の古い RSC で再マウントされても URL から復元されるようにした
 
 ### ライブ情報 + セットリスト
 


### PR DESCRIPTION
## 概要

メンバー / 楽曲 / リリースの一覧で、グループ等で絞り込んだ状態から項目を選んで詳細へ遷移し、ブラウザバックで戻ると、**URL には絞り込みが残っているのに画面は未絞り込み（全件・セクション表示）に戻る**不具合を修正します。

## 原因

各 Browser はフィルタ state を `useState(initialGroupId)` のように**サーバーから渡す `initial*` prop で初期化**していました。詳細→戻りの際、Next App Router は Router Cache から `/songs` 等の**古い RSC（絞り込み前、`initialGroupId=""`）**を使って Browser を再マウントするため、URL は `?groupId=X` でも state は `""` となり、表示と URL が乖離していました（リロード・直リンクではサーバーが searchParams を読むため正しく出るので再現しにくい）。

## 修正

フィルタの**真実源を URL に変更**しました。

- 各 Browser で `useSearchParams()` から `groupId` / `status` / `releaseType` を派生（`useState` 初期化をやめる）
- 変更時は従来どおり `replaceListFilterParams`（`history.replaceState`）で URL を更新。Next が `useSearchParams` を同期するため即時反映され、戻り時も URL から正しく復元される
- `useSearchParams` 利用に伴い各 Browser を `<Suspense>` で内包（旧 Filters と同じ方針）
- ページ側の `initial*` prop と searchParams 読み取りは不要化のため撤去
- タイトル検索 query は従来どおり URL 非同期の local state（仕様どおり）

メンバーの初期表示「現役」も維持（URL に `status` が無ければ active）。

## 確認

- `pnpm --filter oshikatsu-web typecheck` / `lint` 通過
- `pnpm --filter oshikatsu-web build` 成功（`/members` `/songs` `/releases` はいずれも動的レンダリング、`useSearchParams` のビルドエラーなし）

### 手動確認手順（要デプロイ）

1. `/songs` でグループを選択 → 一覧が絞り込まれ URL が `?groupId=X` になる
2. いずれかの曲へ遷移 → ブラウザバック
3. **戻った画面で絞り込み（グループのフラット表示）が維持されている**ことを確認
4. メンバー（グループ＋在籍状況）・リリース（グループ＋タイプ）でも同様に確認
5. リロード・直リンク（`?groupId=X` 直接アクセス）でも絞り込みが反映されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
