### PR TITLE
リリース更新: 孤立する楽曲が出る場合のエラー文言を改善

### DIFF
--- a/apps/oshikatsu-web/app/(authenticated)/admin/releases/[id]/edit/actions.ts
+++ b/apps/oshikatsu-web/app/(authenticated)/admin/releases/[id]/edit/actions.ts
@@ -13,6 +13,17 @@ import type { UpdateReleaseInput, ReleaseImageUploadInput } from "@/types/releas
 import type { ValidationError } from "@/types/errors";
 import { RepositoryError } from "@/types/errors";
 
+// 「楽曲は必ず1リリースに紐づく」制約違反（紐づけ解除で孤立する楽曲が出る更新）かを判定する
+function isOrphanTrackError(error: RepositoryError): boolean {
+  const cause = error.cause as { code?: string; message?: string } | null;
+  const message = cause?.message ?? "";
+  return (
+    cause?.code === "23514" &&
+    (message.includes("track must be linked to at least one release") ||
+      message.includes("track must have at least one release link"))
+  );
+}
+
 async function cleanupReleaseImages(
   releaseImageRepo: ReturnType<typeof createReleaseImageRepository>,
   imagePaths: Array<string | null | undefined>
@@ -73,6 +84,17 @@ export async function updateReleaseAction(
   } catch (e) {
     await cleanupReleaseImages(releaseImageRepo, [uploadedImagePath]);
     if (e instanceof RepositoryError) {
+      if (isOrphanTrackError(e)) {
+        return {
+          errors: [
+            {
+              field: "_form",
+              message:
+                "この変更では、どのリリースにも紐づかなくなる楽曲があります。対象の楽曲は紐づけを残すか、先に別のリリースへ移してから更新してください。",
+            },
+          ],
+        };
+      }
       return {
         errors: [{ field: "_form", message: "リリースが見つからないか、更新に失敗しました" }],
       };


### PR DESCRIPTION
## 概要

リリース編集で楽曲の紐づけを外した際、その楽曲が他リリースに紐づいていないと「楽曲は必ず1リリースに紐づく」制約（`ERRCODE 23514`）に違反して更新が失敗します。これまでは実態とズレた「リリースが見つからないか、更新に失敗しました」と表示されていたため、**行動可能な文言**に改善します。

> 制約自体は維持します（孤立楽曲は許容しない方針）。

## 変更内容
- `app/(authenticated)/admin/releases/[id]/edit/actions.ts`
  - `RepositoryError.cause`（Postgres エラー）の `code === "23514"` ＋メッセージ（`track must be linked to at least one release` / `track must have at least one release link`）を判定する `isOrphanTrackError` を追加
  - 該当時は次のメッセージを返す:
    「この変更では、どのリリースにも紐づかなくなる楽曲があります。対象の楽曲は紐づけを残すか、先に別のリリースへ移してから更新してください。」
  - それ以外の `RepositoryError` は従来どおり

## 補足（原因の説明）
- `update_release_with_relations` はリリースの紐づけを一旦全削除→再挿入します。削除で「最後の紐づけ」を失う楽曲があると、コミット時に遅延制約トリガが発火して失敗します。
- 通常の登録フロー（リリース作成→楽曲作成時に同一トランザクションで紐づけ）は影響を受けません。

## 受け入れ条件
- [x] 紐づけが0件になる楽曲が出る更新で、分かりやすいメッセージが出る
- [x] それ以外の失敗は従来メッセージ
- [x] `pnpm --filter oshikatsu-web typecheck` / `lint` / `build` 通過

## 確認方法
> migration 追加なし。

1. ある楽曲がそのリリースだけに紐づく状態で、リリース編集からその楽曲を外して更新
2. 上部に「どのリリースにも紐づかなくなる楽曲があります…」が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)
