### PR TITLE
[codex] Orbit会場の初期seedを追加

### DIFF
--- a/apps/oshikatsu-web/supabase/config.toml
+++ b/apps/oshikatsu-web/supabase/config.toml
@@ -62,7 +62,13 @@ schema_paths = []
 enabled = true
 # Specifies an ordered list of seed files to load during db reset.
 # Supports glob patterns relative to supabase directory: "./seeds/*.sql"
-sql_paths = ["./seed.sql"]
+sql_paths = [
+  "./seeds/030_seed_sakamichi_release_tracks_starter.sql",
+  "./seeds/031_seed_sakamichi_tracks_expanded.sql",
+  "./seeds/032_seed_sakamichi_single_tracks_expanded.sql",
+  "./seeds/033_fix_hinata_recent_single_tracks.sql",
+  "./seeds/034_seed_sakamichi_venues.sql",
+]
 
 [db.network_restrictions]
 # Enable management of network restrictions.

--- a/apps/oshikatsu-web/supabase/seeds/034_seed_sakamichi_venues.sql
+++ b/apps/oshikatsu-web/supabase/seeds/034_seed_sakamichi_venues.sql
@@ -212,6 +212,105 @@ VALUES
     'https://www.nipponbudokan.or.jp/',
     NULL,
     '参考公演: 日向坂46 四期生ライブ'
+  ),
+  (
+    '幕張イベントホール',
+    '千葉県',
+    9000,
+    'https://www.google.com/maps/search/?api=1&query=幕張イベントホール',
+    'https://www.m-messe.co.jp/',
+    NULL,
+    '幕張メッセ内のイベントホール'
+  ),
+  (
+    '有明アリーナ',
+    '東京都',
+    15000,
+    'https://www.google.com/maps/search/?api=1&query=有明アリーナ',
+    'https://www.ariake-arena.tokyo/',
+    NULL,
+    NULL
+  ),
+  (
+    'TOYOTA ARENA TOKYO',
+    '東京都',
+    10000,
+    'https://www.google.com/maps/search/?api=1&query=TOYOTA ARENA TOKYO',
+    NULL,
+    NULL,
+    '2025年開業（お台場・青海）。公式URL要確認'
+  ),
+  (
+    'Theater MILANO-Za',
+    '東京都',
+    NULL,
+    'https://www.google.com/maps/search/?api=1&query=Theater MILANO-Za',
+    'https://tokyu-kabukicho-tower.jp/',
+    NULL,
+    '東急歌舞伎町タワー内の劇場（約900席）'
+  ),
+  (
+    '京セラドーム',
+    '大阪府',
+    36000,
+    'https://www.google.com/maps/search/?api=1&query=京セラドーム大阪',
+    'https://www.kyoceradome-osaka.jp/',
+    NULL,
+    'コンサート時 約3.6万人'
+  ),
+  (
+    'ZOZOマリンスタジアム',
+    '千葉県',
+    30000,
+    'https://www.google.com/maps/search/?api=1&query=ZOZOマリンスタジアム',
+    'https://www.marines.co.jp/stadium/',
+    NULL,
+    'コンサート時 約3万人'
+  ),
+  (
+    'Kアリーナ横浜',
+    '神奈川県',
+    20000,
+    'https://www.google.com/maps/search/?api=1&query=Kアリーナ横浜',
+    'https://k-arena.com/',
+    NULL,
+    '音楽特化型アリーナ'
+  ),
+  (
+    'LaLa arena TOKYO-BAY',
+    '千葉県',
+    10000,
+    'https://www.google.com/maps/search/?api=1&query=LaLa arena TOKYO-BAY',
+    NULL,
+    NULL,
+    '船橋（ららアリーナ 東京ベイ）。公式URL要確認'
+  ),
+  (
+    '武蔵野の森総合スポーツプラザ',
+    '東京都',
+    10000,
+    'https://www.google.com/maps/search/?api=1&query=武蔵野の森総合スポーツプラザ',
+    'https://www.musashinonomori-sportsplaza.jp/',
+    NULL,
+    'メインアリーナ 約1万人'
+  ),
+  (
+    'さいたまスーパーアリーナ',
+    '埼玉県',
+    37000,
+    'https://www.google.com/maps/search/?api=1&query=さいたまスーパーアリーナ',
+    'https://www.saitama-arena.co.jp/',
+    NULL,
+    '最大約3.7万人（モードにより変動）'
+  ),
+  (
+    '東京国際フォーラムホールA',
+    '東京都',
+    5012,
+    'https://www.google.com/maps/search/?api=1&query=東京国際フォーラム ホールA',
+    'https://www.t-i-forum.co.jp/',
+    NULL,
+    NULL
   );
 
 UPDATE public.orbit_venues AS venue

--- a/apps/oshikatsu-web/supabase/seeds/034_seed_sakamichi_venues.sql
+++ b/apps/oshikatsu-web/supabase/seeds/034_seed_sakamichi_venues.sql
@@ -311,6 +311,96 @@ VALUES
     'https://www.t-i-forum.co.jp/',
     NULL,
     NULL
+  ),
+  (
+    '神戸ワールド記念ホール',
+    '兵庫県',
+    8000,
+    'https://www.google.com/maps/search/?api=1&query=神戸ワールド記念ホール',
+    'https://kobe-cc.jp/',
+    NULL,
+    '参考: 櫻坂46 公式ライブ一覧'
+  ),
+  (
+    '広島グリーンアリーナ',
+    '広島県',
+    10000,
+    'https://www.google.com/maps/search/?api=1&query=広島グリーンアリーナ',
+    NULL,
+    NULL,
+    '広島県立総合体育館。公式URL要確認 / 参考: 櫻坂46 公式ライブ一覧'
+  ),
+  (
+    '豊洲PIT',
+    '東京都',
+    NULL,
+    'https://www.google.com/maps/search/?api=1&query=豊洲PIT',
+    NULL,
+    NULL,
+    'スタンディング 約3,000。公式URL要確認 / 参考: 櫻坂46 公式ライブ一覧'
+  ),
+  (
+    'Zepp DiverCity(TOKYO)',
+    '東京都',
+    2473,
+    'https://www.google.com/maps/search/?api=1&query=Zepp DiverCity TOKYO',
+    'https://www.zepp.co.jp/hall/divercity/',
+    NULL,
+    '参考: 櫻坂46 公式ライブ一覧'
+  ),
+  (
+    '丸善インテックアリーナ大阪',
+    '大阪府',
+    NULL,
+    'https://www.google.com/maps/search/?api=1&query=丸善インテックアリーナ大阪',
+    NULL,
+    NULL,
+    '大阪府立体育会館。公式URL要確認 / 参考: 櫻坂46 公式ライブ一覧'
+  ),
+  (
+    '西日本総合展示場 新館',
+    '福岡県',
+    NULL,
+    'https://www.google.com/maps/search/?api=1&query=西日本総合展示場 新館',
+    NULL,
+    NULL,
+    '北九州。公式URL要確認 / 参考: 櫻坂46 公式ライブ一覧'
+  ),
+  (
+    'Aichi Sky Expo ホールA',
+    '愛知県',
+    NULL,
+    'https://www.google.com/maps/search/?api=1&query=Aichi Sky Expo',
+    'https://www.aichiskyexpo.com/',
+    NULL,
+    '愛知県国際展示場（常滑）/ 参考: 櫻坂46 公式ライブ一覧'
+  ),
+  (
+    '舞浜アンフィシアター',
+    '千葉県',
+    2170,
+    'https://www.google.com/maps/search/?api=1&query=舞浜アンフィシアター',
+    'https://www.maihama-amphitheater.jp/',
+    NULL,
+    '参考: 櫻坂46 公式ライブ一覧'
+  ),
+  (
+    '富士急ハイランドコニファーフォレスト',
+    '山梨県',
+    NULL,
+    'https://www.google.com/maps/search/?api=1&query=富士急ハイランドコニファーフォレスト',
+    NULL,
+    NULL,
+    '野外ライブ会場。公式URL要確認 / 参考: 櫻坂46 公式ライブ一覧'
+  ),
+  (
+    '東京ガーデンシアター',
+    '東京都',
+    8000,
+    'https://www.google.com/maps/search/?api=1&query=東京ガーデンシアター',
+    'https://www.tokyo-gardentheater.com/',
+    NULL,
+    '有明 / 参考: 櫻坂46 公式ライブ一覧'
   );
 
 UPDATE public.orbit_venues AS venue

--- a/apps/oshikatsu-web/supabase/seeds/034_seed_sakamichi_venues.sql
+++ b/apps/oshikatsu-web/supabase/seeds/034_seed_sakamichi_venues.sql
@@ -79,10 +79,10 @@ VALUES
     '参考公演: 乃木坂46 真夏の全国ツアー2025 / 日向坂46 ARENA TOUR 2025'
   ),
   (
-    'マリンメッセ福岡A館',
+    'マリンメッセ福岡Ａ館',
     '福岡県',
     15000,
-    'https://www.google.com/maps/search/?api=1&query=マリンメッセ福岡A館',
+    'https://www.google.com/maps/search/?api=1&query=マリンメッセ福岡Ａ館',
     'https://www.marinemesse.or.jp/messe/',
     NULL,
     '参考公演: 乃木坂46 真夏の全国ツアー2025 / 櫻坂46 4th ARENA TOUR 2024 / 日向坂46 ARENA TOUR 2025'
@@ -241,16 +241,16 @@ VALUES
     '2025年開業（お台場・青海）。公式URL要確認'
   ),
   (
-    'Theater MILANO-Za',
+    'THEATER MILANO-Za',
     '東京都',
     NULL,
-    'https://www.google.com/maps/search/?api=1&query=Theater MILANO-Za',
+    'https://www.google.com/maps/search/?api=1&query=THEATER MILANO-Za',
     'https://tokyu-kabukicho-tower.jp/',
     NULL,
     '東急歌舞伎町タワー内の劇場（約900席）'
   ),
   (
-    '京セラドーム',
+    '京セラドーム大阪',
     '大阪府',
     36000,
     'https://www.google.com/maps/search/?api=1&query=京セラドーム大阪',

--- a/apps/oshikatsu-web/supabase/seeds/034_seed_sakamichi_venues.sql
+++ b/apps/oshikatsu-web/supabase/seeds/034_seed_sakamichi_venues.sql
@@ -1,0 +1,254 @@
+-- ============================================================
+-- Orbit starter seed: Sakamichi live venues
+-- ============================================================
+-- Scope:
+-- - Recent and representative venues used on official live pages for
+--   乃木坂46 / 櫻坂46 / 日向坂46.
+-- - Venue names use the latest official naming found during curation.
+--
+-- Notes:
+-- - This seed assumes migrations through 035_venue_links_drop_address.sql.
+-- - Existing rows are matched by venue name and only empty optional fields are filled.
+-- - Capacity is included only for venues where a public facility figure was found.
+--
+-- Main sources checked:
+-- - 乃木坂46 真夏の全国ツアー2025 / 13th YEAR BIRTHDAY LIVE
+-- - 櫻坂46 3rd/4th YEAR ANNIVERSARY LIVE, TOUR 2023, 4th ARENA TOUR 2024, 5th ANNIVERSARY LIVE
+-- - 日向坂46 ARENA TOUR 2025, 6回目のひな誕祭, Happy Magical Tour 2024,
+--   BRAND NEW LIVE 2025「OVER THE RAINBOW」
+-- ============================================================
+
+DO $seed$
+BEGIN
+DROP TABLE IF EXISTS orbit_seed_venues;
+
+CREATE TEMP TABLE orbit_seed_venues (
+  name TEXT NOT NULL,
+  prefecture TEXT NOT NULL,
+  capacity INT,
+  map_url TEXT,
+  official_url TEXT,
+  access TEXT,
+  notes TEXT
+) ON COMMIT PRESERVE ROWS;
+
+INSERT INTO orbit_seed_venues (
+  name,
+  prefecture,
+  capacity,
+  map_url,
+  official_url,
+  access,
+  notes
+)
+VALUES
+  (
+    '真駒内セキスイハイムアイスアリーナ',
+    '北海道',
+    10024,
+    'https://www.google.com/maps/search/?api=1&query=真駒内セキスイハイムアイスアリーナ',
+    'https://www.makomanai.com/icearena/',
+    NULL,
+    '参考公演: 乃木坂46 真夏の全国ツアー2025'
+  ),
+  (
+    'エコパアリーナ',
+    '静岡県',
+    10000,
+    'https://www.google.com/maps/search/?api=1&query=エコパアリーナ',
+    'https://www.ecopa.jp/facility/arena/',
+    NULL,
+    '参考公演: 乃木坂46 真夏の全国ツアー2025'
+  ),
+  (
+    '大阪城ホール',
+    '大阪府',
+    16000,
+    'https://www.google.com/maps/search/?api=1&query=大阪城ホール',
+    'https://www.osaka-johall.com/',
+    NULL,
+    '参考公演: 乃木坂46 真夏の全国ツアー2025 / 櫻坂46 TOUR 2023 / 日向坂46 ARENA TOUR 2025'
+  ),
+  (
+    'セキスイハイムスーパーアリーナ',
+    '宮城県',
+    7063,
+    'https://www.google.com/maps/search/?api=1&query=セキスイハイムスーパーアリーナ',
+    'https://www.mspf.jp/grande21/index.php?action=sisetu_shoukai_arena',
+    NULL,
+    '参考公演: 乃木坂46 真夏の全国ツアー2025 / 日向坂46 ARENA TOUR 2025'
+  ),
+  (
+    'マリンメッセ福岡A館',
+    '福岡県',
+    15000,
+    'https://www.google.com/maps/search/?api=1&query=マリンメッセ福岡A館',
+    'https://www.marinemesse.or.jp/messe/',
+    NULL,
+    '参考公演: 乃木坂46 真夏の全国ツアー2025 / 櫻坂46 4th ARENA TOUR 2024 / 日向坂46 ARENA TOUR 2025'
+  ),
+  (
+    'あなぶきアリーナ香川',
+    '香川県',
+    10000,
+    'https://www.google.com/maps/search/?api=1&query=あなぶきアリーナ香川',
+    'https://kagawa-arena.com/',
+    NULL,
+    '参考公演: 乃木坂46 真夏の全国ツアー2025'
+  ),
+  (
+    '明治神宮野球場',
+    '東京都',
+    31828,
+    'https://www.google.com/maps/search/?api=1&query=明治神宮野球場',
+    'https://www.jingu-stadium.com/',
+    NULL,
+    '参考公演: 乃木坂46 真夏の全国ツアー2025'
+  ),
+  (
+    '味の素スタジアム',
+    '東京都',
+    49970,
+    'https://www.google.com/maps/search/?api=1&query=味の素スタジアム',
+    'https://www.ajinomotostadium.com/',
+    NULL,
+    '参考公演: 乃木坂46 13th YEAR BIRTHDAY LIVE'
+  ),
+  (
+    '国立代々木競技場第一体育館',
+    '東京都',
+    12542,
+    'https://www.google.com/maps/search/?api=1&query=国立代々木競技場第一体育館',
+    'https://www.jpnsport.go.jp/yoyogi/',
+    NULL,
+    '参考公演: 櫻坂46 TOUR 2023 / 日向坂46 BRAND NEW LIVE 2025「OVER THE RAINBOW」'
+  ),
+  (
+    '日本ガイシホール',
+    '愛知県',
+    10000,
+    'https://www.google.com/maps/search/?api=1&query=日本ガイシホール',
+    'https://www.nespa.or.jp/sports-plaza/hall/',
+    NULL,
+    '参考公演: 櫻坂46 TOUR 2023 / 櫻坂46 4th ARENA TOUR 2024'
+  ),
+  (
+    '福岡国際センター',
+    '福岡県',
+    10000,
+    'https://www.google.com/maps/search/?api=1&query=福岡国際センター',
+    'https://www.marinemesse.or.jp/kokusai/',
+    NULL,
+    '参考公演: 櫻坂46 TOUR 2023'
+  ),
+  (
+    'ぴあアリーナMM',
+    '神奈川県',
+    12141,
+    'https://www.google.com/maps/search/?api=1&query=ぴあアリーナMM',
+    'https://pia-arena-mm.jp/',
+    NULL,
+    '参考公演: 櫻坂46 TOUR 2023 / 櫻坂46 4th ARENA TOUR 2024 / 日向坂46 加藤史帆卒業セレモニー'
+  ),
+  (
+    '東京ドーム',
+    '東京都',
+    55000,
+    'https://www.google.com/maps/search/?api=1&query=東京ドーム',
+    'https://www.tokyo-dome.co.jp/dome/',
+    NULL,
+    '参考公演: 櫻坂46 4th ARENA TOUR 2024 / 日向坂46 Happy Magical Tour 2024'
+  ),
+  (
+    'MUFGスタジアム（国立競技場）',
+    '東京都',
+    67750,
+    'https://www.google.com/maps/search/?api=1&query=MUFGスタジアム（国立競技場）',
+    'https://jns-e.com/',
+    NULL,
+    '参考公演: 櫻坂46 5th ANNIVERSARY LIVE'
+  ),
+  (
+    '横浜スタジアム',
+    '神奈川県',
+    34046,
+    'https://www.google.com/maps/search/?api=1&query=横浜スタジアム',
+    'https://www.yokohama-stadium.co.jp/',
+    NULL,
+    '参考公演: 日向坂46 6回目のひな誕祭'
+  ),
+  (
+    '広島サンプラザホール',
+    '広島県',
+    6052,
+    'https://www.google.com/maps/search/?api=1&query=広島サンプラザホール',
+    'https://www.hiroshima-sunplaza.or.jp/hall/',
+    NULL,
+    '参考公演: 日向坂46 ARENA TOUR 2025'
+  ),
+  (
+    'ポートメッセなごや 第1展示館',
+    '愛知県',
+    15000,
+    'https://www.google.com/maps/search/?api=1&query=ポートメッセなごや第1展示館',
+    'https://portmesse.com/facility/',
+    NULL,
+    '参考公演: 日向坂46 ARENA TOUR 2025 / 日向坂46 Happy Magical Tour 2024'
+  ),
+  (
+    '横浜アリーナ',
+    '神奈川県',
+    17000,
+    'https://www.google.com/maps/search/?api=1&query=横浜アリーナ',
+    'https://www.yokohama-arena.co.jp/',
+    NULL,
+    '参考公演: 日向坂46 齊藤京子卒業コンサート'
+  ),
+  (
+    '日本武道館',
+    '東京都',
+    14471,
+    'https://www.google.com/maps/search/?api=1&query=日本武道館',
+    'https://www.nipponbudokan.or.jp/',
+    NULL,
+    '参考公演: 日向坂46 四期生ライブ'
+  );
+
+UPDATE public.orbit_venues AS venue
+SET
+  prefecture = COALESCE(NULLIF(venue.prefecture, ''), seed.prefecture),
+  capacity = COALESCE(venue.capacity, seed.capacity),
+  map_url = COALESCE(NULLIF(venue.map_url, ''), seed.map_url),
+  official_url = COALESCE(NULLIF(venue.official_url, ''), seed.official_url),
+  access = COALESCE(NULLIF(venue.access, ''), seed.access),
+  notes = COALESCE(NULLIF(venue.notes, ''), seed.notes)
+FROM orbit_seed_venues seed
+WHERE venue.name = seed.name;
+
+INSERT INTO public.orbit_venues (
+  name,
+  prefecture,
+  capacity,
+  map_url,
+  official_url,
+  access,
+  notes
+)
+SELECT
+  seed.name,
+  seed.prefecture,
+  seed.capacity,
+  seed.map_url,
+  seed.official_url,
+  seed.access,
+  seed.notes
+FROM orbit_seed_venues seed
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM public.orbit_venues existing
+  WHERE existing.name = seed.name
+);
+
+DROP TABLE IF EXISTS orbit_seed_venues;
+END;
+$seed$;


### PR DESCRIPTION
## 概要

Orbit の会場マスタ向けに、坂道グループ公式ライブページを参考にした初期 seed を追加しました。

- `orbit_venues` 用の会場 seed を追加
- 会場名・都道府県を必須として、確認できたキャパシティ、Google マップ URL、公式サイト URL を投入
- `db reset` 時に既存 seed と会場 seed が読み込まれるよう `supabase/config.toml` の `sql_paths` を明示
- 同名会場が既にある場合は、空の任意項目だけ補完する形にして既存入力を優先

## 参考

Refs #99
Refs #115

## 検証

- `python3` で `supabase/config.toml` の TOML 構文確認
- `python3` で seed 件数と `DO` ブロック終端確認
- seed 内公式 URL の到達確認（真駒内セキスイハイムアイスアリーナのみ、サイト側で接続がリセットされるため URL は維持）
- `tsc --noEmit`
- `eslint .`