### PR TITLE
ツアー見出しの「○○公演」から都/府/県を除去（北海道は維持）

### DIFF
--- a/apps/oshikatsu-web/components/lives/LiveDetail.tsx
+++ b/apps/oshikatsu-web/components/lives/LiveDetail.tsx
@@ -74,6 +74,11 @@ function groupByVenue(performances: LivePerformance[]): VenueGroup[] {
   return groups;
 }
 
+// ツアー見出し用に都/府/県を除いた表記にする（北海道はそのまま、海外名はそのまま）
+function performanceAreaLabel(prefecture: string): string {
+  return `${prefecture.replace(/[都府県]$/, "")}公演`;
+}
+
 function setlistItemLabel(item: SetlistItem): string {
   if (item.itemType === "song") {
     return item.trackTitle ?? item.songTitle ?? "（曲名未設定）";
@@ -140,7 +145,7 @@ export function LiveDetail({ live }: LiveDetailProps) {
                   >
                     <p className="font-medium text-foreground">
                       {group.venuePrefecture
-                        ? `${group.venuePrefecture}公演`
+                        ? performanceAreaLabel(group.venuePrefecture)
                         : "公演"}
                     </p>
                     {group.venueId && group.venueName ? (


### PR DESCRIPTION
## 概要

ツアーのライブ詳細・上部「会場・日程」カードの見出し `○○公演` から、都/府/県を除いた表記にします。

- 広島県 → **広島公演**
- 大阪府 → **大阪公演**
- 東京都 → **東京公演**
- 北海道 → **北海道公演**（「道」はそのまま維持）
- 海外（例: 台湾）→ **台湾公演**（そのまま）

## 変更内容
- `components/lives/LiveDetail.tsx` に `performanceAreaLabel()` を追加し、`prefecture.replace(/[都府県]$/, "")` で末尾の都/府/県のみ除去
- ツアーの会場カード見出しに適用

## 受け入れ条件
- [x] 都/府/県 が除去され、北海道はそのまま
- [x] 海外名はそのまま
- [x] `pnpm --filter oshikatsu-web typecheck` / `lint` 通過

## 確認方法
> migration 追加なし。

1. ツアーのライブ詳細上部カードが「広島公演」「大阪公演」「北海道公演」表記になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)
