### PR TITLE
トップ: ナビ幅調整・バッジ崩れ修正・管理を最下部に

### DIFF
--- a/apps/oshikatsu-web/app/(authenticated)/page.tsx
+++ b/apps/oshikatsu-web/app/(authenticated)/page.tsx
@@ -38,7 +38,7 @@ export default async function TopPage({ searchParams }: TopPageProps) {
     await getTopPageData(year, month, day);
 
   return (
-    <div className="grid gap-6 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
+    <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_13rem]">
       <div className="space-y-6">
         <div className="flex items-center">
           <Suspense fallback={<div className="h-10" />}>

--- a/apps/oshikatsu-web/components/ui/Badge.tsx
+++ b/apps/oshikatsu-web/components/ui/Badge.tsx
@@ -7,7 +7,7 @@ type BadgeProps = {
 export function Badge({ label, color, className = "" }: BadgeProps) {
   return (
     <span
-      className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${className}`}
+      className={`inline-flex shrink-0 items-center whitespace-nowrap rounded-full px-2.5 py-0.5 text-xs font-medium ${className}`}
       style={
         color
           ? { backgroundColor: `${color}20`, color }

--- a/apps/oshikatsu-web/lib/navigation.ts
+++ b/apps/oshikatsu-web/lib/navigation.ts
@@ -5,18 +5,29 @@ export type AppNavigationItem = {
   label: string;
 };
 
-export const HEADER_NAV_ITEMS: AppNavigationItem[] = [
+const ADMIN_NAV_ITEM: AppNavigationItem = {
+  href: APP_ROUTES.admin,
+  label: "管理",
+};
+
+// 管理を除いた閲覧系ナビ（管理は常に末尾に置く）
+const CONTENT_NAV_ITEMS: AppNavigationItem[] = [
   { href: APP_ROUTES.members, label: "メンバー" },
   { href: APP_ROUTES.songs, label: "楽曲" },
   { href: APP_ROUTES.releases, label: "リリース" },
   { href: APP_ROUTES.lives, label: "ライブ" },
-  { href: APP_ROUTES.admin, label: "管理" },
+];
+
+export const HEADER_NAV_ITEMS: AppNavigationItem[] = [
+  ...CONTENT_NAV_ITEMS,
+  ADMIN_NAV_ITEM,
 ];
 
 export const TOP_NAV_ITEMS: AppNavigationItem[] = [
-  ...HEADER_NAV_ITEMS,
+  ...CONTENT_NAV_ITEMS,
   { href: APP_ROUTES.people, label: "制作陣" },
   { href: APP_ROUTES.venues, label: "会場" },
+  ADMIN_NAV_ITEM,
 ];
 
 export function isNavigationItemActive(pathname: string, href: string): boolean {


### PR DESCRIPTION
## 概要

トップページのナビ幅とバッジ表示崩れを修正し、ナビの「管理」を常に最下部にします。

## 変更内容
- **バッジ崩れ修正**: `Badge` を `shrink-0` / `whitespace-nowrap` に。長いライブ名（例: 乃木坂46 14th YEAR BIRTHDAY LIVE）で「ライブ」バッジが2行に折り返して崩れる問題を解消（当日イベント・今日はなんの日など全バッジに有効）
- **ナビ幅調整**: トップの右ナビ列を `minmax(0,1fr)` から **固定幅 `13rem`** に変更し、カレンダー側を広く
- **管理を最下部に**: `navigation.ts` を整理し、`管理` を常に末尾へ（Top ナビ＝メンバー/楽曲/リリース/ライブ/制作陣/会場/**管理**、ヘッダも 管理 を末尾）

## 受け入れ条件
- [x] 長いライブ名でもバッジが崩れない
- [x] 右ナビが狭くなりカレンダーが広がる
- [x] ナビの管理が最下部
- [x] `pnpm --filter oshikatsu-web typecheck` / `lint` / `build` 通過

## 確認方法
1. トップで長い名前のライブがある日を選び、当日イベントの「ライブ」バッジが1行で崩れない
2. 右ナビが狭くなっている
3. 右ナビ・ヘッダとも「管理」が最後

🤖 Generated with [Claude Code](https://claude.com/claude-code)
