### PR TITLE
ライブ個別画面の日程表示を「6/13(土)」形式に

### DIFF
--- a/apps/oshikatsu-web/components/lives/LiveDetail.tsx
+++ b/apps/oshikatsu-web/components/lives/LiveDetail.tsx
@@ -6,7 +6,7 @@ import {
   SETLIST_ITEM_TYPE_LABELS,
 } from "@/types/live";
 import { GroupBadge } from "@/components/ui/GroupBadge";
-import { formatDate } from "@/lib/formatters";
+import { formatMonthDayWithWeekday } from "@/lib/formatters";
 
 type LiveDetailProps = {
   live: Live;
@@ -35,7 +35,7 @@ function formatScheduleLine(
   performance: LivePerformance
 ): string {
   const date = performance.performanceDate
-    ? formatDate(performance.performanceDate)
+    ? formatMonthDayWithWeekday(performance.performanceDate)
     : "日付未定";
   const time = formatScheduleTime(
     liveType,
@@ -207,7 +207,7 @@ export function LiveDetail({ live }: LiveDetailProps) {
                 <div className="flex flex-wrap items-center gap-2 text-sm">
                   <span className="font-medium text-foreground">
                     {performance.performanceDate
-                      ? formatDate(performance.performanceDate)
+                      ? formatMonthDayWithWeekday(performance.performanceDate)
                       : "日付未定"}
                   </span>
                   <VenueLink performance={performance} />

--- a/apps/oshikatsu-web/lib/formatters.ts
+++ b/apps/oshikatsu-web/lib/formatters.ts
@@ -7,6 +7,15 @@ export function formatMonthLabel(year: number, month: number): string {
   return `${year}年${month}月`;
 }
 
+const WEEKDAY_LABELS = ["日", "月", "火", "水", "木", "金", "土"] as const;
+
+// 6/13(土) のように月/日(曜日)で表示する
+export function formatMonthDayWithWeekday(dateStr: string): string {
+  const date = new Date(dateStr + "T00:00:00");
+  const weekday = WEEKDAY_LABELS[date.getDay()];
+  return `${date.getMonth() + 1}/${date.getDate()}(${weekday})`;
+}
+
 export function formatBirthday(dateStr: string): string {
   const date = new Date(dateStr + "T00:00:00");
   return `${date.getFullYear()}年${date.getMonth() + 1}月${date.getDate()}日`;


### PR DESCRIPTION
## 概要

ライブ個別画面（詳細）の日程表示を **月/日(曜日)**（例: `6/13(土)`）に変更します。一覧画面は従来どおりです。

## 変更内容
- `lib/formatters.ts` に `formatMonthDayWithWeekday()` を追加（`6/13(土)` 形式）
- `LiveDetail` の公演日表示（上部「会場・日程」と下部の公演カード見出し）をこの形式に
- 一覧（`LiveCard`）は従来の `formatDate`（`2026/06/13`）のまま

## 受け入れ条件
- [x] 個別画面の公演日が `6/13(土)` 表記
- [x] 一覧は従来表記のまま
- [x] `pnpm --filter oshikatsu-web typecheck` / `lint` / `build` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)
