### PR TITLE
ライブ: セットリスト基盤（楽曲/MC/影アナ/VTR）を追加 (#101)

### DIFF
--- a/apps/oshikatsu-web/app/(authenticated)/admin/lives/[id]/edit/page.tsx
+++ b/apps/oshikatsu-web/app/(authenticated)/admin/lives/[id]/edit/page.tsx
@@ -22,7 +22,7 @@ export default async function EditLivePage({ params }: EditLivePageProps) {
     notFound();
   }
 
-  const { groups, members, venues } = await getLiveFormMasterData();
+  const { groups, members, venues, songOptions } = await getLiveFormMasterData();
 
   const initialValues: CreateLiveInput = {
     name: live.name,
@@ -43,6 +43,12 @@ export default async function EditLivePage({ params }: EditLivePageProps) {
       absences: performance.absences.map((absence) => ({
         memberId: absence.memberId,
         note: absence.note ?? "",
+      })),
+      setlistItems: performance.setlistItems.map((item) => ({
+        itemType: item.itemType,
+        trackId: item.trackId ?? "",
+        songTitle: item.songTitle ?? "",
+        note: item.note ?? "",
       })),
     })),
   };
@@ -81,6 +87,7 @@ export default async function EditLivePage({ params }: EditLivePageProps) {
         groups={groups}
         members={members}
         venues={venues}
+        tracks={songOptions}
         initialValues={initialValues}
         onSubmit={handleSubmit}
       />

--- a/apps/oshikatsu-web/app/(authenticated)/admin/lives/new/page.tsx
+++ b/apps/oshikatsu-web/app/(authenticated)/admin/lives/new/page.tsx
@@ -6,7 +6,7 @@ import type { CreateLiveInput } from "@/types/live";
 import type { ValidationError } from "@/types/errors";
 
 export default async function NewLivePage() {
-  const { groups, members, venues } = await getLiveFormMasterData();
+  const { groups, members, venues, songOptions } = await getLiveFormMasterData();
 
   async function handleSubmit(
     values: CreateLiveInput
@@ -27,6 +27,7 @@ export default async function NewLivePage() {
         groups={groups}
         members={members}
         venues={venues}
+        tracks={songOptions}
         onSubmit={handleSubmit}
       />
     </div>

--- a/apps/oshikatsu-web/components/admin/LiveForm.tsx
+++ b/apps/oshikatsu-web/components/admin/LiveForm.tsx
@@ -677,6 +677,11 @@ export function LiveForm({
                     }
                     className="w-full rounded-lg border border-foreground/10 bg-background px-2 py-1.5 text-sm text-foreground placeholder:text-foreground/30"
                   />
+                  {errors[`performances.${index}.setlistItems.${itemIndex}`] && (
+                    <p className="text-xs text-red-500">
+                      {errors[`performances.${index}.setlistItems.${itemIndex}`]}
+                    </p>
+                  )}
                 </div>
               ))}
             </div>

--- a/apps/oshikatsu-web/components/admin/LiveForm.tsx
+++ b/apps/oshikatsu-web/components/admin/LiveForm.tsx
@@ -5,11 +5,15 @@ import type { ValidationError } from "@/types/errors";
 import type { Group } from "@/types/group";
 import type { MemberOption } from "@/types/member";
 import type { VenueOption } from "@/types/venue";
+import type { SongOption } from "@/types/song";
 import {
   LIVE_TYPE_LABELS,
   LIVE_TYPE_VALUES,
+  SETLIST_ITEM_TYPE_LABELS,
+  SETLIST_ITEM_TYPE_VALUES,
   type CreateLiveInput,
   type LiveType,
+  type SetlistItemType,
 } from "@/types/live";
 import { Input } from "@/components/ui/Input";
 import { Textarea } from "@/components/ui/Textarea";
@@ -20,6 +24,7 @@ type LiveFormProps = {
   groups: Group[];
   members: MemberOption[];
   venues: VenueOption[];
+  tracks: SongOption[];
   initialValues?: CreateLiveInput;
   onSubmit: (
     values: CreateLiveInput
@@ -27,6 +32,13 @@ type LiveFormProps = {
 };
 
 type AbsenceField = { key: number; memberId: string; note: string };
+type SetlistItemField = {
+  key: number;
+  itemType: SetlistItemType;
+  trackId: string;
+  songTitle: string;
+  note: string;
+};
 type PerformanceField = {
   key: number;
   venueId: string;
@@ -39,6 +51,7 @@ type PerformanceField = {
   ticketInfo: string;
   seatInfo: string;
   absences: AbsenceField[];
+  setlistItems: SetlistItemField[];
 };
 
 const inputClass =
@@ -49,6 +62,7 @@ export function LiveForm({
   groups,
   members,
   venues,
+  tracks,
   initialValues,
   onSubmit,
 }: LiveFormProps) {
@@ -86,6 +100,13 @@ export function LiveForm({
         memberId: absence.memberId,
         note: absence.note,
       })),
+      setlistItems: performance.setlistItems.map((item) => ({
+        key: nextKey(),
+        itemType: item.itemType,
+        trackId: item.trackId,
+        songTitle: item.songTitle,
+        note: item.note,
+      })),
     }))
   );
   const [errors, setErrors] = useState<Record<string, string>>({});
@@ -114,6 +135,7 @@ export function LiveForm({
         ticketInfo: "",
         seatInfo: "",
         absences: [],
+        setlistItems: [],
       },
     ]);
   };
@@ -173,6 +195,69 @@ export function LiveForm({
     );
   };
 
+  const addSetlistItem = (performanceKey: number) => {
+    setPerformances((prev) =>
+      prev.map((p) =>
+        p.key === performanceKey
+          ? {
+              ...p,
+              setlistItems: [
+                ...p.setlistItems,
+                { key: nextKey(), itemType: "song", trackId: "", songTitle: "", note: "" },
+              ],
+            }
+          : p
+      )
+    );
+  };
+
+  const updateSetlistItem = (
+    performanceKey: number,
+    itemKey: number,
+    patch: Partial<SetlistItemField>
+  ) => {
+    setPerformances((prev) =>
+      prev.map((p) =>
+        p.key === performanceKey
+          ? {
+              ...p,
+              setlistItems: p.setlistItems.map((item) =>
+                item.key === itemKey ? { ...item, ...patch } : item
+              ),
+            }
+          : p
+      )
+    );
+  };
+
+  const moveSetlistItem = (
+    performanceKey: number,
+    itemKey: number,
+    direction: -1 | 1
+  ) => {
+    setPerformances((prev) =>
+      prev.map((p) => {
+        if (p.key !== performanceKey) return p;
+        const index = p.setlistItems.findIndex((item) => item.key === itemKey);
+        const target = index + direction;
+        if (index < 0 || target < 0 || target >= p.setlistItems.length) return p;
+        const next = [...p.setlistItems];
+        [next[index], next[target]] = [next[target], next[index]];
+        return { ...p, setlistItems: next };
+      })
+    );
+  };
+
+  const removeSetlistItem = (performanceKey: number, itemKey: number) => {
+    setPerformances((prev) =>
+      prev.map((p) =>
+        p.key === performanceKey
+          ? { ...p, setlistItems: p.setlistItems.filter((item) => item.key !== itemKey) }
+          : p
+      )
+    );
+  };
+
   const rosterMembers = members.filter((member) =>
     performerMemberIds.includes(member.id)
   );
@@ -202,6 +287,12 @@ export function LiveForm({
         absences: performance.absences
           .filter((absence) => absence.memberId)
           .map((absence) => ({ memberId: absence.memberId, note: absence.note })),
+        setlistItems: performance.setlistItems.map((item) => ({
+          itemType: item.itemType,
+          trackId: item.trackId,
+          songTitle: item.songTitle,
+          note: item.note,
+        })),
       })),
     };
 
@@ -479,6 +570,113 @@ export function LiveForm({
                   >
                     削除
                   </button>
+                </div>
+              ))}
+            </div>
+
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <span className="text-xs text-foreground/60">セットリスト</span>
+                <button
+                  type="button"
+                  onClick={() => addSetlistItem(performance.key)}
+                  className="text-xs text-blue-500 hover:underline"
+                >
+                  項目を追加
+                </button>
+              </div>
+              {performance.setlistItems.map((item, itemIndex) => (
+                <div
+                  key={item.key}
+                  className="space-y-2 rounded-lg border border-foreground/10 p-2"
+                >
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="text-xs text-foreground/50">{itemIndex + 1}</span>
+                    <select
+                      value={item.itemType}
+                      onChange={(e) =>
+                        updateSetlistItem(performance.key, item.key, {
+                          itemType: e.target.value as SetlistItemType,
+                        })
+                      }
+                      className="rounded-lg border border-foreground/10 bg-background px-2 py-1.5 text-sm text-foreground"
+                    >
+                      {SETLIST_ITEM_TYPE_VALUES.map((type) => (
+                        <option key={type} value={type}>
+                          {SETLIST_ITEM_TYPE_LABELS[type]}
+                        </option>
+                      ))}
+                    </select>
+                    <div className="ml-auto flex items-center gap-1">
+                      <button
+                        type="button"
+                        onClick={() => moveSetlistItem(performance.key, item.key, -1)}
+                        className="px-1 text-xs text-foreground/60 hover:text-foreground"
+                        aria-label="上へ"
+                      >
+                        ↑
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => moveSetlistItem(performance.key, item.key, 1)}
+                        className="px-1 text-xs text-foreground/60 hover:text-foreground"
+                        aria-label="下へ"
+                      >
+                        ↓
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => removeSetlistItem(performance.key, item.key)}
+                        className="px-1 text-xs text-red-500 hover:underline"
+                      >
+                        削除
+                      </button>
+                    </div>
+                  </div>
+
+                  {item.itemType === "song" ? (
+                    <div className="flex flex-wrap gap-2">
+                      <select
+                        value={item.trackId}
+                        onChange={(e) =>
+                          updateSetlistItem(performance.key, item.key, {
+                            trackId: e.target.value,
+                          })
+                        }
+                        className="rounded-lg border border-foreground/10 bg-background px-2 py-1.5 text-sm text-foreground"
+                      >
+                        <option value="">登録曲から選択</option>
+                        {tracks.map((track) => (
+                          <option key={track.id} value={track.id}>
+                            {track.title}
+                          </option>
+                        ))}
+                      </select>
+                      <input
+                        value={item.songTitle}
+                        onChange={(e) =>
+                          updateSetlistItem(performance.key, item.key, {
+                            songTitle: e.target.value,
+                          })
+                        }
+                        placeholder="未登録曲は曲名を入力"
+                        className="flex-1 rounded-lg border border-foreground/10 bg-background px-2 py-1.5 text-sm text-foreground placeholder:text-foreground/30"
+                      />
+                    </div>
+                  ) : null}
+
+                  <input
+                    value={item.note}
+                    onChange={(e) =>
+                      updateSetlistItem(performance.key, item.key, {
+                        note: e.target.value,
+                      })
+                    }
+                    placeholder={
+                      item.itemType === "song" ? "メモ（任意）" : "内容・メモ"
+                    }
+                    className="w-full rounded-lg border border-foreground/10 bg-background px-2 py-1.5 text-sm text-foreground placeholder:text-foreground/30"
+                  />
                 </div>
               ))}
             </div>

--- a/apps/oshikatsu-web/components/lives/LiveDetail.tsx
+++ b/apps/oshikatsu-web/components/lives/LiveDetail.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
-import type { Live } from "@/types/live";
-import { LIVE_TYPE_LABELS } from "@/types/live";
+import type { Live, SetlistItem } from "@/types/live";
+import { LIVE_TYPE_LABELS, SETLIST_ITEM_TYPE_LABELS } from "@/types/live";
 import { GroupBadge } from "@/components/ui/GroupBadge";
 import { formatDate } from "@/lib/formatters";
 
@@ -16,6 +16,13 @@ function formatTimeRange(
   if (startsAt) return `開演 ${startsAt}`;
   if (doorsOpenAt) return `開場 ${doorsOpenAt}`;
   return null;
+}
+
+function setlistItemLabel(item: SetlistItem): string {
+  if (item.itemType === "song") {
+    return item.trackTitle ?? item.songTitle ?? "（曲名未設定）";
+  }
+  return SETLIST_ITEM_TYPE_LABELS[item.itemType];
 }
 
 export function LiveDetail({ live }: LiveDetailProps) {
@@ -119,6 +126,35 @@ export function LiveDetail({ live }: LiveDetailProps) {
                         )
                         .join("、")}
                     </p>
+                  )}
+
+                  {performance.setlistItems.length > 0 && (
+                    <div className="space-y-1">
+                      <p className="text-xs font-medium text-foreground/70">
+                        セットリスト
+                      </p>
+                      <ol className="space-y-0.5">
+                        {performance.setlistItems.map((item, index) => (
+                          <li
+                            key={`${performance.id}-${index}`}
+                            className="flex gap-2 text-xs text-foreground/80"
+                          >
+                            <span className="w-5 shrink-0 text-right text-foreground/40">
+                              {item.itemType === "song" ? index + 1 : "-"}
+                            </span>
+                            <span>
+                              {item.itemType !== "song" && (
+                                <span className="mr-1 rounded bg-foreground/10 px-1 text-foreground/60">
+                                  {SETLIST_ITEM_TYPE_LABELS[item.itemType]}
+                                </span>
+                              )}
+                              {setlistItemLabel(item)}
+                              {item.note ? `（${item.note}）` : ""}
+                            </span>
+                          </li>
+                        ))}
+                      </ol>
+                    </div>
                   )}
                 </div>
               );

--- a/apps/oshikatsu-web/components/lives/LiveDetail.tsx
+++ b/apps/oshikatsu-web/components/lives/LiveDetail.tsx
@@ -143,13 +143,19 @@ export function LiveDetail({ live }: LiveDetailProps) {
                               {item.itemType === "song" ? index + 1 : "-"}
                             </span>
                             <span>
-                              {item.itemType !== "song" && (
-                                <span className="mr-1 rounded bg-foreground/10 px-1 text-foreground/60">
-                                  {SETLIST_ITEM_TYPE_LABELS[item.itemType]}
-                                </span>
+                              {item.itemType === "song" ? (
+                                <>
+                                  {setlistItemLabel(item)}
+                                  {item.note ? `（${item.note}）` : ""}
+                                </>
+                              ) : (
+                                <>
+                                  <span className="mr-1 rounded bg-foreground/10 px-1 text-foreground/60">
+                                    {SETLIST_ITEM_TYPE_LABELS[item.itemType]}
+                                  </span>
+                                  {item.note}
+                                </>
                               )}
-                              {setlistItemLabel(item)}
-                              {item.note ? `（${item.note}）` : ""}
                             </span>
                           </li>
                         ))}

--- a/apps/oshikatsu-web/lib/revalidateOrbit.ts
+++ b/apps/oshikatsu-web/lib/revalidateOrbit.ts
@@ -41,6 +41,9 @@ export function revalidateOrbitSongData(): void {
     ORBIT_CACHE_TAGS.songs,
     ORBIT_CACHE_TAGS.songsDetail,
     ORBIT_CACHE_TAGS.songsList,
+    // セットリストが楽曲タイトルを参照表示するため失効する
+    ORBIT_CACHE_TAGS.lives,
+    ORBIT_CACHE_TAGS.livesDetail,
   ]);
 }
 

--- a/apps/oshikatsu-web/repositories/liveRepository.ts
+++ b/apps/oshikatsu-web/repositories/liveRepository.ts
@@ -7,8 +7,10 @@ import type {
   LiveOption,
   LivePerformance,
   LiveType,
+  SetlistItem,
   VenuePerformanceSummary,
 } from "@/types/live";
+import { isSetlistItemType } from "@/types/live";
 import { RepositoryError } from "@/types/errors";
 
 type GroupRel = { name_ja: string; color: string } | { name_ja: string; color: string }[] | null;
@@ -31,6 +33,17 @@ type AbsenceRow = {
   orbit_members: MemberRel;
 };
 
+type TrackRel = { title: string } | { title: string }[] | null;
+
+type SetlistItemRow = {
+  position: number;
+  item_type: string;
+  track_id: string | null;
+  song_title: string | null;
+  note: string | null;
+  orbit_tracks: TrackRel;
+};
+
 type PerformanceRow = {
   id: string;
   venue_id: string | null;
@@ -45,6 +58,7 @@ type PerformanceRow = {
   sort_order: number;
   orbit_venues: VenueRel;
   orbit_live_performance_absences: AbsenceRow[] | null;
+  orbit_setlist_items: SetlistItemRow[] | null;
 };
 
 type LiveRow = {
@@ -83,7 +97,8 @@ const DETAIL_SELECT = `
     seat_info,
     sort_order,
     orbit_venues(name),
-    orbit_live_performance_absences(member_id, note, orbit_members(name_ja))
+    orbit_live_performance_absences(member_id, note, orbit_members(name_ja)),
+    orbit_setlist_items(position, item_type, track_id, song_title, note, orbit_tracks(title))
   )
 `;
 
@@ -107,6 +122,16 @@ function mapPerformance(row: PerformanceRow): LivePerformance {
       memberNameJa: pickFirst(absence.orbit_members)?.name_ja ?? "",
       note: absence.note,
     })),
+    setlistItems: (row.orbit_setlist_items ?? [])
+      .map((item): SetlistItem => ({
+        itemType: isSetlistItemType(item.item_type) ? item.item_type : "other",
+        trackId: item.track_id,
+        trackTitle: pickFirst(item.orbit_tracks)?.title ?? null,
+        songTitle: item.song_title,
+        note: item.note,
+        position: item.position,
+      }))
+      .sort((a, b) => a.position - b.position),
   };
 }
 
@@ -160,6 +185,12 @@ function toLivePayload(input: CreateLiveInput) {
           member_id: absence.memberId,
           note: absence.note.trim(),
         })),
+      setlist_items: performance.setlistItems.map((item) => ({
+        item_type: item.itemType,
+        track_id: item.itemType === "song" ? item.trackId : "",
+        song_title: item.itemType === "song" ? item.songTitle.trim() : "",
+        note: item.note.trim(),
+      })),
     })),
   };
 }

--- a/apps/oshikatsu-web/supabase/migrations/032_create_setlist_items.sql
+++ b/apps/oshikatsu-web/supabase/migrations/032_create_setlist_items.sql
@@ -1,0 +1,161 @@
+-- ============================================================
+-- 032: セットリスト基盤（#101）
+-- 公演ごとのセットリスト項目（楽曲/MC/影アナ/VTR/その他）を順序つきで保持する。
+-- 楽曲は orbit_tracks 参照（登録曲）または song_title テキスト（未登録曲）。
+-- upsert_orbit_live RPC を拡張し、公演ごとのセットリストも 1 トランザクションで置換する。
+-- ============================================================
+
+CREATE TABLE orbit_setlist_items (
+  id              UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  performance_id  UUID NOT NULL REFERENCES orbit_live_performances(id) ON DELETE CASCADE,
+  position        INT NOT NULL,
+  item_type       TEXT NOT NULL
+                  CHECK (item_type IN ('song', 'mc', 'shadow_announcement', 'vtr', 'other')),
+  track_id        UUID REFERENCES orbit_tracks(id) ON DELETE RESTRICT,
+  song_title      TEXT,
+  note            TEXT,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_orbit_setlist_items_performance_id
+  ON orbit_setlist_items (performance_id);
+CREATE INDEX idx_orbit_setlist_items_track_id
+  ON orbit_setlist_items (track_id);
+
+ALTER TABLE orbit_setlist_items ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "orbit_setlist_items_select" ON orbit_setlist_items FOR SELECT
+  USING ((select auth.role()) = 'authenticated');
+CREATE POLICY "orbit_setlist_items_insert" ON orbit_setlist_items FOR INSERT
+  WITH CHECK ((select auth.role()) = 'authenticated');
+CREATE POLICY "orbit_setlist_items_update" ON orbit_setlist_items FOR UPDATE
+  USING ((select auth.role()) = 'authenticated');
+CREATE POLICY "orbit_setlist_items_delete" ON orbit_setlist_items FOR DELETE
+  USING ((select auth.role()) = 'authenticated');
+
+-- ============================================================
+-- upsert_orbit_live を拡張（公演ごとのセットリスト挿入を追加）
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.upsert_orbit_live(
+  p_id UUID,
+  p_payload JSONB
+)
+RETURNS UUID
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+DECLARE
+  v_live_id        UUID;
+  v_performance    JSONB;
+  v_performance_id UUID;
+  v_absence        JSONB;
+  v_item           JSONB;
+  v_sort           INT := 0;
+  v_position       INT;
+BEGIN
+  IF p_id IS NULL THEN
+    INSERT INTO public.orbit_lives (name, live_type, description)
+    VALUES (
+      p_payload->>'name',
+      p_payload->>'live_type',
+      NULLIF(p_payload->>'description', '')
+    )
+    RETURNING id INTO v_live_id;
+  ELSE
+    v_live_id := p_id;
+    UPDATE public.orbit_lives
+    SET name = p_payload->>'name',
+        live_type = p_payload->>'live_type',
+        description = NULLIF(p_payload->>'description', '')
+    WHERE id = v_live_id;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'orbit_live not found: %', v_live_id;
+    END IF;
+
+    DELETE FROM public.orbit_live_performances WHERE live_id = v_live_id;
+    DELETE FROM public.orbit_live_performer_groups WHERE live_id = v_live_id;
+    DELETE FROM public.orbit_live_performer_members WHERE live_id = v_live_id;
+  END IF;
+
+  INSERT INTO public.orbit_live_performer_groups (live_id, group_id)
+  SELECT v_live_id, value::uuid
+  FROM jsonb_array_elements_text(COALESCE(p_payload->'performer_group_ids', '[]'::jsonb));
+
+  INSERT INTO public.orbit_live_performer_members (live_id, member_id)
+  SELECT v_live_id, value::uuid
+  FROM jsonb_array_elements_text(COALESCE(p_payload->'performer_member_ids', '[]'::jsonb));
+
+  FOR v_performance IN
+    SELECT * FROM jsonb_array_elements(COALESCE(p_payload->'performances', '[]'::jsonb))
+  LOOP
+    INSERT INTO public.orbit_live_performances (
+      live_id,
+      venue_id,
+      performance_date,
+      doors_open_at,
+      starts_at,
+      session_label,
+      has_streaming,
+      has_live_viewing,
+      ticket_info,
+      seat_info,
+      sort_order
+    )
+    VALUES (
+      v_live_id,
+      NULLIF(v_performance->>'venue_id', '')::uuid,
+      NULLIF(v_performance->>'performance_date', '')::date,
+      NULLIF(v_performance->>'doors_open_at', ''),
+      NULLIF(v_performance->>'starts_at', ''),
+      NULLIF(v_performance->>'session_label', ''),
+      COALESCE((v_performance->>'has_streaming')::boolean, false),
+      COALESCE((v_performance->>'has_live_viewing')::boolean, false),
+      NULLIF(v_performance->>'ticket_info', ''),
+      NULLIF(v_performance->>'seat_info', ''),
+      v_sort
+    )
+    RETURNING id INTO v_performance_id;
+
+    FOR v_absence IN
+      SELECT * FROM jsonb_array_elements(COALESCE(v_performance->'absences', '[]'::jsonb))
+    LOOP
+      IF COALESCE(v_absence->>'member_id', '') <> '' THEN
+        INSERT INTO public.orbit_live_performance_absences (performance_id, member_id, note)
+        VALUES (
+          v_performance_id,
+          (v_absence->>'member_id')::uuid,
+          NULLIF(v_absence->>'note', '')
+        );
+      END IF;
+    END LOOP;
+
+    v_position := 0;
+    FOR v_item IN
+      SELECT * FROM jsonb_array_elements(COALESCE(v_performance->'setlist_items', '[]'::jsonb))
+    LOOP
+      INSERT INTO public.orbit_setlist_items (
+        performance_id,
+        position,
+        item_type,
+        track_id,
+        song_title,
+        note
+      )
+      VALUES (
+        v_performance_id,
+        v_position,
+        v_item->>'item_type',
+        NULLIF(v_item->>'track_id', '')::uuid,
+        NULLIF(v_item->>'song_title', ''),
+        NULLIF(v_item->>'note', '')
+      );
+      v_position := v_position + 1;
+    END LOOP;
+
+    v_sort := v_sort + 1;
+  END LOOP;
+
+  RETURN v_live_id;
+END;
+$$;

--- a/apps/oshikatsu-web/types/live.ts
+++ b/apps/oshikatsu-web/types/live.ts
@@ -24,6 +24,37 @@ export type LivePerformerMember = {
   memberNameJa: string;
 };
 
+export const SETLIST_ITEM_TYPE_VALUES = [
+  "song",
+  "mc",
+  "shadow_announcement",
+  "vtr",
+  "other",
+] as const;
+
+export type SetlistItemType = (typeof SETLIST_ITEM_TYPE_VALUES)[number];
+
+export const SETLIST_ITEM_TYPE_LABELS: Record<SetlistItemType, string> = {
+  song: "楽曲",
+  mc: "MC",
+  shadow_announcement: "影アナ",
+  vtr: "VTR",
+  other: "その他",
+};
+
+export function isSetlistItemType(value: string): value is SetlistItemType {
+  return (SETLIST_ITEM_TYPE_VALUES as readonly string[]).includes(value);
+}
+
+export type SetlistItem = {
+  itemType: SetlistItemType;
+  trackId: string | null;
+  trackTitle: string | null;
+  songTitle: string | null;
+  note: string | null;
+  position: number;
+};
+
 export type LivePerformanceAbsence = {
   memberId: string;
   memberNameJa: string;
@@ -44,6 +75,7 @@ export type LivePerformance = {
   seatInfo: string | null;
   sortOrder: number;
   absences: LivePerformanceAbsence[];
+  setlistItems: SetlistItem[];
 };
 
 export type Live = {
@@ -84,6 +116,13 @@ export type CreateLivePerformanceAbsenceInput = {
   note: string;
 };
 
+export type CreateSetlistItemInput = {
+  itemType: SetlistItemType;
+  trackId: string;
+  songTitle: string;
+  note: string;
+};
+
 export type CreateLivePerformanceInput = {
   venueId: string;
   performanceDate: string;
@@ -95,6 +134,7 @@ export type CreateLivePerformanceInput = {
   ticketInfo: string;
   seatInfo: string;
   absences: CreateLivePerformanceAbsenceInput[];
+  setlistItems: CreateSetlistItemInput[];
 };
 
 export type CreateLiveInput = {

--- a/apps/oshikatsu-web/usecases/readOrbitAdminData.ts
+++ b/apps/oshikatsu-web/usecases/readOrbitAdminData.ts
@@ -149,19 +149,26 @@ export async function getReleaseFormMasterData() {
 
 const loadLiveFormMasterData = createSharedReadLoader(
   ["orbit", "admin", "live-form-masters"],
-  [ORBIT_CACHE_TAGS.groups, ORBIT_CACHE_TAGS.members, ORBIT_CACHE_TAGS.venues],
+  [
+    ORBIT_CACHE_TAGS.groups,
+    ORBIT_CACHE_TAGS.members,
+    ORBIT_CACHE_TAGS.venues,
+    ORBIT_CACHE_TAGS.songOptions,
+  ],
   async () =>
     withOrbitReadClient(async (supabase) => {
-      const [groups, members, venues] = await Promise.all([
+      const [groups, members, venues, songOptions] = await Promise.all([
         getGroups(createGroupRepository(supabase)),
         listMemberOptions(createMemberRepository(supabase)),
         createVenueRepository(supabase).findOptions(),
+        listSongOptions(createSongRepository(supabase)),
       ]);
 
       return {
         groups,
         members,
         venues,
+        songOptions,
       };
     })
 );

--- a/apps/oshikatsu-web/usecases/validateLive.ts
+++ b/apps/oshikatsu-web/usecases/validateLive.ts
@@ -1,6 +1,6 @@
 import type { CreateLiveInput } from "@/types/live";
 import type { ValidationError } from "@/types/errors";
-import { isLiveType } from "@/types/live";
+import { isLiveType, isSetlistItemType } from "@/types/live";
 import { isValidDateString } from "@/lib/validation";
 
 function isValidTimeString(value: string): boolean {
@@ -56,17 +56,19 @@ export function validateLive(input: CreateLiveInput): ValidationError[] {
     }
 
     performance.setlistItems.forEach((item, itemIndex) => {
+      const field = `performances.${index}.setlistItems.${itemIndex}`;
+      if (!isSetlistItemType(item.itemType)) {
+        errors.push({ field, message: "無効な項目種別です" });
+        return;
+      }
       if (item.itemType === "song" && !item.trackId && !item.songTitle.trim()) {
         errors.push({
-          field: `performances.${index}.setlistItems.${itemIndex}`,
+          field,
           message: "楽曲は登録曲の選択か曲名の入力が必要です",
         });
       }
       if (item.note.length > 500) {
-        errors.push({
-          field: `performances.${index}.setlistItems.${itemIndex}`,
-          message: "メモは500文字以内で入力してください",
-        });
+        errors.push({ field, message: "メモは500文字以内で入力してください" });
       }
     });
 

--- a/apps/oshikatsu-web/usecases/validateLive.ts
+++ b/apps/oshikatsu-web/usecases/validateLive.ts
@@ -55,6 +55,21 @@ export function validateLive(input: CreateLiveInput): ValidationError[] {
       });
     }
 
+    performance.setlistItems.forEach((item, itemIndex) => {
+      if (item.itemType === "song" && !item.trackId && !item.songTitle.trim()) {
+        errors.push({
+          field: `performances.${index}.setlistItems.${itemIndex}`,
+          message: "楽曲は登録曲の選択か曲名の入力が必要です",
+        });
+      }
+      if (item.note.length > 500) {
+        errors.push({
+          field: `performances.${index}.setlistItems.${itemIndex}`,
+          message: "メモは500文字以内で入力してください",
+        });
+      }
+    });
+
     const rosterIds = new Set(input.performerMemberIds);
     const seenAbsentMembers = new Set<string>();
     for (const absence of performance.absences) {

--- a/docs/orbit-roadmap.md
+++ b/docs/orbit-roadmap.md
@@ -228,7 +228,10 @@
   - [x] Admin CRUD（`/admin/lives`）／公開一覧・詳細（`/lives`, `/lives/[id]`）
   - [x] 会場詳細にその会場の公演を逆引き表示
   - [x] ネスト更新を RPC `upsert_orbit_live` でトランザクション化（migration 031）
-- [ ] C: セットリスト基盤（楽曲/MC/影アナ/VTR）（Issue #101）
+- [x] C: セットリスト基盤（楽曲/MC/影アナ/VTR）（Issue #101）
+  - [x] `orbit_setlist_items`（公演ごと・順序つき・種別）を追加し、RPC `upsert_orbit_live` を拡張
+  - [x] 楽曲は登録曲（`orbit_tracks`）参照 or 未登録曲テキスト。MC/影アナ/VTR/その他に対応
+  - [x] LiveForm にセットリスト編集（行追加・並べ替え・削除）、公開公演詳細に表示
 - [ ] D: セトリ楽曲の拡張（センター/披露メンバー/披露タイプ）（Issue #102）
 - [ ] E（将来/バックログ）: 参加記録＋現地カウント/ランキング（Issue #103）
 


### PR DESCRIPTION
アンブレラ: #98

## 概要

ライブ情報＋セットリスト（#98）のステップ C。**公演ごとのセットリスト**を順序つきで管理できるようにしました。項目種別は **楽曲 / MC / 影アナ / VTR / その他**。楽曲は登録曲（`orbit_tracks`）参照が基本ですが、**他グループ・個人PV等の未登録曲はテキスト入力**で保持できます。

Closes #101

## データモデル（migration 032）

- `orbit_setlist_items`（performance_id, position, `item_type` {song|mc|shadow_announcement|vtr|other}, track_id?(FK orbit_tracks), song_title?, note?）
- RPC `upsert_orbit_live` を拡張し、公演ごとのセットリストも 1 トランザクションで置換（#100 と同じ仕組み）

## 変更内容

- **Data**: migration 032（テーブル + RLS + index、RPC 拡張）
- **型**: `SetlistItem` / `CreateSetlistItemInput`、`LivePerformance` / `CreateLivePerformanceInput` を拡張
- **Repository**: `DETAIL_SELECT` にセットリスト（`orbit_tracks(title)` join）を追加、マッピング・payload を拡張
- **UseCase**: `validateLive` に「楽曲項目は登録曲選択か曲名入力が必須」検証を追加
- **admin master**: `getLiveFormMasterData` に楽曲候補（`songOptions`）を追加
- **UI**: `LiveForm` に公演ごとのセットリスト編集（種別選択 / 楽曲は登録曲セレクト＋未登録テキスト / メモ / ↑↓並べ替え / 削除）、`LiveDetail` にセットリスト表示
- **cache**: 楽曲更新時に `lives` / `livesDetail` も失効（セットリストが曲名を参照表示するため）

## 受け入れ条件

- [x] `orbit_setlist_items`（順序つき・種別・登録曲 or テキスト・メモ）
- [x] Admin: 公演編集（ライブ編集画面）でセットリストを行追加・並べ替え・削除
- [x] 楽曲は登録曲選択 or 曲名テキスト（バリデーションでいずれか必須）
- [x] MC/影アナ/VTR/その他はメモのみで登録可
- [x] Public: 公演詳細にセットリストを順序表示（種別が分かる表示）
- [x] `pnpm --filter oshikatsu-web typecheck` / `lint` / `build` 通過

## 確認方法（要 migration 適用）

> Supabase に `032_create_setlist_items.sql` を適用後に確認（030/031 適用済み前提）。

1. `/admin/lives/[id]/edit` の公演にセットリストを追加（楽曲＝登録曲 or テキスト、MC/VTR 等）
2. ↑↓で並べ替え、削除
3. `/lives/[id]` でセットリストが順序・種別つきで表示される
4. 楽曲名を編集すると `/lives/[id]` の表示も更新される（キャッシュ失効）

## 補足

- センター/披露メンバー/披露タイプは次の **D（#102）** で対応します（本PRは項目・順序・種別・楽曲参照まで）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
