### PR TITLE
メンバー一覧に期（世代）絞り込みを追加 (#96)

### DIFF
--- a/apps/oshikatsu-web/components/members/MemberBrowser.tsx
+++ b/apps/oshikatsu-web/components/members/MemberBrowser.tsx
@@ -76,6 +76,10 @@ export function MemberBrowser({ groups, members }: MemberBrowserProps) {
     return [...present].sort((a, b) => Number(a) - Number(b));
   }, [isGroupFiltered, groups, groupId, members]);
 
+  // 期はグループ選択中かつ選択肢に含まれる値のみ有効（グループ未選択や範囲外URLは無効化）
+  const effectiveGeneration =
+    isGroupFiltered && generationOptions.includes(generation) ? generation : "";
+
   // ステータスで先に絞り込んだ母集合
   const baseMembers = useMemo(
     () => filterMembersByStatus(members, status),
@@ -88,9 +92,9 @@ export function MemberBrowser({ groups, members }: MemberBrowserProps) {
       filterMembersByGeneration(
         filterMembersByGroup(baseMembers, groupId),
         groupId,
-        generation
+        effectiveGeneration
       ),
-    [baseMembers, groupId, generation]
+    [baseMembers, groupId, effectiveGeneration]
   );
   // セクション表示はグループ未選択時のみ使う
   const memberSections = useMemo(
@@ -136,7 +140,7 @@ export function MemberBrowser({ groups, members }: MemberBrowserProps) {
         </select>
         {isGroupFiltered && generationOptions.length > 0 && (
           <select
-            value={generation}
+            value={effectiveGeneration}
             onChange={(event) => handleGenerationChange(event.target.value)}
             aria-label="期で絞り込み"
             className="rounded-lg border border-foreground/10 bg-background px-3 py-1.5 text-sm text-foreground"

--- a/apps/oshikatsu-web/components/members/MemberBrowser.tsx
+++ b/apps/oshikatsu-web/components/members/MemberBrowser.tsx
@@ -8,6 +8,7 @@ import { replaceListFilterParams } from "@/lib/listFilterUrl";
 import type { Group } from "@/types/group";
 import type { MemberListItem } from "@/types/member";
 import {
+  filterMembersByGeneration,
   filterMembersByGroup,
   filterMembersByStatus,
   type MemberStatus,
@@ -35,8 +36,10 @@ export function MemberBrowser({ groups, members }: MemberBrowserProps) {
   const searchParams = useSearchParams();
   const urlGroupId = searchParams.get("groupId") ?? "";
   const urlStatus = toMemberStatus(searchParams.get("status"));
+  const urlGeneration = searchParams.get("generation") ?? "";
   const [groupId, setGroupId] = useState(urlGroupId);
   const [status, setStatus] = useState<MemberStatus>(urlStatus);
+  const [generation, setGeneration] = useState(urlGeneration);
 
   useEffect(() => {
     setGroupId(urlGroupId);
@@ -44,8 +47,34 @@ export function MemberBrowser({ groups, members }: MemberBrowserProps) {
   useEffect(() => {
     setStatus(urlStatus);
   }, [urlStatus]);
+  useEffect(() => {
+    setGeneration(urlGeneration);
+  }, [urlGeneration]);
 
   const isGroupFiltered = groupId !== "";
+
+  // 期の選択肢：選択グループの maxGeneration（無ければ所属メンバーの実在世代から導出）
+  const generationOptions = useMemo(() => {
+    if (!isGroupFiltered) {
+      return [];
+    }
+    const selectedGroup = groups.find((group) => group.id === groupId) ?? null;
+    const maxGeneration = selectedGroup?.maxGeneration ?? null;
+    if (maxGeneration && maxGeneration > 0) {
+      return Array.from({ length: maxGeneration }, (_, index) =>
+        String(index + 1)
+      );
+    }
+    const present = new Set<string>();
+    members.forEach((member) =>
+      member.groups.forEach((group) => {
+        if (group.groupId === groupId && group.generation) {
+          present.add(group.generation);
+        }
+      })
+    );
+    return [...present].sort((a, b) => Number(a) - Number(b));
+  }, [isGroupFiltered, groups, groupId, members]);
 
   // ステータスで先に絞り込んだ母集合
   const baseMembers = useMemo(
@@ -53,10 +82,15 @@ export function MemberBrowser({ groups, members }: MemberBrowserProps) {
     [members, status]
   );
 
-  // 件数表示・フラット表示用（グループも適用）
+  // 件数表示・フラット表示用（グループ＋期も適用）
   const flatMembers = useMemo(
-    () => filterMembersByGroup(baseMembers, groupId),
-    [baseMembers, groupId]
+    () =>
+      filterMembersByGeneration(
+        filterMembersByGroup(baseMembers, groupId),
+        groupId,
+        generation
+      ),
+    [baseMembers, groupId, generation]
   );
   // セクション表示はグループ未選択時のみ使う
   const memberSections = useMemo(
@@ -66,7 +100,14 @@ export function MemberBrowser({ groups, members }: MemberBrowserProps) {
 
   const handleGroupChange = (nextGroupId: string) => {
     setGroupId(nextGroupId);
-    replaceListFilterParams({ groupId: nextGroupId });
+    // 期はグループ依存のため、グループ変更時はリセット
+    setGeneration("");
+    replaceListFilterParams({ groupId: nextGroupId, generation: "" });
+  };
+
+  const handleGenerationChange = (nextGeneration: string) => {
+    setGeneration(nextGeneration);
+    replaceListFilterParams({ generation: nextGeneration });
   };
 
   const handleStatusChange = (nextStatus: MemberStatus) => {
@@ -93,6 +134,21 @@ export function MemberBrowser({ groups, members }: MemberBrowserProps) {
             </option>
           ))}
         </select>
+        {isGroupFiltered && generationOptions.length > 0 && (
+          <select
+            value={generation}
+            onChange={(event) => handleGenerationChange(event.target.value)}
+            aria-label="期で絞り込み"
+            className="rounded-lg border border-foreground/10 bg-background px-3 py-1.5 text-sm text-foreground"
+          >
+            <option value="">全期</option>
+            {generationOptions.map((option) => (
+              <option key={option} value={option}>
+                {option}期生
+              </option>
+            ))}
+          </select>
+        )}
         <select
           value={status}
           onChange={(event) =>

--- a/apps/oshikatsu-web/usecases/memberFilters.ts
+++ b/apps/oshikatsu-web/usecases/memberFilters.ts
@@ -14,6 +14,24 @@ export function filterMembersByGroup(
   );
 }
 
+export function filterMembersByGeneration(
+  members: MemberListItem[],
+  groupId: string,
+  generation: string
+): MemberListItem[] {
+  if (generation === "") {
+    return members;
+  }
+  // 期はグループ依存のため、グループ選択時は当該グループ内の世代で絞る
+  return members.filter((member) =>
+    member.groups.some(
+      (group) =>
+        group.generation === generation &&
+        (groupId === "" || group.groupId === groupId)
+    )
+  );
+}
+
 export function filterMembersByStatus(
   members: MemberListItem[],
   status: MemberStatus

--- a/docs/orbit-roadmap.md
+++ b/docs/orbit-roadmap.md
@@ -210,6 +210,9 @@
   - [x] 全件取得し、グループ/リリースタイプを in-memory フィルタ。`ReleaseBrowser` に統合、`usecases/releaseFilters.ts` を追加、`ReleaseFilters` を撤去
 - [x] 不具合修正: 詳細→一覧へ戻った際に URL の絞り込みが画面へ反映されない（3一覧共通）
   - [x] フィルタ state の初期化元をサーバー prop から `useSearchParams`（URL）へ変更し、URL を真実源化。Router Cache の古い RSC で再マウントされても URL から復元されるようにした
+  - [x] 不具合修正: 上記後にプルダウン即時反映が壊れた回帰を、即時=local state / 復元=useSearchParams のハイブリッドで解消（PR #95）
+- [x] メンバー一覧に期（世代）絞り込みを追加（Issue #96）
+  - [x] グループ選択時のみ表示。選択肢は `Group.maxGeneration`（無ければ実在世代から導出）。グループスコープで絞り込み、グループ変更時はリセット。URL `generation` を同期
 
 ### ライブ情報 + セットリスト
 


### PR DESCRIPTION
## 概要

メンバー一覧（`/members`）に「期（世代）」絞り込みを追加しました。グループを選択したときだけ、**グループと在籍状況の間**に期プルダウンが表示され、追加で絞り込めます（初期は「全期」）。

Closes #96

## 仕様

- グループ未選択時は期プルダウンを**表示しない**（期はグループ依存のため）
- グループ選択時に表示。選択肢は「全期」＋ 1〜`Group.maxGeneration`（「N期生」表記）
  - `maxGeneration` が未設定のグループは、所属メンバーに実在する世代から導出（フォールバック）
- 期を選ぶと、**選択グループ内**でその世代に該当するメンバーのみ表示（グループスコープ）
- グループを変更/クリアすると期はリセット（URL からも `generation` を除去）
- `generation` を URL に同期し、リロード・直リンク・詳細→戻りで復元（#88 のハイブリッド方式）

## 変更内容

- **UseCase** (`usecases/memberFilters.ts`): `filterMembersByGeneration(members, groupId, generation)` を追加（グループスコープ）
- **UI** (`components/members/MemberBrowser.tsx`): 期 state ＋ 条件表示の `<select>` を追加。選択肢は `Group.maxGeneration` ベース。グループ変更時に期をリセット。即時反映=local state / 復元=`useSearchParams`+`useEffect`

データは一覧で全件取得済み・`groups` に `maxGeneration` 込みのため、**追加フェッチなし**です。

## 受け入れ条件

- [x] グループ未選択時は期プルダウン非表示
- [x] グループ選択時に「全期」＋ 1〜maxGeneration を表示
- [x] 初期は全期（絞り込みなし）
- [x] 期選択で選択グループ内の該当世代のみ表示
- [x] グループ変更/クリアで期リセット（URL からも除去）
- [x] `generation` を `replaceState` 同期、リロード・直リンク・戻りで復元
- [x] 件数表示が追従
- [x] `pnpm --filter oshikatsu-web typecheck` / `lint` / `build` 通過

## 確認方法

> テスト基盤が未導入のため手動確認。

1. `/members` でグループ未選択時に期プルダウンが出ないことを確認
2. グループを選ぶと期プルダウン（全期＋N期生）が表示される
3. 期を選ぶと当該グループのその世代のメンバーのみになる
4. グループを変えると期がリセットされる
5. `?groupId=X&generation=3` の直リンク・リロード・詳細→戻りで状態が復元される

🤖 Generated with [Claude Code](https://claude.com/claude-code)
