### PR TITLE
カレンダーにライブ公演・リリース日を統合（読み取り集約）

### DIFF
--- a/apps/oshikatsu-web/components/events/EventCalendar.tsx
+++ b/apps/oshikatsu-web/components/events/EventCalendar.tsx
@@ -1,8 +1,21 @@
 import Link from "next/link";
 import type { CalendarEvent } from "@/types/event";
 import { generateCalendarGrid } from "@/lib/calendarUtils";
-import { BIRTHDAY_COLOR } from "@/lib/constants";
+import { BIRTHDAY_COLOR, LIVE_COLOR, RELEASE_COLOR } from "@/lib/constants";
 import { getTodayInAppTimeZone } from "@/lib/dateParams";
+
+function calendarEventColor(event: CalendarEvent): string {
+  switch (event.type) {
+    case "birthday":
+      return BIRTHDAY_COLOR;
+    case "live":
+      return LIVE_COLOR;
+    case "release":
+      return RELEASE_COLOR;
+    default:
+      return event.eventTypeColor;
+  }
+}
 
 type EventCalendarProps = {
   events: CalendarEvent[];
@@ -84,12 +97,7 @@ export function EventCalendar({
                     <span
                       key={i}
                       className="h-1 w-1 rounded-full"
-                      style={{
-                        backgroundColor:
-                          e.type === "birthday"
-                            ? BIRTHDAY_COLOR
-                            : e.eventTypeColor,
-                      }}
+                      style={{ backgroundColor: calendarEventColor(e) }}
                     />
                   ))}
                 </div>

--- a/apps/oshikatsu-web/components/events/EventList.tsx
+++ b/apps/oshikatsu-web/components/events/EventList.tsx
@@ -2,7 +2,19 @@ import Link from "next/link";
 import type { CalendarEvent } from "@/types/event";
 import { Badge } from "@/components/ui/Badge";
 import { formatTime } from "@/lib/formatters";
-import { BIRTHDAY_COLOR } from "@/lib/constants";
+import { BIRTHDAY_COLOR, LIVE_COLOR, RELEASE_COLOR } from "@/lib/constants";
+
+function eventKey(event: CalendarEvent): string {
+  switch (event.type) {
+    case "birthday":
+      return `birthday-${event.memberId}-${event.date}`;
+    case "live":
+    case "release":
+      return `${event.type}-${event.id}`;
+    default:
+      return `event-${event.id}`;
+  }
+}
 
 type EventListProps = {
   events: CalendarEvent[];
@@ -24,8 +36,28 @@ export function EventList({
       ) : (
         <div className="space-y-2">
           {events.map((event) => (
-            <div key={event.type === "birthday" ? `birthday-${event.memberId}-${event.date}` : `event-${event.id}`} className="flex items-start gap-2 text-sm">
-              {event.type === "birthday" ? (
+            <div key={eventKey(event)} className="flex items-start gap-2 text-sm">
+              {event.type === "live" ? (
+                <>
+                  <Badge label="ライブ" color={LIVE_COLOR} />
+                  <Link
+                    href={`/lives/${event.liveId}`}
+                    className="text-foreground hover:underline"
+                  >
+                    {event.name}
+                  </Link>
+                </>
+              ) : event.type === "release" ? (
+                <>
+                  <Badge label="リリース" color={RELEASE_COLOR} />
+                  <Link
+                    href={`/releases/${event.releaseId}`}
+                    className="text-foreground hover:underline"
+                  >
+                    {event.title}
+                  </Link>
+                </>
+              ) : event.type === "birthday" ? (
                 <>
                   <Badge label="誕生日" color={BIRTHDAY_COLOR} />
                   <div>

--- a/apps/oshikatsu-web/components/events/OnThisDay.tsx
+++ b/apps/oshikatsu-web/components/events/OnThisDay.tsx
@@ -1,8 +1,10 @@
-import type { Event } from "@/types/event";
+import Link from "next/link";
+import type { OnThisDayItem } from "@/types/event";
 import { Badge } from "@/components/ui/Badge";
+import { LIVE_COLOR, RELEASE_COLOR } from "@/lib/constants";
 
 type OnThisDayProps = {
-  events: Event[];
+  events: OnThisDayItem[];
   selectedDate: Date;
   title?: string;
   emptyMessage?: string;
@@ -18,9 +20,7 @@ export function OnThisDay({
 
   return (
     <div className="rounded-lg border border-foreground/10 bg-background p-4">
-      <h2 className="mb-3 text-sm font-medium text-foreground/70">
-        {title}
-      </h2>
+      <h2 className="mb-3 text-sm font-medium text-foreground/70">{title}</h2>
 
       {events.length === 0 ? (
         <p className="text-sm text-foreground/40">{emptyMessage}</p>
@@ -31,20 +31,47 @@ export function OnThisDay({
             const yearsAgo = currentYear - eventYear;
 
             return (
-              <div key={event.id} className="flex items-start gap-2 text-sm">
+              <div
+                key={`${event.type}-${event.id}`}
+                className="flex items-start gap-2 text-sm"
+              >
                 <span className="shrink-0 text-xs font-medium text-foreground/50">
                   {yearsAgo}年前
                 </span>
-                <Badge
-                  label={event.eventTypeName}
-                  color={event.eventTypeColor}
-                />
-                <div>
-                  <span className="text-foreground">{event.title}</span>
-                  <span className="ml-1 text-xs text-foreground/40">
-                    {event.groupNames.join(", ")}
-                  </span>
-                </div>
+                {event.type === "live" ? (
+                  <>
+                    <Badge label="ライブ" color={LIVE_COLOR} />
+                    <Link
+                      href={`/lives/${event.liveId}`}
+                      className="text-foreground hover:underline"
+                    >
+                      {event.name}
+                    </Link>
+                  </>
+                ) : event.type === "release" ? (
+                  <>
+                    <Badge label="リリース" color={RELEASE_COLOR} />
+                    <Link
+                      href={`/releases/${event.releaseId}`}
+                      className="text-foreground hover:underline"
+                    >
+                      {event.title}
+                    </Link>
+                  </>
+                ) : (
+                  <>
+                    <Badge
+                      label={event.eventTypeName}
+                      color={event.eventTypeColor}
+                    />
+                    <div>
+                      <span className="text-foreground">{event.title}</span>
+                      <span className="ml-1 text-xs text-foreground/40">
+                        {event.groupNames.join(", ")}
+                      </span>
+                    </div>
+                  </>
+                )}
               </div>
             );
           })}

--- a/apps/oshikatsu-web/lib/constants.ts
+++ b/apps/oshikatsu-web/lib/constants.ts
@@ -2,6 +2,8 @@ export const BLOOD_TYPES = ["A", "B", "O", "AB", "不明"] as const;
 export type BloodType = (typeof BLOOD_TYPES)[number];
 
 export const BIRTHDAY_COLOR = "#D946EF";
+export const LIVE_COLOR = "#F97316";
+export const RELEASE_COLOR = "#3B82F6";
 
 export const SNS_TYPES = [
   { value: "x", label: "X" },

--- a/apps/oshikatsu-web/repositories/liveRepository.ts
+++ b/apps/oshikatsu-web/repositories/liveRepository.ts
@@ -287,6 +287,29 @@ export function createLiveRepository(supabase: SupabaseClient): LiveRepository {
       });
     },
 
+    async findCalendarPerformances() {
+      const { data, error } = await supabase
+        .from("orbit_live_performances")
+        .select("performance_date, live_id, orbit_lives(name)")
+        .not("performance_date", "is", null);
+
+      if (error) {
+        throw new RepositoryError("カレンダー用ライブの取得に失敗しました", error);
+      }
+
+      type Row = {
+        performance_date: string;
+        live_id: string;
+        orbit_lives: { name: string } | { name: string }[] | null;
+      };
+
+      return ((data as unknown as Row[]) ?? []).map((row) => ({
+        liveId: row.live_id,
+        liveName: pickFirst(row.orbit_lives)?.name ?? "",
+        date: row.performance_date,
+      }));
+    },
+
     async findOptions() {
       const { data, error } = await supabase
         .from("orbit_lives")

--- a/apps/oshikatsu-web/repositories/releaseRepository.ts
+++ b/apps/oshikatsu-web/repositories/releaseRepository.ts
@@ -344,6 +344,25 @@ export function createReleaseRepository(
       return ((data as ReleaseOptionRow[] | null) ?? []).map(mapToReleaseOption);
     },
 
+    async findCalendarItems() {
+      const { data, error } = await supabase
+        .from("orbit_releases")
+        .select("id, title, release_date")
+        .not("release_date", "is", null);
+
+      if (error) {
+        throw new RepositoryError("カレンダー用リリースの取得に失敗しました", error);
+      }
+
+      type Row = { id: string; title: string; release_date: string };
+
+      return ((data as Row[] | null) ?? []).map((row) => ({
+        releaseId: row.id,
+        title: row.title,
+        date: row.release_date,
+      }));
+    },
+
     async findById(id) {
       const { data, error } = await supabase
         .from("orbit_releases")

--- a/apps/oshikatsu-web/types/event.ts
+++ b/apps/oshikatsu-web/types/event.ts
@@ -41,6 +41,30 @@ export type BirthdayEvent = {
   groupNames: string[];
 };
 
+export type LiveCalendarEvent = {
+  type: "live";
+  id: string;
+  liveId: string;
+  name: string;
+  date: string;
+};
+
+export type ReleaseCalendarEvent = {
+  type: "release";
+  id: string;
+  releaseId: string;
+  title: string;
+  date: string;
+};
+
 export type CalendarEvent =
   | (Event & { type: "event" })
-  | BirthdayEvent;
+  | BirthdayEvent
+  | LiveCalendarEvent
+  | ReleaseCalendarEvent;
+
+// 「今日はなんの日」用（過去の出来事。誕生日は含めない）
+export type OnThisDayItem =
+  | (Event & { type: "event" })
+  | LiveCalendarEvent
+  | ReleaseCalendarEvent;

--- a/apps/oshikatsu-web/types/repositories.ts
+++ b/apps/oshikatsu-web/types/repositories.ts
@@ -99,8 +99,21 @@ export type VenueRepository = {
   delete(id: string): Promise<void>;
 };
 
+export type LiveCalendarPerformance = {
+  liveId: string;
+  liveName: string;
+  date: string;
+};
+
+export type ReleaseCalendarItem = {
+  releaseId: string;
+  title: string;
+  date: string;
+};
+
 export type LiveRepository = {
   findPublicList(): Promise<LiveListItem[]>;
+  findCalendarPerformances(): Promise<LiveCalendarPerformance[]>;
   findOptions(): Promise<LiveOption[]>;
   findById(id: string): Promise<Live | null>;
   findPerformancesByVenue(venueId: string): Promise<VenuePerformanceSummary[]>;
@@ -112,6 +125,7 @@ export type LiveRepository = {
 export type ReleaseRepository = {
   findAll(filters?: ReleaseFilters): Promise<Release[]>;
   findPublicList(filters?: ReleaseFilters): Promise<ReleaseListItem[]>;
+  findCalendarItems(): Promise<ReleaseCalendarItem[]>;
   findOptions(): Promise<ReleaseOption[]>;
   findById(id: string): Promise<Release | null>;
   create(input: CreateReleaseInput): Promise<Release>;

--- a/apps/oshikatsu-web/usecases/getTopPageContent.ts
+++ b/apps/oshikatsu-web/usecases/getTopPageContent.ts
@@ -1,5 +1,15 @@
-import type { CalendarEvent, Event } from "@/types/event";
-import type { EventRepository, MemberRepository } from "@/types/repositories";
+import type {
+  CalendarEvent,
+  LiveCalendarEvent,
+  OnThisDayItem,
+  ReleaseCalendarEvent,
+} from "@/types/event";
+import type {
+  EventRepository,
+  LiveRepository,
+  MemberRepository,
+  ReleaseRepository,
+} from "@/types/repositories";
 import { getEventsForDate } from "@/usecases/getEventsForDate";
 import { getEventsForMonth } from "@/usecases/getEventsForMonth";
 import { getOnThisDay } from "@/usecases/getOnThisDay";
@@ -7,23 +17,99 @@ import { getOnThisDay } from "@/usecases/getOnThisDay";
 export type TopPageContent = {
   monthEvents: CalendarEvent[];
   selectedDateEvents: CalendarEvent[];
-  onThisDayEvents: Event[];
+  onThisDayEvents: OnThisDayItem[];
 };
+
+function pad(value: number): string {
+  return String(value).padStart(2, "0");
+}
 
 export async function getTopPageContent(
   eventRepo: EventRepository,
   memberRepo: MemberRepository,
+  liveRepo: LiveRepository,
+  releaseRepo: ReleaseRepository,
   year: number,
   month: number,
   day: number
 ): Promise<TopPageContent> {
   const selectedDate = new Date(year, month - 1, day);
 
-  const [monthEvents, selectedDateEvents, onThisDayEvents] = await Promise.all([
+  const [
+    monthEvents,
+    selectedDateEvents,
+    onThisDayBaseEvents,
+    livePerformances,
+    releaseItems,
+  ] = await Promise.all([
     getEventsForMonth(eventRepo, memberRepo, year, month),
     getEventsForDate(eventRepo, memberRepo, selectedDate),
     getOnThisDay(eventRepo, selectedDate),
+    liveRepo.findCalendarPerformances(),
+    releaseRepo.findCalendarItems(),
   ]);
+
+  const monthPrefix = `${year}-${pad(month)}`;
+  const dateStr = `${year}-${pad(month)}-${pad(day)}`;
+  const monthDaySuffix = `-${pad(month)}-${pad(day)}`;
+
+  const toLiveEvent = (p: {
+    liveId: string;
+    liveName: string;
+    date: string;
+  }): LiveCalendarEvent => ({
+    type: "live",
+    id: `${p.liveId}:${p.date}`,
+    liveId: p.liveId,
+    name: p.liveName,
+    date: p.date,
+  });
+
+  const toReleaseEvent = (r: {
+    releaseId: string;
+    title: string;
+    date: string;
+  }): ReleaseCalendarEvent => ({
+    type: "release",
+    id: r.releaseId,
+    releaseId: r.releaseId,
+    title: r.title,
+    date: r.date,
+  });
+
+  // 月のカレンダー
+  for (const p of livePerformances) {
+    if (p.date.startsWith(monthPrefix)) monthEvents.push(toLiveEvent(p));
+  }
+  for (const r of releaseItems) {
+    if (r.date.startsWith(monthPrefix)) monthEvents.push(toReleaseEvent(r));
+  }
+  monthEvents.sort((a, b) => a.date.localeCompare(b.date));
+
+  // 選択日
+  for (const p of livePerformances) {
+    if (p.date === dateStr) selectedDateEvents.push(toLiveEvent(p));
+  }
+  for (const r of releaseItems) {
+    if (r.date === dateStr) selectedDateEvents.push(toReleaseEvent(r));
+  }
+
+  // 今日はなんの日（過去・同じ月日）
+  const onThisDayEvents: OnThisDayItem[] = onThisDayBaseEvents.map((e) => ({
+    ...e,
+    type: "event" as const,
+  }));
+  for (const p of livePerformances) {
+    if (p.date.endsWith(monthDaySuffix) && p.date < dateStr) {
+      onThisDayEvents.push(toLiveEvent(p));
+    }
+  }
+  for (const r of releaseItems) {
+    if (r.date.endsWith(monthDaySuffix) && r.date < dateStr) {
+      onThisDayEvents.push(toReleaseEvent(r));
+    }
+  }
+  onThisDayEvents.sort((a, b) => b.date.localeCompare(a.date));
 
   return {
     monthEvents,

--- a/apps/oshikatsu-web/usecases/getTopPageContent.ts
+++ b/apps/oshikatsu-web/usecases/getTopPageContent.ts
@@ -49,6 +49,13 @@ export async function getTopPageContent(
     releaseRepo.findCalendarItems(),
   ]);
 
+  // 同一ライブ・同一日（昼夜公演など）はカレンダー上で1件に集約する
+  const uniqueLivePerformances = Array.from(
+    new Map(
+      livePerformances.map((p) => [`${p.liveId}:${p.date}`, p])
+    ).values()
+  );
+
   const monthPrefix = `${year}-${pad(month)}`;
   const dateStr = `${year}-${pad(month)}-${pad(day)}`;
   const monthDaySuffix = `-${pad(month)}-${pad(day)}`;
@@ -78,7 +85,7 @@ export async function getTopPageContent(
   });
 
   // 月のカレンダー
-  for (const p of livePerformances) {
+  for (const p of uniqueLivePerformances) {
     if (p.date.startsWith(monthPrefix)) monthEvents.push(toLiveEvent(p));
   }
   for (const r of releaseItems) {
@@ -87,7 +94,7 @@ export async function getTopPageContent(
   monthEvents.sort((a, b) => a.date.localeCompare(b.date));
 
   // 選択日
-  for (const p of livePerformances) {
+  for (const p of uniqueLivePerformances) {
     if (p.date === dateStr) selectedDateEvents.push(toLiveEvent(p));
   }
   for (const r of releaseItems) {
@@ -99,7 +106,7 @@ export async function getTopPageContent(
     ...e,
     type: "event" as const,
   }));
-  for (const p of livePerformances) {
+  for (const p of uniqueLivePerformances) {
     if (p.date.endsWith(monthDaySuffix) && p.date < dateStr) {
       onThisDayEvents.push(toLiveEvent(p));
     }

--- a/apps/oshikatsu-web/usecases/readOrbitData.ts
+++ b/apps/oshikatsu-web/usecases/readOrbitData.ts
@@ -61,12 +61,14 @@ function createSharedReadLoader<TArgs extends unknown[], TResult>(
 
 const loadTopPageData = createSharedReadLoader(
   ["orbit", "top-page-data"],
-  [ORBIT_CACHE_TAGS.top],
+  [ORBIT_CACHE_TAGS.top, ORBIT_CACHE_TAGS.lives, ORBIT_CACHE_TAGS.releases],
   async (year: number, month: number, day: number) =>
     withOrbitReadClient(async (supabase) => {
       return getTopPageContent(
         createEventRepository(supabase),
         createMemberRepository(supabase),
+        createLiveRepository(supabase),
+        createReleaseRepository(supabase),
         year,
         month,
         day

--- a/docs/orbit-roadmap.md
+++ b/docs/orbit-roadmap.md
@@ -214,6 +214,12 @@
 - [x] メンバー一覧に期（世代）絞り込みを追加（Issue #96）
   - [x] グループ選択時のみ表示。選択肢は `Group.maxGeneration`（無ければ実在世代から導出）。グループスコープで絞り込み、グループ変更時はリセット。URL `generation` を同期
 
+### カレンダーにライブ公演・リリース日を統合
+
+- [x] トップのカレンダー/当日イベント/今日はなんの日に、ライブ公演日とリリース日を表示（読み取り側で集約、データ二重化なし）
+  - [x] `liveRepository.findCalendarPerformances` / `releaseRepository.findCalendarItems` を追加し `getTopPageContent` で月/当日/OnThisDay にマージ
+  - [x] 種別ごとに色ドット（ライブ/リリース）＋一覧・OnThisDay にバッジとリンク表示。top キャッシュを lives/releases タグに連動
+
 ### リリース/ライブ一覧の表示見直し
 
 - [x] リリース一覧: グループ別セクションを廃止し、リリース日降順のフラット表示＋グループ色バッジに変更（グループ＋リリースタイプ絞り込みは維持、日付未定は末尾）


### PR DESCRIPTION
## 概要

トップのカレンダー・当日イベント・「今日はなんの日」に、**ライブ公演日**と**リリース日**を表示します。データは**読み取り側で集約**し、`orbit_events` への複製はしません（編集すれば自動反映、同期ズレなし）。

## 変更内容

### データ取得（読み取り集約）
- `liveRepository.findCalendarPerformances()`（公演日＋ライブ名/ID）、`releaseRepository.findCalendarItems()`（リリース日＋タイトル/ID）を追加
- `getTopPageContent` で、月カレンダー / 当日イベント / 今日はなんの日（過去・同じ月日）にマージ
- `loadTopPageData` のキャッシュタグに `lives` / `releases` を追加 → ライブ/リリース更新でカレンダーも自動失効

### 表示
- 種別ごとの**色ドット**（ライブ=橙、リリース=青、誕生日・イベントは従来色）を `EventCalendar` に追加
- `EventList`（当日）・`OnThisDay` に **ライブ/リリースのバッジ＋詳細リンク**を表示
- 型 `LiveCalendarEvent` / `ReleaseCalendarEvent` / `OnThisDayItem` を追加

## 受け入れ条件
- [x] カレンダーにライブ公演日・リリース日が色ドットで表示
- [x] 当日イベントにライブ/リリースが表示（詳細へリンク）
- [x] 今日はなんの日に過去のライブ/リリース（同月日）が表示
- [x] ライブ/リリース編集でカレンダーに反映（cache tag 連動）
- [x] `pnpm --filter oshikatsu-web typecheck` / `lint` / `build` 通過

## 確認方法
> migration 追加なし。

1. ライブ公演・リリースを登録 → トップのカレンダー該当日に色ドット
2. その日を選ぶと当日イベントにライブ/リリースが出てリンクで遷移
3. 過去の同月日に公演/リリースがあれば「今日はなんの日」に「N年前」で表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)
