### PR TITLE
fix: プルダウン変更時の即時反映を復活（一覧の絞り込み）

### DIFF
--- a/apps/oshikatsu-web/components/members/MemberBrowser.tsx
+++ b/apps/oshikatsu-web/components/members/MemberBrowser.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { MemberGrid } from "@/components/members/MemberGrid";
 import { MemberSectionList } from "@/components/members/MemberSectionList";
@@ -31,10 +31,19 @@ function toMemberStatus(value: string | null): MemberStatus {
 }
 
 export function MemberBrowser({ groups, members }: MemberBrowserProps) {
-  // 絞り込みは URL を真実源にする（詳細→戻りでも URL から復元される）
+  // 即時反映は local state、戻る/リロード等の URL 変化は useEffect で同期する
   const searchParams = useSearchParams();
-  const groupId = searchParams.get("groupId") ?? "";
-  const status = toMemberStatus(searchParams.get("status"));
+  const urlGroupId = searchParams.get("groupId") ?? "";
+  const urlStatus = toMemberStatus(searchParams.get("status"));
+  const [groupId, setGroupId] = useState(urlGroupId);
+  const [status, setStatus] = useState<MemberStatus>(urlStatus);
+
+  useEffect(() => {
+    setGroupId(urlGroupId);
+  }, [urlGroupId]);
+  useEffect(() => {
+    setStatus(urlStatus);
+  }, [urlStatus]);
 
   const isGroupFiltered = groupId !== "";
 
@@ -56,10 +65,12 @@ export function MemberBrowser({ groups, members }: MemberBrowserProps) {
   );
 
   const handleGroupChange = (nextGroupId: string) => {
+    setGroupId(nextGroupId);
     replaceListFilterParams({ groupId: nextGroupId });
   };
 
   const handleStatusChange = (nextStatus: MemberStatus) => {
+    setStatus(nextStatus);
     // 既定（現役）に戻す場合は URL から status を外す
     replaceListFilterParams({
       status: nextStatus === "active" ? "" : nextStatus,

--- a/apps/oshikatsu-web/components/releases/ReleaseBrowser.tsx
+++ b/apps/oshikatsu-web/components/releases/ReleaseBrowser.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { ReleaseGrid } from "@/components/releases/ReleaseGrid";
 import { ReleaseSectionList } from "@/components/releases/ReleaseSectionList";
@@ -29,10 +29,21 @@ function toReleaseType(value: string | null): ReleaseType | "" {
 }
 
 export function ReleaseBrowser({ groups, releases }: ReleaseBrowserProps) {
-  // 絞り込みは URL を真実源にする（詳細→戻りでも URL から復元される）
+  // 即時反映は local state、戻る/リロード等の URL 変化は useEffect で同期する
   const searchParams = useSearchParams();
-  const groupId = searchParams.get("groupId") ?? "";
-  const releaseType = toReleaseType(searchParams.get("releaseType"));
+  const urlGroupId = searchParams.get("groupId") ?? "";
+  const urlReleaseType = toReleaseType(searchParams.get("releaseType"));
+  const [groupId, setGroupId] = useState(urlGroupId);
+  const [releaseType, setReleaseType] = useState<ReleaseType | "">(
+    urlReleaseType
+  );
+
+  useEffect(() => {
+    setGroupId(urlGroupId);
+  }, [urlGroupId]);
+  useEffect(() => {
+    setReleaseType(urlReleaseType);
+  }, [urlReleaseType]);
 
   const isGroupFiltered = groupId !== "";
 
@@ -54,10 +65,12 @@ export function ReleaseBrowser({ groups, releases }: ReleaseBrowserProps) {
   );
 
   const handleGroupChange = (nextGroupId: string) => {
+    setGroupId(nextGroupId);
     replaceListFilterParams({ groupId: nextGroupId });
   };
 
   const handleReleaseTypeChange = (nextReleaseType: ReleaseType | "") => {
+    setReleaseType(nextReleaseType);
     replaceListFilterParams({ releaseType: nextReleaseType });
   };
 

--- a/apps/oshikatsu-web/components/songs/SongBrowser.tsx
+++ b/apps/oshikatsu-web/components/songs/SongBrowser.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { SongGrid } from "@/components/songs/SongGrid";
 import { SongSectionList } from "@/components/songs/SongSectionList";
@@ -20,11 +20,16 @@ type SongBrowserProps = {
 };
 
 export function SongBrowser({ groups, songs, songSections }: SongBrowserProps) {
-  // グループ絞り込みは URL を真実源にする（詳細→戻りでも URL から復元される）
+  // 即時反映は local state、戻る/リロード等の URL 変化は useEffect で同期する
   const searchParams = useSearchParams();
-  const groupId = searchParams.get("groupId") ?? "";
+  const urlGroupId = searchParams.get("groupId") ?? "";
+  const [groupId, setGroupId] = useState(urlGroupId);
   // タイトル検索は URL 非同期の一時状態
   const [query, setQuery] = useState("");
+
+  useEffect(() => {
+    setGroupId(urlGroupId);
+  }, [urlGroupId]);
 
   const isGroupFiltered = groupId !== "";
 
@@ -41,6 +46,7 @@ export function SongBrowser({ groups, songs, songSections }: SongBrowserProps) {
   );
 
   const handleGroupChange = (nextGroupId: string) => {
+    setGroupId(nextGroupId);
     replaceListFilterParams({ groupId: nextGroupId });
   };
 


### PR DESCRIPTION
## 概要

#94 で「詳細→一覧へ戻った際に絞り込みが画面へ反映されない」不具合を修正した際、フィルタの真実源を URL（`useSearchParams` 派生）のみにした結果、**プルダウン変更で URL は変わるが画面が変わらない**回帰が発生していました。本PRでその回帰を修正します（#94 はマージ済みのため新規PR）。

## 原因

この環境では `window.history.replaceState`（`replaceListFilterParams`）で URL を更新しても `useSearchParams()` が即時に再レンダリングをトリガーしないため、`useSearchParams` 派生のみだと選択しても表示が更新されませんでした。一方、戻る/リロードでは `useSearchParams` が更新されるため、その経路は #94 で直っていました。

## 修正（ハイブリッド方式）

3つの一覧（メンバー / 楽曲 / リリース）の Browser を、即時反映と URL 復元を両立する方式に統一しました。

- **即時反映**: フィルタを local `useState` で保持し、`onChange` で `setState`（プルダウン変更が即画面へ）
- **URL同期**: 変更時に `replaceListFilterParams` で `?groupId=` 等を更新（共有・リロード用）
- **戻る/リロード/直リンクの復元**: `useSearchParams` の値を `useEffect` で state へ同期。初期値も URL 由来のため、Router Cache の古い RSC で再マウントされても URL から復元される

メンバーの初期表示「現役」も維持（URL に `status` が無ければ active）。タイトル検索は従来どおり URL 非同期の local state。

## 変更ファイル

- `components/songs/SongBrowser.tsx`
- `components/members/MemberBrowser.tsx`
- `components/releases/ReleaseBrowser.tsx`

## 確認

- `pnpm --filter oshikatsu-web typecheck` / `lint` 通過
- `pnpm --filter oshikatsu-web build` 成功（3一覧とも動的レンダリング）

### 手動確認手順（要デプロイ）

1. `/songs`（/members・/releases も）でプルダウンを変更 → **即座に**一覧が絞り込まれ、URL も追従する
2. いずれかへ遷移 → ブラウザバック → 絞り込みが**維持**されている
3. リロード・直リンク（`?groupId=X`）でも絞り込みが反映される
4. メンバーの初期表示が「現役」であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
