### PR TITLE
ライブ: セトリ楽曲にセンター/披露メンバー/披露タイプを追加 (#102)

### DIFF
--- a/apps/oshikatsu-web/app/(authenticated)/admin/lives/[id]/edit/page.tsx
+++ b/apps/oshikatsu-web/app/(authenticated)/admin/lives/[id]/edit/page.tsx
@@ -49,6 +49,11 @@ export default async function EditLivePage({ params }: EditLivePageProps) {
         trackId: item.trackId ?? "",
         songTitle: item.songTitle ?? "",
         note: item.note ?? "",
+        performanceStyle: item.performanceStyle ?? "",
+        members: item.members.map((member) => ({
+          memberId: member.memberId,
+          isCenter: member.isCenter,
+        })),
       })),
     })),
   };

--- a/apps/oshikatsu-web/components/admin/LiveForm.tsx
+++ b/apps/oshikatsu-web/components/admin/LiveForm.tsx
@@ -327,6 +327,17 @@ export function LiveForm({
     performerMemberIds.includes(member.id)
   );
   const absenceCandidates = rosterMembers.length > 0 ? rosterMembers : members;
+  const membersById = new Map(members.map((member) => [member.id, member]));
+
+  // 披露メンバー候補 = ロスター候補 ∪ 選択済み（ロスター外でも解除できるよう表示）
+  const setlistMemberCandidates = (item: SetlistItemField): MemberOption[] => {
+    const candidateIds = new Set(absenceCandidates.map((member) => member.id));
+    const extras = item.members
+      .filter((member) => member.memberId && !candidateIds.has(member.memberId))
+      .map((member) => membersById.get(member.memberId))
+      .filter((member): member is MemberOption => Boolean(member));
+    return [...absenceCandidates, ...extras];
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -754,7 +765,7 @@ export function LiveForm({
                           披露メンバー（C=センター）
                         </p>
                         <div className="grid max-h-40 grid-cols-2 gap-1 overflow-y-auto sm:grid-cols-3">
-                          {absenceCandidates.map((candidate) => {
+                          {setlistMemberCandidates(item).map((candidate) => {
                             const selected = item.members.find(
                               (m) => m.memberId === candidate.id
                             );

--- a/apps/oshikatsu-web/components/admin/LiveForm.tsx
+++ b/apps/oshikatsu-web/components/admin/LiveForm.tsx
@@ -9,10 +9,14 @@ import type { SongOption } from "@/types/song";
 import {
   LIVE_TYPE_LABELS,
   LIVE_TYPE_VALUES,
+  PERFORMANCE_STYLE_LABELS,
+  PERFORMANCE_STYLE_VALUES,
   SETLIST_ITEM_TYPE_LABELS,
   SETLIST_ITEM_TYPE_VALUES,
   type CreateLiveInput,
+  type CreateSetlistMemberInput,
   type LiveType,
+  type PerformanceStyle,
   type SetlistItemType,
 } from "@/types/live";
 import { Input } from "@/components/ui/Input";
@@ -38,6 +42,8 @@ type SetlistItemField = {
   trackId: string;
   songTitle: string;
   note: string;
+  performanceStyle: PerformanceStyle | "";
+  members: CreateSetlistMemberInput[];
 };
 type PerformanceField = {
   key: number;
@@ -106,6 +112,8 @@ export function LiveForm({
         trackId: item.trackId,
         songTitle: item.songTitle,
         note: item.note,
+        performanceStyle: item.performanceStyle,
+        members: item.members.map((member) => ({ ...member })),
       })),
     }))
   );
@@ -203,7 +211,15 @@ export function LiveForm({
               ...p,
               setlistItems: [
                 ...p.setlistItems,
-                { key: nextKey(), itemType: "song", trackId: "", songTitle: "", note: "" },
+                {
+                  key: nextKey(),
+                  itemType: "song",
+                  trackId: "",
+                  songTitle: "",
+                  note: "",
+                  performanceStyle: "",
+                  members: [],
+                },
               ],
             }
           : p
@@ -258,6 +274,55 @@ export function LiveForm({
     );
   };
 
+  const toggleSetlistMember = (
+    performanceKey: number,
+    itemKey: number,
+    memberId: string
+  ) => {
+    setPerformances((prev) =>
+      prev.map((p) => {
+        if (p.key !== performanceKey) return p;
+        return {
+          ...p,
+          setlistItems: p.setlistItems.map((item) => {
+            if (item.key !== itemKey) return item;
+            const exists = item.members.some((m) => m.memberId === memberId);
+            return {
+              ...item,
+              members: exists
+                ? item.members.filter((m) => m.memberId !== memberId)
+                : [...item.members, { memberId, isCenter: false }],
+            };
+          }),
+        };
+      })
+    );
+  };
+
+  const toggleSetlistCenter = (
+    performanceKey: number,
+    itemKey: number,
+    memberId: string
+  ) => {
+    setPerformances((prev) =>
+      prev.map((p) => {
+        if (p.key !== performanceKey) return p;
+        return {
+          ...p,
+          setlistItems: p.setlistItems.map((item) => {
+            if (item.key !== itemKey) return item;
+            return {
+              ...item,
+              members: item.members.map((m) =>
+                m.memberId === memberId ? { ...m, isCenter: !m.isCenter } : m
+              ),
+            };
+          }),
+        };
+      })
+    );
+  };
+
   const rosterMembers = members.filter((member) =>
     performerMemberIds.includes(member.id)
   );
@@ -292,6 +357,8 @@ export function LiveForm({
           trackId: item.trackId,
           songTitle: item.songTitle,
           note: item.note,
+          performanceStyle: item.performanceStyle,
+          members: item.members,
         })),
       })),
     };
@@ -635,34 +702,109 @@ export function LiveForm({
                   </div>
 
                   {item.itemType === "song" ? (
-                    <div className="flex flex-wrap gap-2">
-                      <select
-                        value={item.trackId}
-                        onChange={(e) =>
-                          updateSetlistItem(performance.key, item.key, {
-                            trackId: e.target.value,
-                          })
-                        }
-                        className="rounded-lg border border-foreground/10 bg-background px-2 py-1.5 text-sm text-foreground"
-                      >
-                        <option value="">登録曲から選択</option>
-                        {tracks.map((track) => (
-                          <option key={track.id} value={track.id}>
-                            {track.title}
-                          </option>
-                        ))}
-                      </select>
-                      <input
-                        value={item.songTitle}
-                        onChange={(e) =>
-                          updateSetlistItem(performance.key, item.key, {
-                            songTitle: e.target.value,
-                          })
-                        }
-                        placeholder="未登録曲は曲名を入力"
-                        className="flex-1 rounded-lg border border-foreground/10 bg-background px-2 py-1.5 text-sm text-foreground placeholder:text-foreground/30"
-                      />
-                    </div>
+                    <>
+                      <div className="flex flex-wrap gap-2">
+                        <select
+                          value={item.trackId}
+                          onChange={(e) =>
+                            updateSetlistItem(performance.key, item.key, {
+                              trackId: e.target.value,
+                            })
+                          }
+                          className="rounded-lg border border-foreground/10 bg-background px-2 py-1.5 text-sm text-foreground"
+                        >
+                          <option value="">登録曲から選択</option>
+                          {tracks.map((track) => (
+                            <option key={track.id} value={track.id}>
+                              {track.title}
+                            </option>
+                          ))}
+                        </select>
+                        <input
+                          value={item.songTitle}
+                          onChange={(e) =>
+                            updateSetlistItem(performance.key, item.key, {
+                              songTitle: e.target.value,
+                            })
+                          }
+                          placeholder="未登録曲は曲名を入力"
+                          className="flex-1 rounded-lg border border-foreground/10 bg-background px-2 py-1.5 text-sm text-foreground placeholder:text-foreground/30"
+                        />
+                        <select
+                          value={item.performanceStyle}
+                          onChange={(e) =>
+                            updateSetlistItem(performance.key, item.key, {
+                              performanceStyle: e.target.value as PerformanceStyle | "",
+                            })
+                          }
+                          aria-label="披露タイプ"
+                          className="rounded-lg border border-foreground/10 bg-background px-2 py-1.5 text-sm text-foreground"
+                        >
+                          <option value="">披露タイプ</option>
+                          {PERFORMANCE_STYLE_VALUES.map((style) => (
+                            <option key={style} value={style}>
+                              {PERFORMANCE_STYLE_LABELS[style]}
+                            </option>
+                          ))}
+                        </select>
+                      </div>
+
+                      <div className="rounded-lg border border-foreground/10 p-2">
+                        <p className="mb-1 text-xs text-foreground/50">
+                          披露メンバー（C=センター）
+                        </p>
+                        <div className="grid max-h-40 grid-cols-2 gap-1 overflow-y-auto sm:grid-cols-3">
+                          {absenceCandidates.map((candidate) => {
+                            const selected = item.members.find(
+                              (m) => m.memberId === candidate.id
+                            );
+                            return (
+                              <div
+                                key={candidate.id}
+                                className="flex items-center gap-1 text-xs"
+                              >
+                                <label className="flex flex-1 cursor-pointer items-center gap-1">
+                                  <input
+                                    type="checkbox"
+                                    checked={Boolean(selected)}
+                                    onChange={() =>
+                                      toggleSetlistMember(
+                                        performance.key,
+                                        item.key,
+                                        candidate.id
+                                      )
+                                    }
+                                  />
+                                  <span className="text-foreground">
+                                    {candidate.nameJa}
+                                  </span>
+                                </label>
+                                {selected && (
+                                  <button
+                                    type="button"
+                                    onClick={() =>
+                                      toggleSetlistCenter(
+                                        performance.key,
+                                        item.key,
+                                        candidate.id
+                                      )
+                                    }
+                                    className={`rounded px-1 ${
+                                      selected.isCenter
+                                        ? "bg-pink-500 text-white"
+                                        : "bg-foreground/10 text-foreground/50"
+                                    }`}
+                                    aria-label="センター切り替え"
+                                  >
+                                    C
+                                  </button>
+                                )}
+                              </div>
+                            );
+                          })}
+                        </div>
+                      </div>
+                    </>
                   ) : null}
 
                   <input

--- a/apps/oshikatsu-web/components/lives/LiveDetail.tsx
+++ b/apps/oshikatsu-web/components/lives/LiveDetail.tsx
@@ -1,6 +1,10 @@
 import Link from "next/link";
 import type { Live, SetlistItem } from "@/types/live";
-import { LIVE_TYPE_LABELS, SETLIST_ITEM_TYPE_LABELS } from "@/types/live";
+import {
+  LIVE_TYPE_LABELS,
+  PERFORMANCE_STYLE_LABELS,
+  SETLIST_ITEM_TYPE_LABELS,
+} from "@/types/live";
 import { GroupBadge } from "@/components/ui/GroupBadge";
 import { formatDate } from "@/lib/formatters";
 
@@ -142,21 +146,36 @@ export function LiveDetail({ live }: LiveDetailProps) {
                             <span className="w-5 shrink-0 text-right text-foreground/40">
                               {item.itemType === "song" ? index + 1 : "-"}
                             </span>
-                            <span>
-                              {item.itemType === "song" ? (
-                                <>
-                                  {setlistItemLabel(item)}
-                                  {item.note ? `（${item.note}）` : ""}
-                                </>
-                              ) : (
-                                <>
-                                  <span className="mr-1 rounded bg-foreground/10 px-1 text-foreground/60">
-                                    {SETLIST_ITEM_TYPE_LABELS[item.itemType]}
+                            {item.itemType === "song" ? (
+                              <span>
+                                {setlistItemLabel(item)}
+                                {item.performanceStyle && (
+                                  <span className="ml-1 rounded bg-foreground/10 px-1 text-[10px] text-foreground/60">
+                                    {PERFORMANCE_STYLE_LABELS[item.performanceStyle]}
                                   </span>
-                                  {item.note}
-                                </>
-                              )}
-                            </span>
+                                )}
+                                {item.note ? `（${item.note}）` : ""}
+                                {item.members.length > 0 && (
+                                  <span className="ml-1 text-foreground/50">
+                                    {" / "}
+                                    {item.members
+                                      .map((member) =>
+                                        member.isCenter
+                                          ? `${member.memberNameJa}（C）`
+                                          : member.memberNameJa
+                                      )
+                                      .join("、")}
+                                  </span>
+                                )}
+                              </span>
+                            ) : (
+                              <span>
+                                <span className="mr-1 rounded bg-foreground/10 px-1 text-foreground/60">
+                                  {SETLIST_ITEM_TYPE_LABELS[item.itemType]}
+                                </span>
+                                {item.note}
+                              </span>
+                            )}
                           </li>
                         ))}
                       </ol>

--- a/apps/oshikatsu-web/repositories/liveRepository.ts
+++ b/apps/oshikatsu-web/repositories/liveRepository.ts
@@ -10,7 +10,7 @@ import type {
   SetlistItem,
   VenuePerformanceSummary,
 } from "@/types/live";
-import { isSetlistItemType } from "@/types/live";
+import { isSetlistItemType, isPerformanceStyle } from "@/types/live";
 import { RepositoryError } from "@/types/errors";
 
 type GroupRel = { name_ja: string; color: string } | { name_ja: string; color: string }[] | null;
@@ -35,13 +35,22 @@ type AbsenceRow = {
 
 type TrackRel = { title: string } | { title: string }[] | null;
 
+type SetlistItemMemberRow = {
+  member_id: string;
+  is_center: boolean;
+  sort_order: number;
+  orbit_members: MemberRel;
+};
+
 type SetlistItemRow = {
   position: number;
   item_type: string;
   track_id: string | null;
   song_title: string | null;
   note: string | null;
+  performance_style: string | null;
   orbit_tracks: TrackRel;
+  orbit_setlist_item_members: SetlistItemMemberRow[] | null;
 };
 
 type PerformanceRow = {
@@ -98,7 +107,16 @@ const DETAIL_SELECT = `
     sort_order,
     orbit_venues(name),
     orbit_live_performance_absences(member_id, note, orbit_members(name_ja)),
-    orbit_setlist_items(position, item_type, track_id, song_title, note, orbit_tracks(title))
+    orbit_setlist_items(
+      position,
+      item_type,
+      track_id,
+      song_title,
+      note,
+      performance_style,
+      orbit_tracks(title),
+      orbit_setlist_item_members(member_id, is_center, sort_order, orbit_members(name_ja))
+    )
   )
 `;
 
@@ -129,6 +147,18 @@ function mapPerformance(row: PerformanceRow): LivePerformance {
         trackTitle: pickFirst(item.orbit_tracks)?.title ?? null,
         songTitle: item.song_title,
         note: item.note,
+        performanceStyle:
+          item.performance_style && isPerformanceStyle(item.performance_style)
+            ? item.performance_style
+            : null,
+        members: (item.orbit_setlist_item_members ?? [])
+          .slice()
+          .sort((a, b) => a.sort_order - b.sort_order)
+          .map((member) => ({
+            memberId: member.member_id,
+            memberNameJa: pickFirst(member.orbit_members)?.name_ja ?? "",
+            isCenter: member.is_center,
+          })),
         position: item.position,
       }))
       .sort((a, b) => a.position - b.position),
@@ -185,12 +215,24 @@ function toLivePayload(input: CreateLiveInput) {
           member_id: absence.memberId,
           note: absence.note.trim(),
         })),
-      setlist_items: performance.setlistItems.map((item) => ({
-        item_type: item.itemType,
-        track_id: item.itemType === "song" ? item.trackId : "",
-        song_title: item.itemType === "song" ? item.songTitle.trim() : "",
-        note: item.note.trim(),
-      })),
+      setlist_items: performance.setlistItems.map((item) => {
+        const isSong = item.itemType === "song";
+        return {
+          item_type: item.itemType,
+          track_id: isSong ? item.trackId : "",
+          song_title: isSong ? item.songTitle.trim() : "",
+          note: item.note.trim(),
+          performance_style: isSong ? item.performanceStyle : "",
+          members: isSong
+            ? item.members
+                .filter((member) => member.memberId)
+                .map((member) => ({
+                  member_id: member.memberId,
+                  is_center: member.isCenter,
+                }))
+            : [],
+        };
+      }),
     })),
   };
 }

--- a/apps/oshikatsu-web/supabase/migrations/033_extend_setlist_song_details.sql
+++ b/apps/oshikatsu-web/supabase/migrations/033_extend_setlist_song_details.sql
@@ -1,0 +1,191 @@
+-- ============================================================
+-- 033: セットリスト楽曲の拡張（#102）
+-- セットリスト楽曲項目にセンター/披露メンバー/披露タイプを追加する。
+-- - orbit_setlist_items.performance_style（披露タイプ）
+-- - orbit_setlist_item_members（披露メンバー、is_center）
+-- upsert_orbit_live RPC を拡張し、これらも 1 トランザクションで置換する。
+-- ============================================================
+
+ALTER TABLE orbit_setlist_items
+  ADD COLUMN performance_style TEXT
+  CHECK (performance_style IN ('full', 'one_half', 'interlude_long', 'other'));
+
+CREATE TABLE orbit_setlist_item_members (
+  id               UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  setlist_item_id  UUID NOT NULL REFERENCES orbit_setlist_items(id) ON DELETE CASCADE,
+  member_id        UUID NOT NULL REFERENCES orbit_members(id) ON DELETE RESTRICT,
+  is_center        BOOLEAN NOT NULL DEFAULT false,
+  sort_order       INT NOT NULL DEFAULT 0,
+  UNIQUE (setlist_item_id, member_id)
+);
+
+CREATE INDEX idx_orbit_setlist_item_members_setlist_item_id
+  ON orbit_setlist_item_members (setlist_item_id);
+CREATE INDEX idx_orbit_setlist_item_members_member_id
+  ON orbit_setlist_item_members (member_id);
+
+ALTER TABLE orbit_setlist_item_members ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "orbit_setlist_item_members_select" ON orbit_setlist_item_members FOR SELECT
+  USING ((select auth.role()) = 'authenticated');
+CREATE POLICY "orbit_setlist_item_members_insert" ON orbit_setlist_item_members FOR INSERT
+  WITH CHECK ((select auth.role()) = 'authenticated');
+CREATE POLICY "orbit_setlist_item_members_update" ON orbit_setlist_item_members FOR UPDATE
+  USING ((select auth.role()) = 'authenticated');
+CREATE POLICY "orbit_setlist_item_members_delete" ON orbit_setlist_item_members FOR DELETE
+  USING ((select auth.role()) = 'authenticated');
+
+-- ============================================================
+-- upsert_orbit_live を拡張（披露タイプ + 披露メンバー）
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.upsert_orbit_live(
+  p_id UUID,
+  p_payload JSONB
+)
+RETURNS UUID
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+DECLARE
+  v_live_id        UUID;
+  v_performance    JSONB;
+  v_performance_id UUID;
+  v_absence        JSONB;
+  v_item           JSONB;
+  v_item_id        UUID;
+  v_item_member    JSONB;
+  v_sort           INT := 0;
+  v_position       INT;
+  v_member_sort    INT;
+BEGIN
+  IF p_id IS NULL THEN
+    INSERT INTO public.orbit_lives (name, live_type, description)
+    VALUES (
+      p_payload->>'name',
+      p_payload->>'live_type',
+      NULLIF(p_payload->>'description', '')
+    )
+    RETURNING id INTO v_live_id;
+  ELSE
+    v_live_id := p_id;
+    UPDATE public.orbit_lives
+    SET name = p_payload->>'name',
+        live_type = p_payload->>'live_type',
+        description = NULLIF(p_payload->>'description', '')
+    WHERE id = v_live_id;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'orbit_live not found: %', v_live_id;
+    END IF;
+
+    DELETE FROM public.orbit_live_performances WHERE live_id = v_live_id;
+    DELETE FROM public.orbit_live_performer_groups WHERE live_id = v_live_id;
+    DELETE FROM public.orbit_live_performer_members WHERE live_id = v_live_id;
+  END IF;
+
+  INSERT INTO public.orbit_live_performer_groups (live_id, group_id)
+  SELECT v_live_id, value::uuid
+  FROM jsonb_array_elements_text(COALESCE(p_payload->'performer_group_ids', '[]'::jsonb));
+
+  INSERT INTO public.orbit_live_performer_members (live_id, member_id)
+  SELECT v_live_id, value::uuid
+  FROM jsonb_array_elements_text(COALESCE(p_payload->'performer_member_ids', '[]'::jsonb));
+
+  FOR v_performance IN
+    SELECT * FROM jsonb_array_elements(COALESCE(p_payload->'performances', '[]'::jsonb))
+  LOOP
+    INSERT INTO public.orbit_live_performances (
+      live_id,
+      venue_id,
+      performance_date,
+      doors_open_at,
+      starts_at,
+      session_label,
+      has_streaming,
+      has_live_viewing,
+      ticket_info,
+      seat_info,
+      sort_order
+    )
+    VALUES (
+      v_live_id,
+      NULLIF(v_performance->>'venue_id', '')::uuid,
+      NULLIF(v_performance->>'performance_date', '')::date,
+      NULLIF(v_performance->>'doors_open_at', ''),
+      NULLIF(v_performance->>'starts_at', ''),
+      NULLIF(v_performance->>'session_label', ''),
+      COALESCE((v_performance->>'has_streaming')::boolean, false),
+      COALESCE((v_performance->>'has_live_viewing')::boolean, false),
+      NULLIF(v_performance->>'ticket_info', ''),
+      NULLIF(v_performance->>'seat_info', ''),
+      v_sort
+    )
+    RETURNING id INTO v_performance_id;
+
+    FOR v_absence IN
+      SELECT * FROM jsonb_array_elements(COALESCE(v_performance->'absences', '[]'::jsonb))
+    LOOP
+      IF COALESCE(v_absence->>'member_id', '') <> '' THEN
+        INSERT INTO public.orbit_live_performance_absences (performance_id, member_id, note)
+        VALUES (
+          v_performance_id,
+          (v_absence->>'member_id')::uuid,
+          NULLIF(v_absence->>'note', '')
+        );
+      END IF;
+    END LOOP;
+
+    v_position := 0;
+    FOR v_item IN
+      SELECT * FROM jsonb_array_elements(COALESCE(v_performance->'setlist_items', '[]'::jsonb))
+    LOOP
+      INSERT INTO public.orbit_setlist_items (
+        performance_id,
+        position,
+        item_type,
+        track_id,
+        song_title,
+        note,
+        performance_style
+      )
+      VALUES (
+        v_performance_id,
+        v_position,
+        v_item->>'item_type',
+        NULLIF(v_item->>'track_id', '')::uuid,
+        NULLIF(v_item->>'song_title', ''),
+        NULLIF(v_item->>'note', ''),
+        NULLIF(v_item->>'performance_style', '')
+      )
+      RETURNING id INTO v_item_id;
+
+      v_member_sort := 0;
+      FOR v_item_member IN
+        SELECT * FROM jsonb_array_elements(COALESCE(v_item->'members', '[]'::jsonb))
+      LOOP
+        IF COALESCE(v_item_member->>'member_id', '') <> '' THEN
+          INSERT INTO public.orbit_setlist_item_members (
+            setlist_item_id,
+            member_id,
+            is_center,
+            sort_order
+          )
+          VALUES (
+            v_item_id,
+            (v_item_member->>'member_id')::uuid,
+            COALESCE((v_item_member->>'is_center')::boolean, false),
+            v_member_sort
+          );
+          v_member_sort := v_member_sort + 1;
+        END IF;
+      END LOOP;
+
+      v_position := v_position + 1;
+    END LOOP;
+
+    v_sort := v_sort + 1;
+  END LOOP;
+
+  RETURN v_live_id;
+END;
+$$;

--- a/apps/oshikatsu-web/types/live.ts
+++ b/apps/oshikatsu-web/types/live.ts
@@ -46,12 +46,40 @@ export function isSetlistItemType(value: string): value is SetlistItemType {
   return (SETLIST_ITEM_TYPE_VALUES as readonly string[]).includes(value);
 }
 
+export const PERFORMANCE_STYLE_VALUES = [
+  "full",
+  "one_half",
+  "interlude_long",
+  "other",
+] as const;
+
+export type PerformanceStyle = (typeof PERFORMANCE_STYLE_VALUES)[number];
+
+export const PERFORMANCE_STYLE_LABELS: Record<PerformanceStyle, string> = {
+  full: "フル",
+  one_half: "ワンハーフ",
+  interlude_long: "間奏ロング",
+  other: "その他",
+};
+
+export function isPerformanceStyle(value: string): value is PerformanceStyle {
+  return (PERFORMANCE_STYLE_VALUES as readonly string[]).includes(value);
+}
+
+export type SetlistMember = {
+  memberId: string;
+  memberNameJa: string;
+  isCenter: boolean;
+};
+
 export type SetlistItem = {
   itemType: SetlistItemType;
   trackId: string | null;
   trackTitle: string | null;
   songTitle: string | null;
   note: string | null;
+  performanceStyle: PerformanceStyle | null;
+  members: SetlistMember[];
   position: number;
 };
 
@@ -116,11 +144,18 @@ export type CreateLivePerformanceAbsenceInput = {
   note: string;
 };
 
+export type CreateSetlistMemberInput = {
+  memberId: string;
+  isCenter: boolean;
+};
+
 export type CreateSetlistItemInput = {
   itemType: SetlistItemType;
   trackId: string;
   songTitle: string;
   note: string;
+  performanceStyle: PerformanceStyle | "";
+  members: CreateSetlistMemberInput[];
 };
 
 export type CreateLivePerformanceInput = {

--- a/apps/oshikatsu-web/usecases/validateLive.ts
+++ b/apps/oshikatsu-web/usecases/validateLive.ts
@@ -72,6 +72,12 @@ export function validateLive(input: CreateLiveInput): ValidationError[] {
       if (item.note.length > 500) {
         errors.push({ field, message: "メモは500文字以内で入力してください" });
       }
+
+      // 披露タイプ・披露メンバーは楽曲項目のみ対象（非楽曲は保存時に破棄される）
+      if (item.itemType !== "song") {
+        return;
+      }
+
       if (item.performanceStyle && !isPerformanceStyle(item.performanceStyle)) {
         errors.push({ field, message: "無効な披露タイプです" });
       }

--- a/apps/oshikatsu-web/usecases/validateLive.ts
+++ b/apps/oshikatsu-web/usecases/validateLive.ts
@@ -1,6 +1,6 @@
 import type { CreateLiveInput } from "@/types/live";
 import type { ValidationError } from "@/types/errors";
-import { isLiveType, isSetlistItemType } from "@/types/live";
+import { isLiveType, isSetlistItemType, isPerformanceStyle } from "@/types/live";
 import { isValidDateString } from "@/lib/validation";
 
 function isValidTimeString(value: string): boolean {
@@ -55,6 +55,8 @@ export function validateLive(input: CreateLiveInput): ValidationError[] {
       });
     }
 
+    const rosterIds = new Set(input.performerMemberIds);
+
     performance.setlistItems.forEach((item, itemIndex) => {
       const field = `performances.${index}.setlistItems.${itemIndex}`;
       if (!isSetlistItemType(item.itemType)) {
@@ -70,9 +72,23 @@ export function validateLive(input: CreateLiveInput): ValidationError[] {
       if (item.note.length > 500) {
         errors.push({ field, message: "メモは500文字以内で入力してください" });
       }
+      if (item.performanceStyle && !isPerformanceStyle(item.performanceStyle)) {
+        errors.push({ field, message: "無効な披露タイプです" });
+      }
+      const seenMembers = new Set<string>();
+      for (const member of item.members) {
+        if (!member.memberId) continue;
+        if (seenMembers.has(member.memberId)) {
+          errors.push({ field, message: "同じ披露メンバーが重複しています" });
+          break;
+        }
+        if (rosterIds.size > 0 && !rosterIds.has(member.memberId)) {
+          errors.push({ field, message: "披露メンバーは出演メンバーから選択してください" });
+          break;
+        }
+        seenMembers.add(member.memberId);
+      }
     });
-
-    const rosterIds = new Set(input.performerMemberIds);
     const seenAbsentMembers = new Set<string>();
     for (const absence of performance.absences) {
       if (!absence.memberId) continue;

--- a/docs/orbit-roadmap.md
+++ b/docs/orbit-roadmap.md
@@ -232,7 +232,10 @@
   - [x] `orbit_setlist_items`（公演ごと・順序つき・種別）を追加し、RPC `upsert_orbit_live` を拡張
   - [x] 楽曲は登録曲（`orbit_tracks`）参照 or 未登録曲テキスト。MC/影アナ/VTR/その他に対応
   - [x] LiveForm にセットリスト編集（行追加・並べ替え・削除）、公開公演詳細に表示
-- [ ] D: セトリ楽曲の拡張（センター/披露メンバー/披露タイプ）（Issue #102）
+- [x] D: セトリ楽曲の拡張（センター/披露メンバー/披露タイプ）（Issue #102）
+  - [x] `orbit_setlist_item_members`（is_center）＋ `orbit_setlist_items.performance_style` を追加、RPC 拡張
+  - [x] 披露タイプ（フル/ワンハーフ/間奏ロング/その他）＝ enum＋その他
+  - [x] LiveForm に披露タイプ・披露メンバー（センター）編集、LiveDetail に表示
 - [ ] E（将来/バックログ）: 参加記録＋現地カウント/ランキング（Issue #103）
 
 ---


### PR DESCRIPTION
アンブレラ: #98

## 概要

ライブ情報＋セットリスト（#98）のステップ D。セットリストの**楽曲項目**に、**披露タイプ**（フル/ワンハーフ/間奏ロング/その他）と**披露メンバー（センター指定可）**を登録できるようにしました。オリジナルのフォーメーションと異なる披露メンバーを公演ごとに記録できます。

Closes #102

## データモデル（migration 033）

- `orbit_setlist_items.performance_style`（`full|one_half|interlude_long|other`、nullable）
- `orbit_setlist_item_members`（setlist_item_id, member_id, `is_center`, sort_order、UNIQUE(item, member)）
- RPC `upsert_orbit_live` を拡張し、披露タイプ・披露メンバーも 1 トランザクションで置換

## 変更内容

- **型**: `PerformanceStyle`（enum＋ラベル）、`SetlistMember`、`SetlistItem` / `CreateSetlistItemInput` を拡張
- **Repository**: `DETAIL_SELECT` に `performance_style` と `orbit_setlist_item_members(...)` を追加、マッピング（sort_order 昇順）・payload を拡張
- **UseCase**: `validateLive` に披露タイプの有効値検証、披露メンバーの重複・ロスター内チェックを追加
- **UI**: `LiveForm` の楽曲項目に披露タイプ選択＋披露メンバー チェックリスト（`C` ボタンでセンター切替）、`LiveDetail` に披露タイプ・披露メンバー（センターは「（C）」）を表示

## 受け入れ条件

- [x] `orbit_setlist_item_members`（is_center）＋ `performance_style` 追加
- [x] Admin: 楽曲項目ごとに披露メンバー（複数, センター指定）と披露タイプを編集
- [x] Public: 公演詳細の楽曲にセンター/披露メンバー/披露タイプを表示
- [x] 披露メンバーは `orbit_members` から選択（出演ロスター優先、なければ全メンバー）
- [x] `pnpm --filter oshikatsu-web typecheck` / `lint` / `build` 通過

## 確認方法（要 migration 適用）

> Supabase に `033_extend_setlist_song_details.sql` を適用後に確認（030〜032 適用済み前提）。

1. `/admin/lives/[id]/edit` の楽曲項目で披露タイプを選択、披露メンバーを選び `C` でセンター指定
2. `/lives/[id]` でセットリスト楽曲に披露タイプ・披露メンバー（C）が表示される
3. ロスター外メンバーを休演/披露に入れるとバリデーションで弾かれる

## 補足

- これで #98 シリーズ（会場→ライブ/公演→セットリスト→セトリ拡張）が完了見込みです。残るは将来バックログの #103（参加記録＋ランキング）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
