### PR TITLE
リリースのナンバリング表記を修正（21st / 21st Single）

### DIFF
--- a/apps/oshikatsu-web/components/releases/ReleaseCard.tsx
+++ b/apps/oshikatsu-web/components/releases/ReleaseCard.tsx
@@ -1,7 +1,7 @@
 import { PendingLink } from "@/components/ui/PendingLink";
 import { GroupBadge } from "@/components/ui/GroupBadge";
 import type { ReleaseListItem } from "@/types/release";
-import { RELEASE_TYPE_LABELS } from "@/types/release";
+import { formatReleaseTypeLabel } from "@/types/release";
 import { formatDate } from "@/lib/formatters";
 import { APP_ROUTES } from "@/lib/routes";
 
@@ -11,10 +11,7 @@ type ReleaseCardProps = {
 };
 
 export function ReleaseCard({ release, showGroupName = true }: ReleaseCardProps) {
-  const metaParts = [
-    RELEASE_TYPE_LABELS[release.releaseType],
-    ...(release.numbering ? [String(release.numbering)] : []),
-  ];
+  const typeLabel = formatReleaseTypeLabel(release.releaseType, release.numbering);
 
   return (
     <PendingLink
@@ -30,7 +27,7 @@ export function ReleaseCard({ release, showGroupName = true }: ReleaseCardProps)
             groupColor={release.groupColor}
           />
         )}
-        <span className="text-xs text-foreground/50">{metaParts.join(" / ")}</span>
+        <span className="text-xs text-foreground/50">{typeLabel}</span>
       </div>
       <p className="mt-1 text-xs text-foreground/50">曲目: {release.trackCount}曲</p>
       {release.releaseDate && (

--- a/apps/oshikatsu-web/components/releases/ReleaseDetail.tsx
+++ b/apps/oshikatsu-web/components/releases/ReleaseDetail.tsx
@@ -1,7 +1,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import type { Release } from "@/types/release";
-import { RELEASE_TYPE_LABELS } from "@/types/release";
+import { RELEASE_TYPE_LABELS, ordinalNumber } from "@/types/release";
 import { GroupBadge } from "@/components/ui/GroupBadge";
 import { Card } from "@/components/ui/Card";
 import { formatDate } from "@/lib/formatters";
@@ -34,7 +34,7 @@ export function ReleaseDetail({ release }: ReleaseDetailProps) {
           </span>
           {release.numbering && (
             <span className="rounded-full border border-foreground/10 px-2 py-0.5 text-xs text-foreground/70">
-              No.{release.numbering}
+              {ordinalNumber(release.numbering)}
             </span>
           )}
         </div>

--- a/apps/oshikatsu-web/types/release.ts
+++ b/apps/oshikatsu-web/types/release.ts
@@ -16,6 +16,38 @@ export const RELEASE_TYPE_LABELS: Record<ReleaseType, string> = {
   other: "その他",
 };
 
+export const RELEASE_TYPE_LABELS_EN: Record<ReleaseType, string> = {
+  single: "Single",
+  album: "Album",
+  digital_single: "Digital Single",
+  other: "Other",
+};
+
+// 21 -> "21st", 5 -> "5th"
+export function ordinalNumber(value: number): string {
+  const mod100 = value % 100;
+  if (mod100 >= 11 && mod100 <= 13) return `${value}th`;
+  switch (value % 10) {
+    case 1:
+      return `${value}st`;
+    case 2:
+      return `${value}nd`;
+    case 3:
+      return `${value}rd`;
+    default:
+      return `${value}th`;
+  }
+}
+
+// 一覧用のリリース表記（例: "21st Single" / "5th Album" / "Digital Single"）
+export function formatReleaseTypeLabel(
+  releaseType: ReleaseType,
+  numbering: number | null
+): string {
+  const typeLabel = RELEASE_TYPE_LABELS_EN[releaseType];
+  return numbering ? `${ordinalNumber(numbering)} ${typeLabel}` : typeLabel;
+}
+
 export type ReleaseBonusVideo = {
   id: string;
   edition: string;


### PR DESCRIPTION
## 概要

リリースのナンバリング表示を修正します。

- **個別画面（リリース詳細）**: `No.21` → **`21st`**（序数表記）
- **一覧画面（リリースカード）**: タイプと合わせて **`21st Single` / `5th Album`**（英語タイプ＋序数）。ナンバリングが無いタイプ（配信シングル/その他）は `Digital Single` / `Other`

## 変更内容
- `types/release.ts`: `RELEASE_TYPE_LABELS_EN`、`ordinalNumber()`（21→21st, 11/12/13→th 対応）、`formatReleaseTypeLabel()` を追加
- `ReleaseDetail`: ナンバリングのバッジを `ordinalNumber` 表記に
- `ReleaseCard`: タイプ表記を `formatReleaseTypeLabel` に統一

## 受け入れ条件
- [x] 詳細: 21st 表記
- [x] 一覧: "21st Single" / "5th Album"
- [x] `pnpm --filter oshikatsu-web typecheck` / `lint` / `build` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)
