### PR TITLE
楽曲一覧: 紐づけリリース表記をナンバリング種別に (#132)

### DIFF
--- a/apps/oshikatsu-web/components/songs/SongCard.tsx
+++ b/apps/oshikatsu-web/components/songs/SongCard.tsx
@@ -1,5 +1,6 @@
 import { PendingLink } from "@/components/ui/PendingLink";
 import type { SongListItem } from "@/types/song";
+import { formatReleaseTypeLabel } from "@/types/release";
 import { formatDate } from "@/lib/formatters";
 import { APP_ROUTES } from "@/lib/routes";
 
@@ -21,9 +22,14 @@ export function SongCard({ showGroupName = true, song }: SongCardProps) {
           {song.groupNameJa}
         </p>
       )}
-      <p className="mt-1 text-xs text-foreground/50">
-        紐づけリリース: {song.releaseCount}件
-      </p>
+      {song.representativeReleaseType && (
+        <p className="mt-1 text-xs text-foreground/50">
+          {formatReleaseTypeLabel(
+            song.representativeReleaseType,
+            song.representativeNumbering
+          )}
+        </p>
+      )}
       {song.firstReleaseDate && (
         <p className="mt-1 text-xs text-foreground/50">
           初回リリース: {formatDate(song.firstReleaseDate)}

--- a/apps/oshikatsu-web/repositories/songRepository.ts
+++ b/apps/oshikatsu-web/repositories/songRepository.ts
@@ -13,6 +13,7 @@ import type {
   SongListItem,
 } from "@/types/song";
 import type { SongRepository } from "@/types/repositories";
+import type { ReleaseType } from "@/types/release";
 import { RepositoryError } from "@/types/errors";
 import { splitCreditNames } from "@/lib/songCredits";
 
@@ -139,9 +140,13 @@ type SongRow = {
 type SongListReleaseDateRel =
   | {
       release_date: string | null;
+      release_type: ReleaseType;
+      numbering: number | null;
     }
   | Array<{
       release_date: string | null;
+      release_type: ReleaseType;
+      numbering: number | null;
     }>
   | null;
 
@@ -240,7 +245,7 @@ const SONG_PUBLIC_LIST_SELECT = `
   orbit_release_tracks(
     release_id,
     track_number,
-    orbit_releases(release_date)
+    orbit_releases(release_date, release_type, numbering)
   )
 `;
 
@@ -399,23 +404,29 @@ function mapToSongListItem(row: SongListRow): SongListItem {
   const group = pickFirst(row.orbit_groups);
   const releaseTracks = row.orbit_release_tracks ?? [];
 
-  // 代表リリース = 初出（最古の非nullリリース日）。日付が並んだら release_id で決定的に。
-  const datedLinks = releaseTracks
-    .map((releaseTrack) => ({
+  // 全紐づけ（種別・ナンバリング含む）。
+  const allLinks = releaseTracks.map((releaseTrack) => {
+    const release = pickFirst(releaseTrack.orbit_releases);
+    return {
       releaseId: releaseTrack.release_id,
       trackNumber: releaseTrack.track_number,
-      releaseDate: pickFirst(releaseTrack.orbit_releases)?.release_date ?? null,
-    }))
-    .filter(
-      (link): link is { releaseId: string; trackNumber: number; releaseDate: string } =>
-        Boolean(link.releaseDate)
-    )
+      releaseDate: release?.release_date ?? null,
+      releaseType: release?.release_type ?? null,
+      numbering: release?.numbering ?? null,
+    };
+  });
+
+  // 代表リリース = 初出（最古の非nullリリース日）。日付が並んだら release_id で決定的に。
+  const datedLinks = allLinks
+    .filter((link) => Boolean(link.releaseDate))
     .sort((a, b) => {
-      const dateCompare = a.releaseDate.localeCompare(b.releaseDate);
+      const dateCompare = (a.releaseDate ?? "").localeCompare(b.releaseDate ?? "");
       return dateCompare !== 0 ? dateCompare : a.releaseId.localeCompare(b.releaseId);
     });
 
   const representative = datedLinks[0] ?? null;
+  // 表示用代表 = 初出リリース（無ければ任意の紐づけ）。一覧の種別表記に使う。
+  const labelRepresentative = representative ?? allLinks[0] ?? null;
 
   return {
     id: row.id,
@@ -427,6 +438,8 @@ function mapToSongListItem(row: SongListRow): SongListItem {
     firstReleaseDate: representative?.releaseDate ?? null,
     representativeReleaseId: representative?.releaseId ?? null,
     representativeTrackNumber: representative?.trackNumber ?? null,
+    representativeReleaseType: labelRepresentative?.releaseType ?? null,
+    representativeNumbering: labelRepresentative?.numbering ?? null,
   };
 }
 

--- a/apps/oshikatsu-web/types/song.ts
+++ b/apps/oshikatsu-web/types/song.ts
@@ -74,6 +74,9 @@ export type SongListItem = {
   // 一覧の並び替え用：初出（最古）リリースの識別子とトラック番号
   representativeReleaseId: string | null;
   representativeTrackNumber: number | null;
+  // 一覧表示用：初出リリースの種別とナンバリング（例: 31st Single / 3rd Album）
+  representativeReleaseType: ReleaseType | null;
+  representativeNumbering: number | null;
 };
 
 export type SongSection = {


### PR DESCRIPTION
Closes #132

## 概要
楽曲一覧の紐づけリリース表示を「N件」から、**初出（最古）リリースのナンバリング種別表記**に変更します。

## 仕様
- 一番早いリリース（リリース日が最古、無ければ任意の紐づけ）を参照
- ナンバリングあり → `31st Single` / `3rd Album`
- ナンバリング無し → 種別そのまま（`Digital Single` / `BEST Album` / `Compilation Album` など）
- 「N件」の件数表示は廃止

## 変更内容
- `SongListItem` に `representativeReleaseType` / `representativeNumbering` を追加
- `songRepository.findPublicList`: SELECT に `release_type` / `numbering` を追加し、代表リリースから算出
- `SongCard`: `formatReleaseTypeLabel` で表示

## 受け入れ条件
- [x] 楽曲一覧で `31st Single` 等が表示される
- [x] 紐づけ無し楽曲は表示なし
- [x] `pnpm --filter oshikatsu-web typecheck` / `lint` / `build` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)
