### PR TITLE
会場一覧をソート可能に（既定=都道府県の北→南）

### DIFF
--- a/apps/oshikatsu-web/app/(authenticated)/venues/page.tsx
+++ b/apps/oshikatsu-web/app/(authenticated)/venues/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { getVenuesPageData } from "@/usecases/readOrbitData";
+import { VenueTable } from "@/components/venues/VenueTable";
 import { Button } from "@/components/ui/Button";
 
 export default async function VenuesPage() {
@@ -14,53 +15,12 @@ export default async function VenuesPage() {
         </Link>
       </div>
 
-      <div className="overflow-x-auto">
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="border-b border-foreground/10 text-left">
-              <th className="pb-2 pr-4 font-medium text-foreground/70">会場名</th>
-              <th className="pb-2 pr-4 font-medium text-foreground/70">都道府県</th>
-              <th className="pb-2 pr-4 font-medium text-foreground/70">キャパ</th>
-              <th className="pb-2 font-medium text-foreground/70">操作</th>
-            </tr>
-          </thead>
-          <tbody>
-            {venues.map((venue) => (
-              <tr key={venue.id} className="border-b border-foreground/5">
-                <td className="py-2 pr-4">
-                  <Link
-                    href={`/venues/${venue.id}`}
-                    className="text-foreground hover:underline"
-                  >
-                    {venue.name}
-                  </Link>
-                </td>
-                <td className="py-2 pr-4 text-foreground/70">
-                  {venue.prefecture ?? "—"}
-                </td>
-                <td className="py-2 pr-4 text-foreground/70">
-                  {venue.capacity != null
-                    ? `${venue.capacity.toLocaleString()}人`
-                    : "—"}
-                </td>
-                <td className="py-2">
-                  <Link
-                    href={`/venues/${venue.id}/edit`}
-                    className="text-sm text-blue-500 hover:underline"
-                  >
-                    編集
-                  </Link>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-
-      {venues.length === 0 && (
+      {venues.length === 0 ? (
         <p className="py-12 text-center text-sm text-foreground/50">
           会場が登録されていません
         </p>
+      ) : (
+        <VenueTable venues={venues} />
       )}
     </div>
   );

--- a/apps/oshikatsu-web/components/venues/VenueTable.tsx
+++ b/apps/oshikatsu-web/components/venues/VenueTable.tsx
@@ -61,31 +61,59 @@ export function VenueTable({ venues }: VenueTableProps) {
     }
   };
 
-  const indicator = (key: SortKey) => {
-    if (key !== sortKey) return "";
-    return sortDir === "asc" ? " ▲" : " ▼";
+  const ariaSort = (key: SortKey): "ascending" | "descending" | "none" => {
+    if (key !== sortKey) return "none";
+    return sortDir === "asc" ? "ascending" : "descending";
   };
 
-  const headerButton = (key: SortKey, label: string) => (
-    <button
-      type="button"
-      onClick={() => handleSort(key)}
-      className="flex items-center font-medium text-foreground/70 hover:text-foreground"
-    >
-      {label}
-      <span className="text-xs">{indicator(key)}</span>
-    </button>
-  );
+  const sortableHeader = (key: SortKey, label: string) => {
+    const active = key === sortKey;
+    const nextDir = active ? (sortDir === "asc" ? "desc" : "asc") : "desc";
+    return (
+      <th scope="col" aria-sort={ariaSort(key)} className="pb-2 pr-4">
+        <button
+          type="button"
+          onClick={() => handleSort(key)}
+          aria-label={`${label}を${nextDir === "asc" ? "昇順" : "降順"}で並び替え`}
+          className={`group flex items-center gap-0.5 hover:text-foreground ${
+            active ? "font-semibold text-foreground" : "font-medium text-foreground/70"
+          }`}
+        >
+          {label}
+          <svg
+            viewBox="0 0 20 20"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+            className={`h-3 w-3 transition-all ${
+              active
+                ? sortDir === "asc"
+                  ? "rotate-180 opacity-100"
+                  : "opacity-100"
+                : "opacity-0 group-hover:opacity-40"
+            }`}
+          >
+            <path d="M5 7.5 10 12.5 15 7.5" />
+          </svg>
+        </button>
+      </th>
+    );
+  };
 
   return (
     <div className="overflow-x-auto">
       <table className="w-full text-sm">
         <thead>
           <tr className="border-b border-foreground/10 text-left">
-            <th className="pb-2 pr-4">{headerButton("name", "会場名")}</th>
-            <th className="pb-2 pr-4">{headerButton("prefecture", "都道府県")}</th>
-            <th className="pb-2 pr-4">{headerButton("capacity", "キャパ")}</th>
-            <th className="pb-2 font-medium text-foreground/70">操作</th>
+            {sortableHeader("name", "会場名")}
+            {sortableHeader("prefecture", "都道府県")}
+            {sortableHeader("capacity", "キャパ")}
+            <th scope="col" className="pb-2 font-medium text-foreground/70">
+              操作
+            </th>
           </tr>
         </thead>
         <tbody>

--- a/apps/oshikatsu-web/components/venues/VenueTable.tsx
+++ b/apps/oshikatsu-web/components/venues/VenueTable.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import type { Venue } from "@/types/venue";
+import { PREFECTURES } from "@/lib/prefectures";
+
+type SortKey = "name" | "prefecture" | "capacity";
+type SortDir = "asc" | "desc";
+
+type VenueTableProps = {
+  venues: Venue[];
+};
+
+// 北→南の順序（PREFECTURES の並び）。海外・未設定は末尾。
+function prefectureRank(prefecture: string | null): number {
+  if (!prefecture) return PREFECTURES.length + 1;
+  const index = (PREFECTURES as readonly string[]).indexOf(prefecture);
+  return index === -1 ? PREFECTURES.length : index;
+}
+
+export function VenueTable({ venues }: VenueTableProps) {
+  // 既定は都道府県の北→南（昇順）
+  const [sortKey, setSortKey] = useState<SortKey>("prefecture");
+  const [sortDir, setSortDir] = useState<SortDir>("asc");
+
+  const sorted = useMemo(() => {
+    const factor = sortDir === "asc" ? 1 : -1;
+    return [...venues].sort((a, b) => {
+      if (sortKey === "capacity") {
+        // 未設定（null）は方向に関わらず末尾
+        if (a.capacity == null && b.capacity == null) {
+          return a.name.localeCompare(b.name, "ja");
+        }
+        if (a.capacity == null) return 1;
+        if (b.capacity == null) return -1;
+        const cmp = a.capacity - b.capacity;
+        return cmp !== 0 ? cmp * factor : a.name.localeCompare(b.name, "ja");
+      }
+      if (sortKey === "prefecture") {
+        const cmp = prefectureRank(a.prefecture) - prefectureRank(b.prefecture);
+        return cmp !== 0
+          ? cmp * factor
+          : a.name.localeCompare(b.name, "ja");
+      }
+      return a.name.localeCompare(b.name, "ja") * factor;
+    });
+  }, [venues, sortKey, sortDir]);
+
+  const handleSort = (key: SortKey) => {
+    if (key === sortKey) {
+      setSortDir((dir) => (dir === "asc" ? "desc" : "asc"));
+    } else {
+      // 別項目は最初のクリックで降順
+      setSortKey(key);
+      setSortDir("desc");
+    }
+  };
+
+  const indicator = (key: SortKey) => {
+    if (key !== sortKey) return "";
+    return sortDir === "asc" ? " ▲" : " ▼";
+  };
+
+  const headerButton = (key: SortKey, label: string) => (
+    <button
+      type="button"
+      onClick={() => handleSort(key)}
+      className="flex items-center font-medium text-foreground/70 hover:text-foreground"
+    >
+      {label}
+      <span className="text-xs">{indicator(key)}</span>
+    </button>
+  );
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-foreground/10 text-left">
+            <th className="pb-2 pr-4">{headerButton("name", "会場名")}</th>
+            <th className="pb-2 pr-4">{headerButton("prefecture", "都道府県")}</th>
+            <th className="pb-2 pr-4">{headerButton("capacity", "キャパ")}</th>
+            <th className="pb-2 font-medium text-foreground/70">操作</th>
+          </tr>
+        </thead>
+        <tbody>
+          {sorted.map((venue) => (
+            <tr key={venue.id} className="border-b border-foreground/5">
+              <td className="py-2 pr-4">
+                <Link
+                  href={`/venues/${venue.id}`}
+                  className="text-foreground hover:underline"
+                >
+                  {venue.name}
+                </Link>
+              </td>
+              <td className="py-2 pr-4 text-foreground/70">
+                {venue.prefecture ?? "—"}
+              </td>
+              <td className="py-2 pr-4 text-foreground/70">
+                {venue.capacity != null
+                  ? `${venue.capacity.toLocaleString()}人`
+                  : "—"}
+              </td>
+              <td className="py-2">
+                <Link
+                  href={`/venues/${venue.id}/edit`}
+                  className="text-sm text-blue-500 hover:underline"
+                >
+                  編集
+                </Link>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/oshikatsu-web/components/venues/VenueTable.tsx
+++ b/apps/oshikatsu-web/components/venues/VenueTable.tsx
@@ -12,9 +12,9 @@ type VenueTableProps = {
   venues: Venue[];
 };
 
-// 北→南の順序（PREFECTURES の並び）。海外・未設定は末尾。
-function prefectureRank(prefecture: string | null): number {
-  if (!prefecture) return PREFECTURES.length + 1;
+// 北→南の順序（PREFECTURES の並び）。海外は48番目（47都道府県の次）。
+// 未設定(null)は別途「常に末尾」で扱うため、ここでは非nullのみ受ける。
+function prefectureRank(prefecture: string): number {
   const index = (PREFECTURES as readonly string[]).indexOf(prefecture);
   return index === -1 ? PREFECTURES.length : index;
 }
@@ -38,10 +38,14 @@ export function VenueTable({ venues }: VenueTableProps) {
         return cmp !== 0 ? cmp * factor : a.name.localeCompare(b.name, "ja");
       }
       if (sortKey === "prefecture") {
+        // 未設定（null）は方向に関わらず末尾
+        if (!a.prefecture && !b.prefecture) {
+          return a.name.localeCompare(b.name, "ja");
+        }
+        if (!a.prefecture) return 1;
+        if (!b.prefecture) return -1;
         const cmp = prefectureRank(a.prefecture) - prefectureRank(b.prefecture);
-        return cmp !== 0
-          ? cmp * factor
-          : a.name.localeCompare(b.name, "ja");
+        return cmp !== 0 ? cmp * factor : a.name.localeCompare(b.name, "ja");
       }
       return a.name.localeCompare(b.name, "ja") * factor;
     });


### PR DESCRIPTION
## 概要

会場一覧（`/venues`）の並びを都道府県の北→南を既定にし、列ヘッダのクリックでソートできるようにします。

## 変更内容

- 一覧テーブルをクライアントコンポーネント `components/venues/VenueTable.tsx` に切り出し
- **既定の並び順**: 都道府県の北→南（`lib/prefectures.ts` の並び順。海外は48番目の都道府県としてソートに含み、未設定は末尾）
- **ヘッダクリックでソート**: 会場名 / 都道府県 / キャパ の各ヘッダを押すと、その項目で**降順**に並び替え。**同じヘッダを再度押すと昇順⇄降順をトグル**
- ソート方向の表示（▲/▼）を現在のキーに付与
- キャパ未設定（null）は方向に関わらず末尾、同値は会場名で安定ソート

## 受け入れ条件

- [x] 既定が都道府県の北→南
- [x] 3列（会場名/都道府県/キャパ）クリックで降順ソート
- [x] 再クリックで昇順/降順トグル
- [x] `pnpm --filter oshikatsu-web typecheck` / `lint` / `build` 通過

## 確認方法

> migration 追加なし。

1. `/venues` の初期表示が都道府県の北→南
2. 「キャパ」ヘッダ → 降順（大きい順）、再クリックで昇順
3. 「会場名」「都道府県」も同様にトグル
4. キャパ未設定の会場は常に末尾

🤖 Generated with [Claude Code](https://claude.com/claude-code)
