### PR TITLE
ライブ/リリース: 参加メンバーを期別・名前順に統一 (#135)

### DIFF
--- a/apps/oshikatsu-web/lib/memberOrder.ts
+++ b/apps/oshikatsu-web/lib/memberOrder.ts
@@ -1,0 +1,27 @@
+// 参加メンバーの並びを「期(generation)昇順 → 名前順」に統一するための比較関数。
+// generation は数値（"1","2"...）想定。数値化できない/未設定は末尾に置く。
+
+export type MemberOrderInput = {
+  generation: string | null;
+  name: string;
+};
+
+function generationRank(generation: string | null): number {
+  if (!generation) return Number.POSITIVE_INFINITY;
+  const value = Number(generation);
+  return Number.isFinite(value) ? value : Number.POSITIVE_INFINITY;
+}
+
+export function compareByGenerationThenName(
+  a: MemberOrderInput,
+  b: MemberOrderInput
+): number {
+  const rankA = generationRank(a.generation);
+  const rankB = generationRank(b.generation);
+  if (rankA !== rankB) return rankA - rankB;
+  // 同順位（同期 or どちらも未設定/非数値）は generation 文字列→名前で安定化
+  if ((a.generation ?? "") !== (b.generation ?? "")) {
+    return (a.generation ?? "").localeCompare(b.generation ?? "", "ja");
+  }
+  return a.name.localeCompare(b.name, "ja");
+}

--- a/apps/oshikatsu-web/lib/memberOrder.ts
+++ b/apps/oshikatsu-web/lib/memberOrder.ts
@@ -25,3 +25,26 @@ export function compareByGenerationThenName(
   }
   return a.name.localeCompare(b.name, "ja");
 }
+
+type MembershipGeneration = {
+  group_id: string;
+  generation: string | null;
+};
+
+// メンバーの所属から並び替え用の期を決定的に選ぶ。
+// 優先グループ内の所属があればそれを、無ければ全所属を対象に、
+// 期(数値)昇順 → group_id 昇順で先頭を採用する（DB返却順に依存しない）。
+export function pickMembershipGeneration(
+  memberships: MembershipGeneration[],
+  preferredGroupIds: ReadonlySet<string>
+): string | null {
+  const preferred = memberships.filter((m) => preferredGroupIds.has(m.group_id));
+  const pool = preferred.length > 0 ? preferred : memberships;
+  if (pool.length === 0) return null;
+  const sorted = [...pool].sort((a, b) => {
+    const rankDiff = generationRank(a.generation) - generationRank(b.generation);
+    if (rankDiff !== 0) return rankDiff;
+    return a.group_id.localeCompare(b.group_id);
+  });
+  return sorted[0].generation;
+}

--- a/apps/oshikatsu-web/repositories/liveRepository.ts
+++ b/apps/oshikatsu-web/repositories/liveRepository.ts
@@ -12,7 +12,10 @@ import type {
 } from "@/types/live";
 import { isSetlistItemType, isPerformanceStyle } from "@/types/live";
 import { RepositoryError } from "@/types/errors";
-import { compareByGenerationThenName } from "@/lib/memberOrder";
+import {
+  compareByGenerationThenName,
+  pickMembershipGeneration,
+} from "@/lib/memberOrder";
 
 type GroupRel = { name_ja: string; color: string } | { name_ja: string; color: string }[] | null;
 type MemberRel = { name_ja: string } | { name_ja: string }[] | null;
@@ -198,15 +201,11 @@ function mapLive(row: LiveRow): Live {
       .map((pm) => {
         const member = pickFirst(pm.orbit_members);
         const memberships = member?.orbit_member_groups ?? [];
-        // 出演グループでの期を優先（無ければ任意の所属の期）
-        const membership =
-          memberships.find((mg) => performerGroupIds.has(mg.group_id)) ??
-          memberships[0] ??
-          null;
+        // 出演グループでの期を優先しつつ、DB返却順に依存せず決定的に選ぶ
         return {
           memberId: pm.member_id,
           memberNameJa: member?.name_ja ?? "",
-          generation: membership?.generation ?? null,
+          generation: pickMembershipGeneration(memberships, performerGroupIds),
         };
       })
       .sort((a, b) =>

--- a/apps/oshikatsu-web/repositories/liveRepository.ts
+++ b/apps/oshikatsu-web/repositories/liveRepository.ts
@@ -12,6 +12,7 @@ import type {
 } from "@/types/live";
 import { isSetlistItemType, isPerformanceStyle } from "@/types/live";
 import { RepositoryError } from "@/types/errors";
+import { compareByGenerationThenName } from "@/lib/memberOrder";
 
 type GroupRel = { name_ja: string; color: string } | { name_ja: string; color: string }[] | null;
 type MemberRel = { name_ja: string } | { name_ja: string }[] | null;
@@ -25,9 +26,19 @@ type PerformerGroupRow = {
   orbit_groups: GroupRel;
 };
 
+type PerformerMemberGroupRow = {
+  group_id: string;
+  generation: string | null;
+};
+
+type PerformerMemberRel =
+  | { name_ja: string; orbit_member_groups: PerformerMemberGroupRow[] | null }
+  | { name_ja: string; orbit_member_groups: PerformerMemberGroupRow[] | null }[]
+  | null;
+
 type PerformerMemberRow = {
   member_id: string;
-  orbit_members: MemberRel;
+  orbit_members: PerformerMemberRel;
 };
 
 type AbsenceRow = {
@@ -94,7 +105,7 @@ const DETAIL_SELECT = `
   live_type,
   description,
   orbit_live_performer_groups(group_id, orbit_groups(name_ja, color)),
-  orbit_live_performer_members(member_id, orbit_members(name_ja)),
+  orbit_live_performer_members(member_id, orbit_members(name_ja, orbit_member_groups(group_id, generation))),
   orbit_live_performances(
     id,
     venue_id,
@@ -167,6 +178,9 @@ function mapPerformance(row: PerformanceRow): LivePerformance {
 }
 
 function mapLive(row: LiveRow): Live {
+  const performerGroupIds = new Set(
+    (row.orbit_live_performer_groups ?? []).map((pg) => pg.group_id)
+  );
   return {
     id: row.id,
     name: row.name,
@@ -180,10 +194,28 @@ function mapLive(row: LiveRow): Live {
         groupColor: group?.color ?? "#6B7280",
       };
     }),
-    performerMembers: (row.orbit_live_performer_members ?? []).map((pm) => ({
-      memberId: pm.member_id,
-      memberNameJa: pickFirst(pm.orbit_members)?.name_ja ?? "",
-    })),
+    performerMembers: (row.orbit_live_performer_members ?? [])
+      .map((pm) => {
+        const member = pickFirst(pm.orbit_members);
+        const memberships = member?.orbit_member_groups ?? [];
+        // 出演グループでの期を優先（無ければ任意の所属の期）
+        const membership =
+          memberships.find((mg) => performerGroupIds.has(mg.group_id)) ??
+          memberships[0] ??
+          null;
+        return {
+          memberId: pm.member_id,
+          memberNameJa: member?.name_ja ?? "",
+          generation: membership?.generation ?? null,
+        };
+      })
+      .sort((a, b) =>
+        compareByGenerationThenName(
+          { generation: a.generation, name: a.memberNameJa },
+          { generation: b.generation, name: b.memberNameJa }
+        )
+      )
+      .map(({ memberId, memberNameJa }) => ({ memberId, memberNameJa })),
     performances: (row.orbit_live_performances ?? [])
       .map(mapPerformance)
       .sort((a, b) => {

--- a/apps/oshikatsu-web/repositories/releaseRepository.ts
+++ b/apps/oshikatsu-web/repositories/releaseRepository.ts
@@ -8,6 +8,7 @@ import type {
 } from "@/types/release";
 import type { ReleaseRepository } from "@/types/repositories";
 import { RepositoryError } from "@/types/errors";
+import { compareByGenerationThenName } from "@/lib/memberOrder";
 
 type ReleaseGroupRow =
   | {
@@ -35,12 +36,19 @@ type ReleaseBonusVideoRow = {
   sort_order: number;
 };
 
+type ReleaseMemberGroupRow = {
+  group_id: string;
+  generation: string | null;
+};
+
 type ReleaseMemberNameRow =
   | {
       name_ja: string;
+      orbit_member_groups: ReleaseMemberGroupRow[] | null;
     }
   | Array<{
       name_ja: string;
+      orbit_member_groups: ReleaseMemberGroupRow[] | null;
     }>;
 
 type ReleaseMemberRow = {
@@ -105,7 +113,7 @@ const RELEASE_LIST_SELECT = `
   artwork_path,
   orbit_people(display_name),
   orbit_groups(name_ja, color),
-  orbit_release_members(member_id, orbit_members(name_ja)),
+  orbit_release_members(member_id, orbit_members(name_ja, orbit_member_groups(group_id, generation))),
   orbit_release_tracks(track_number)
 `;
 
@@ -120,7 +128,7 @@ const RELEASE_DETAIL_SELECT = `
   orbit_people(display_name),
   orbit_groups(name_ja, color),
   orbit_release_bonus_videos(id, edition, title, description, sort_order),
-  orbit_release_members(member_id, orbit_members(name_ja)),
+  orbit_release_members(member_id, orbit_members(name_ja, orbit_member_groups(group_id, generation))),
   orbit_release_tracks(track_number, orbit_tracks(id, title))
 `;
 
@@ -139,7 +147,7 @@ const RELEASE_OPTION_SELECT = `
   id,
   title,
   release_type,
-  orbit_release_members(member_id, orbit_members(name_ja))
+  orbit_release_members(member_id, orbit_members(name_ja, orbit_member_groups(group_id, generation)))
 `;
 
 function mapToRelease(row: ReleaseRow): Release {
@@ -152,15 +160,27 @@ function mapToRelease(row: ReleaseRow): Release {
     ? row.orbit_groups[0]
     : row.orbit_groups;
 
-  const participants = (row.orbit_release_members ?? []).map((member) => {
-    const orbitMember = Array.isArray(member.orbit_members)
-      ? member.orbit_members[0]
-      : member.orbit_members;
-    return {
-      memberId: member.member_id,
-      memberNameJa: orbitMember?.name_ja ?? "",
-    };
-  });
+  const participants = (row.orbit_release_members ?? [])
+    .map((member) => {
+      const orbitMember = Array.isArray(member.orbit_members)
+        ? member.orbit_members[0]
+        : member.orbit_members;
+      // リリースのグループでの期を採用（無ければ null）
+      const membership = (orbitMember?.orbit_member_groups ?? []).find(
+        (mg) => mg.group_id === row.group_id
+      );
+      return {
+        memberId: member.member_id,
+        memberNameJa: orbitMember?.name_ja ?? "",
+        generation: membership?.generation ?? null,
+      };
+    })
+    .sort((a, b) =>
+      compareByGenerationThenName(
+        { generation: a.generation, name: a.memberNameJa },
+        { generation: b.generation, name: b.memberNameJa }
+      )
+    );
 
   return {
     id: row.id,

--- a/apps/oshikatsu-web/repositories/releaseRepository.ts
+++ b/apps/oshikatsu-web/repositories/releaseRepository.ts
@@ -96,11 +96,16 @@ type ReleaseListRow = {
   orbit_release_tracks?: Array<{ track_number: number }>;
 };
 
+type ReleaseOptionMemberRow = {
+  member_id: string;
+  orbit_members: { name_ja: string } | { name_ja: string }[] | null;
+};
+
 type ReleaseOptionRow = {
   id: string;
   title: string;
   release_type: ReleaseType;
-  orbit_release_members?: ReleaseMemberRow[];
+  orbit_release_members?: ReleaseOptionMemberRow[];
 };
 
 const RELEASE_LIST_SELECT = `
@@ -147,7 +152,7 @@ const RELEASE_OPTION_SELECT = `
   id,
   title,
   release_type,
-  orbit_release_members(member_id, orbit_members(name_ja, orbit_member_groups(group_id, generation)))
+  orbit_release_members(member_id, orbit_members(name_ja))
 `;
 
 function mapToRelease(row: ReleaseRow): Release {


### PR DESCRIPTION
Closes #135

## 概要
ライブ・リリースの参加メンバー表示の並びを **期(generation)昇順 → 名前順** に統一します。

## 変更内容
- `lib/memberOrder.ts`: `compareByGenerationThenName`（期は数値昇順、未設定/非数値は末尾、同順位は名前順）を追加
- **リリース詳細**: 参加メンバーをリリースのグループでの期で並び替え（`releaseRepository` のメンバー取得に `orbit_member_groups(group_id, generation)` を追加）
- **ライブ詳細**: 出演メンバーを出演グループでの期で並び替え（`liveRepository` の performer member 取得に同様の join を追加）

## 補足
- 期はメンバーの所属グループ（member_groups）に紐づくため、対象（リリース/出演）グループでの期を採用。複数所属時は対象グループの期を優先。
- 休演・セットリストのメンバー表示は対象外（それぞれ別の意味の並び）。

## 受け入れ条件
- [x] リリース/ライブ詳細で参加メンバーが期別・名前順に並ぶ
- [x] `pnpm --filter oshikatsu-web typecheck` / `lint` / `build` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)
