### PR TITLE
楽曲フォーム: 曲順を末尾自動採番ベースに（入力時のみ重複チェック）(#133)

### DIFF
--- a/apps/oshikatsu-web/app/(authenticated)/admin/songs/[id]/edit/actions.ts
+++ b/apps/oshikatsu-web/app/(authenticated)/admin/songs/[id]/edit/actions.ts
@@ -9,6 +9,10 @@ import { revalidateOrbitSongData } from "@/lib/revalidateOrbit";
 import type { UpdateSongInput } from "@/types/song";
 import type { ValidationError } from "@/types/errors";
 import { RepositoryError } from "@/types/errors";
+import {
+  isDuplicateTrackNumberError,
+  DUPLICATE_TRACK_NUMBER_MESSAGE,
+} from "@/lib/releaseTrackErrors";
 
 export async function updateSongAction(
   id: string,
@@ -35,6 +39,11 @@ export async function updateSongAction(
     return {};
   } catch (e) {
     if (e instanceof RepositoryError) {
+      if (isDuplicateTrackNumberError(e)) {
+        return {
+          errors: [{ field: "_form", message: DUPLICATE_TRACK_NUMBER_MESSAGE }],
+        };
+      }
       return {
         errors: [{ field: "_form", message: "楽曲が見つからないか、更新に失敗しました" }],
       };

--- a/apps/oshikatsu-web/app/(authenticated)/admin/songs/new/actions.ts
+++ b/apps/oshikatsu-web/app/(authenticated)/admin/songs/new/actions.ts
@@ -8,6 +8,10 @@ import { revalidateOrbitSongData } from "@/lib/revalidateOrbit";
 import type { CreateSongInput } from "@/types/song";
 import type { ValidationError } from "@/types/errors";
 import { RepositoryError } from "@/types/errors";
+import {
+  isDuplicateTrackNumberError,
+  DUPLICATE_TRACK_NUMBER_MESSAGE,
+} from "@/lib/releaseTrackErrors";
 
 export async function createSongAction(
   input: CreateSongInput
@@ -33,6 +37,11 @@ export async function createSongAction(
     return {};
   } catch (e) {
     if (e instanceof RepositoryError) {
+      if (isDuplicateTrackNumberError(e)) {
+        return {
+          errors: [{ field: "_form", message: DUPLICATE_TRACK_NUMBER_MESSAGE }],
+        };
+      }
       return {
         errors: [{ field: "_form", message: "楽曲の作成に失敗しました" }],
       };

--- a/apps/oshikatsu-web/components/admin/SongForm.tsx
+++ b/apps/oshikatsu-web/components/admin/SongForm.tsx
@@ -76,7 +76,7 @@ function getDefaultValues(): FormValues {
     title: "",
     groupId: "",
     durationSeconds: "",
-    releaseLinks: [withReleaseKey({ releaseId: "", trackNumber: "1" })],
+    releaseLinks: [withReleaseKey({ releaseId: "", trackNumber: "" })],
     lyricsPeople: "",
     musicPeople: "",
     arrangementPeople: "",
@@ -275,7 +275,8 @@ export function SongForm({
   const addReleaseLink = () => {
     const nextReleaseLink = withReleaseKey({
       releaseId: "",
-      trackNumber: String(values.releaseLinks.length + 1),
+      // 既定は空欄（保存時にそのリリースの末尾へ自動採番）
+      trackNumber: "",
     });
 
     setValues((prev) => ({
@@ -578,6 +579,7 @@ export function SongForm({
                     label="曲順"
                     type="number"
                     min={1}
+                    placeholder="空欄で末尾"
                     value={link.trackNumber}
                     onChange={(e) => updateReleaseLink(link._key, "trackNumber", e.target.value)}
                     error={errors[`releaseLinks.${index}.trackNumber`]}

--- a/apps/oshikatsu-web/lib/releaseTrackErrors.ts
+++ b/apps/oshikatsu-web/lib/releaseTrackErrors.ts
@@ -1,0 +1,14 @@
+import { RepositoryError } from "@/types/errors";
+
+// 同一リリース内で曲順(track_number)が重複した場合のユニーク制約違反かを判定する
+export function isDuplicateTrackNumberError(error: RepositoryError): boolean {
+  const cause = error.cause as { code?: string; message?: string } | null;
+  const message = cause?.message ?? "";
+  return (
+    cause?.code === "23505" &&
+    message.includes("idx_orbit_release_tracks_unique_release_track_number")
+  );
+}
+
+export const DUPLICATE_TRACK_NUMBER_MESSAGE =
+  "その曲順は既に使われています。空欄にするとそのリリースの末尾に自動で追加されます。";

--- a/apps/oshikatsu-web/repositories/songRepository.ts
+++ b/apps/oshikatsu-web/repositories/songRepository.ts
@@ -450,12 +450,48 @@ function parseDurationSeconds(value: string): number | null {
 
 function parseReleaseLinks(input: CreateSongInput["releaseLinks"]): Array<{
   releaseId: string;
-  trackNumber: number;
+  trackNumber: number | null;
 }> {
-  return input.map((link) => ({
-    releaseId: link.releaseId,
-    trackNumber: Number(link.trackNumber),
-  }));
+  return input.map((link) => {
+    const raw = link.trackNumber.trim();
+    return {
+      releaseId: link.releaseId,
+      // 空欄は末尾自動採番のため null（保存時に解決する）
+      trackNumber: raw === "" ? null : Number(raw),
+    };
+  });
+}
+
+// 曲順が空欄(null)の紐づけを、そのリリース内の末尾（max + 1）に解決する
+async function resolveReleaseLinkTrackNumbers(
+  supabase: SupabaseClient,
+  links: Array<{ releaseId: string; trackNumber: number | null }>,
+  excludeTrackId?: string
+): Promise<Array<{ releaseId: string; trackNumber: number }>> {
+  const resolved: Array<{ releaseId: string; trackNumber: number }> = [];
+  for (const link of links) {
+    if (link.trackNumber != null) {
+      resolved.push({ releaseId: link.releaseId, trackNumber: link.trackNumber });
+      continue;
+    }
+    let query = supabase
+      .from("orbit_release_tracks")
+      .select("track_number")
+      .eq("release_id", link.releaseId)
+      .order("track_number", { ascending: false })
+      .limit(1);
+    if (excludeTrackId) {
+      query = query.neq("track_id", excludeTrackId);
+    }
+    const { data, error } = await query;
+    if (error) {
+      throw new RepositoryError("曲順の自動採番に失敗しました", error);
+    }
+    const maxNumber =
+      data && data.length > 0 ? (data[0] as { track_number: number }).track_number : 0;
+    resolved.push({ releaseId: link.releaseId, trackNumber: maxNumber + 1 });
+  }
+  return resolved;
 }
 
 function parseCredits(input: CreateSongInput): Array<{
@@ -622,7 +658,10 @@ export function createSongRepository(
 
     async create(input) {
       const durationSeconds = parseDurationSeconds(input.durationSeconds);
-      const releaseLinks = parseReleaseLinks(input.releaseLinks);
+      const releaseLinks = await resolveReleaseLinkTrackNumbers(
+        supabase,
+        parseReleaseLinks(input.releaseLinks)
+      );
       const credits = parseCredits(input);
       const formationRows = parseFormationRows(input.formationRows);
       const mv = parseMv(input.mv);
@@ -661,7 +700,11 @@ export function createSongRepository(
       }
 
       const durationSeconds = parseDurationSeconds(input.durationSeconds);
-      const releaseLinks = parseReleaseLinks(input.releaseLinks);
+      const releaseLinks = await resolveReleaseLinkTrackNumbers(
+        supabase,
+        parseReleaseLinks(input.releaseLinks),
+        id
+      );
       const credits = parseCredits(input);
       const formationRows = parseFormationRows(input.formationRows);
       const mv = parseMv(input.mv);

--- a/apps/oshikatsu-web/usecases/validateSong.ts
+++ b/apps/oshikatsu-web/usecases/validateSong.ts
@@ -58,12 +58,16 @@ export function validateSong(input: CreateSongInput): ValidationError[] {
     }
     releaseIdSet.add(link.releaseId);
 
-    const trackNumber = Number(link.trackNumber);
-    if (!Number.isInteger(trackNumber) || trackNumber <= 0) {
-      errors.push({
-        field: `releaseLinks.${i}.trackNumber`,
-        message: "曲順は1以上の整数で入力してください",
-      });
+    // 曲順は任意。空欄なら末尾に自動採番される。入力時のみ検証する。
+    const trackNumberRaw = link.trackNumber.trim();
+    if (trackNumberRaw !== "") {
+      const trackNumber = Number(trackNumberRaw);
+      if (!Number.isInteger(trackNumber) || trackNumber <= 0) {
+        errors.push({
+          field: `releaseLinks.${i}.trackNumber`,
+          message: "曲順は1以上の整数で入力してください",
+        });
+      }
     }
   }
 


### PR DESCRIPTION
Closes #133

## 概要
楽曲追加/編集時の紐づけリリースで、曲順（track_number）をなるべく手入力させないようにします。

## 仕様
- 曲順は **空欄を許可**。空欄なら保存時に **そのリリース内の末尾（max + 1）へ自動採番**
- 曲順を入力した場合のみ、既存の曲順と重複していれば **「その曲順は既に使われています」** を表示（空欄にすれば末尾に自動追加される旨も案内）

## 変更内容
- `songRepository`: `parseReleaseLinks` を `number | null` 化（空欄→null）、`resolveReleaseLinkTrackNumbers` を追加し create/update で末尾採番を解決（更新時は自分自身の紐づけを除外して max を算出）
- `validateSong`: 曲順は入力時のみ正数チェック（必須を解除）
- `SongForm`: 曲順の既定値を空欄に、`placeholder="空欄で末尾"`
- 重複検知: ユニーク制約 `idx_orbit_release_tracks_unique_release_track_number` 違反（23505）を判定する `lib/releaseTrackErrors` を追加し、楽曲の作成/更新アクションで文言化

## 整合性
- DB のユニーク制約はそのまま活用（重複は二重で防止）。マイグレーション追加なし。

## 受け入れ条件
- [x] 曲順空欄で保存 → そのリリースの末尾に採番される
- [x] 既存の曲順を手入力 → 重複エラーが出る
- [x] `pnpm --filter oshikatsu-web typecheck` / `lint` / `build` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)
