### PR TITLE
chore(ci): GitHub Actions を Node24 対応の v5 に更新

### DIFF
--- a/.github/workflows/ci-household-web.yml
+++ b/.github/workflows/ci-household-web.yml
@@ -29,11 +29,11 @@ jobs:
         working-directory: apps/household-web
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version-file: ".nvmrc"
           cache: "pnpm"

--- a/.github/workflows/ci-oshikatsu-web.yml
+++ b/.github/workflows/ci-oshikatsu-web.yml
@@ -29,11 +29,11 @@ jobs:
         working-directory: apps/oshikatsu-web
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version-file: ".nvmrc"
           cache: "pnpm"


### PR DESCRIPTION
## 概要

CI（Typecheck / Lint / Build）で出ていた非推奨警告に対応します。

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4, actions/setup-node@v4, pnpm/action-setup@v4

これは**ビルドに使う Node のバージョン**（`.nvmrc`=24 で問題なし）ではなく、**各 action 自身の実行ランタイム**が Node20 ターゲットであることに対する警告です。各 action を Node24 化された最初のメジャー **v5** に更新します。

## 変更

`ci-household-web.yml` / `ci-oshikatsu-web.yml` 両方で:

- `actions/checkout@v4` → `@v5`（v5.0.0 で Node24 化）
- `actions/setup-node@v4` → `@v5`（v5.0.0 で Node24 化）
- `pnpm/action-setup@v4` → `@v5`（v5.0.0 で Node24 化）

最新メジャー（checkout v7 等）ではなく、Node24 化された最初のメジャー v5 を選び、挙動変更リスクを最小化しています。

## 互換性

- ビルド用 Node は `.nvmrc`=24 のまま（変更なし）
- `actions/setup-node` の `node-version-file: .nvmrc` / `cache: pnpm` の使い方は不変
- pnpm のバージョンは `package.json` の `packageManager: pnpm@9.15.5` から解決されるため、`pnpm/action-setup@v5` でも `version` 指定不要

## 確認

- 本 PR はワークフロー自身の変更を含み、パスフィルタに `.github/workflows/ci-*.yml` が含まれるため、この PR の CI 実行で警告解消を確認できます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
