### PR TITLE
リリースの「曲目」表記を「収録曲」に統一 (#131)

### DIFF
--- a/apps/oshikatsu-web/components/admin/ReleaseForm.tsx
+++ b/apps/oshikatsu-web/components/admin/ReleaseForm.tsx
@@ -487,7 +487,7 @@ export function ReleaseForm({
       </div>
 
       <div className="space-y-3 rounded-lg border border-foreground/10 p-4">
-        <p className="text-sm font-medium text-foreground">曲目アートワーク</p>
+        <p className="text-sm font-medium text-foreground">収録曲アートワーク</p>
 
         <Input
           id="artworkPersonName"
@@ -611,7 +611,7 @@ export function ReleaseForm({
 
       <div>
         <div className="mb-2 flex items-center justify-between">
-          <label className="text-sm font-medium text-foreground/70">曲目（楽曲）</label>
+          <label className="text-sm font-medium text-foreground/70">収録曲（楽曲）</label>
           <Button type="button" variant="ghost" onClick={addTrackLink}>
             + 楽曲を追加
           </Button>

--- a/apps/oshikatsu-web/components/releases/ReleaseCard.tsx
+++ b/apps/oshikatsu-web/components/releases/ReleaseCard.tsx
@@ -29,7 +29,7 @@ export function ReleaseCard({ release, showGroupName = true }: ReleaseCardProps)
         )}
         <span className="text-xs text-foreground/50">{typeLabel}</span>
       </div>
-      <p className="mt-1 text-xs text-foreground/50">曲目: {release.trackCount}曲</p>
+      <p className="mt-1 text-xs text-foreground/50">収録曲: {release.trackCount}曲</p>
       {release.releaseDate && (
         <p className="mt-1 text-xs text-foreground/50">{formatDate(release.releaseDate)}</p>
       )}

--- a/apps/oshikatsu-web/components/releases/ReleaseDetail.tsx
+++ b/apps/oshikatsu-web/components/releases/ReleaseDetail.tsx
@@ -42,7 +42,7 @@ export function ReleaseDetail({ release }: ReleaseDetailProps) {
 
       {artworkSrc && (
         <Card>
-          <h2 className="mb-3 text-sm font-medium text-foreground/70">曲目アートワーク</h2>
+          <h2 className="mb-3 text-sm font-medium text-foreground/70">収録曲アートワーク</h2>
           <Image
             src={artworkSrc}
             alt={`${release.title} artwork`}
@@ -74,7 +74,7 @@ export function ReleaseDetail({ release }: ReleaseDetailProps) {
 
       {release.tracks.length > 0 && (
         <Card>
-          <h2 className="mb-3 text-sm font-medium text-foreground/70">曲目</h2>
+          <h2 className="mb-3 text-sm font-medium text-foreground/70">収録曲</h2>
           <ol className="space-y-2">
             {release.tracks.map((track) => (
               <li key={track.trackId} className="rounded-lg border border-foreground/10 p-3">


### PR DESCRIPTION
Closes #131

## 概要
リリースの「曲目」表記を「収録曲」に統一します。

## 変更内容
- 一覧（`ReleaseCard`）: 「曲目: N曲」→「収録曲: N曲」
- 詳細（`ReleaseDetail`）: 収録曲セクション見出し、アートワーク見出し
- 作成フォーム（`ReleaseForm`）: 収録曲ラベル、アートワーク見出し
- `SongDetail` の「N曲目」（順番カウンタ）は意味が異なるため変更なし

## 受け入れ条件
- [x] 一覧・詳細・フォームで「収録曲」表記
- [x] `pnpm --filter oshikatsu-web typecheck` / `lint` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)
