### PR TITLE
楽曲ラベル（表題/選抜/アンダー/ソロ/ユニット/期別）を追加 (#141)

### DIFF
--- a/apps/oshikatsu-web/app/(authenticated)/admin/songs/[id]/edit/page.tsx
+++ b/apps/oshikatsu-web/app/(authenticated)/admin/songs/[id]/edit/page.tsx
@@ -31,7 +31,8 @@ export default async function EditSongPage({
   const initialValues: CreateSongInput = {
     title: song.title,
     groupId: song.groupId,
-    durationSeconds: song.durationSeconds ? String(song.durationSeconds) : "",
+    label: song.label ?? "",
+    generation: song.generation ?? "",
     releaseLinks: song.releases.map((release) => ({
       releaseId: release.releaseId,
       trackNumber: String(release.trackNumber),

--- a/apps/oshikatsu-web/components/admin/SongForm.tsx
+++ b/apps/oshikatsu-web/components/admin/SongForm.tsx
@@ -296,6 +296,17 @@ export function SongForm({
     });
   };
 
+  // グループ変更で期の候補が変わるため、期はクリアする
+  const updateGroupId = (groupId: string) => {
+    setValues((prev) => ({ ...prev, groupId, generation: "" }));
+    setErrors((prev) => {
+      const next = { ...prev };
+      delete next.groupId;
+      delete next.generation;
+      return next;
+    });
+  };
+
   const addReleaseLink = () => {
     const nextReleaseLink = withReleaseKey({
       releaseId: "",
@@ -519,7 +530,7 @@ export function SongForm({
         <select
           id="groupId"
           value={values.groupId}
-          onChange={(e) => update("groupId", e.target.value)}
+          onChange={(e) => updateGroupId(e.target.value)}
           className="w-full rounded-lg border border-foreground/10 bg-background px-3 py-2 text-sm"
         >
           <option value="">選択してください</option>

--- a/apps/oshikatsu-web/components/admin/SongForm.tsx
+++ b/apps/oshikatsu-web/components/admin/SongForm.tsx
@@ -10,6 +10,7 @@ import type {
   CreateSongFormationRowInput,
   CreateSongReleaseLinkInput,
 } from "@/types/song";
+import { SONG_LABELS, SONG_LABEL_LABELS } from "@/types/song";
 import type { ValidationError } from "@/types/errors";
 import { Input } from "@/components/ui/Input";
 import { Textarea } from "@/components/ui/Textarea";
@@ -75,7 +76,8 @@ function getDefaultValues(): FormValues {
   return {
     title: "",
     groupId: "",
-    durationSeconds: "",
+    label: "",
+    generation: "",
     releaseLinks: [withReleaseKey({ releaseId: "", trackNumber: "" })],
     lyricsPeople: "",
     musicPeople: "",
@@ -106,7 +108,8 @@ function toSubmitValues(values: FormValues): CreateSongInput {
   return {
     title: values.title,
     groupId: values.groupId,
-    durationSeconds: values.durationSeconds,
+    label: values.label,
+    generation: values.label === "generation" ? values.generation : "",
     releaseLinks: values.releaseLinks.map((link) => ({
       releaseId: link.releaseId,
       trackNumber: link.trackNumber,
@@ -268,6 +271,27 @@ export function SongForm({
     setErrors((prev) => {
       const next = { ...prev };
       delete next[field];
+      return next;
+    });
+  };
+
+  // 期の候補はグループの maxGeneration から 1..max（メンバー登録と同じ供給源）
+  const generationOptions = useMemo(() => {
+    const group = groups.find((g) => g.id === values.groupId);
+    const max = group?.maxGeneration ?? 0;
+    return Array.from({ length: max }, (_, i) => String(i + 1));
+  }, [groups, values.groupId]);
+
+  const updateLabel = (label: string) => {
+    setValues((prev) => ({
+      ...prev,
+      label,
+      generation: label === "generation" ? prev.generation : "",
+    }));
+    setErrors((prev) => {
+      const next = { ...prev };
+      delete next.label;
+      delete next.generation;
       return next;
     });
   };
@@ -510,15 +534,56 @@ export function SongForm({
         )}
       </div>
 
-      <Input
-        id="durationSeconds"
-        label="時間（秒）"
-        type="number"
-        min={1}
-        value={values.durationSeconds}
-        onChange={(e) => update("durationSeconds", e.target.value)}
-        error={errors.durationSeconds}
-      />
+      <div>
+        <label htmlFor="label" className="mb-1 block text-sm font-medium text-foreground/70">
+          ラベル
+        </label>
+        <select
+          id="label"
+          value={values.label}
+          onChange={(e) => updateLabel(e.target.value)}
+          className="w-full rounded-lg border border-foreground/10 bg-background px-3 py-2 text-sm"
+        >
+          <option value="">なし</option>
+          {SONG_LABELS.map((label) => (
+            <option key={label} value={label}>
+              {SONG_LABEL_LABELS[label]}
+            </option>
+          ))}
+        </select>
+        {errors.label && (
+          <p className="mt-1 text-xs text-red-500">{errors.label}</p>
+        )}
+      </div>
+
+      {values.label === "generation" && (
+        <div>
+          <label htmlFor="generation" className="mb-1 block text-sm font-medium text-foreground/70">
+            期
+          </label>
+          <select
+            id="generation"
+            value={values.generation}
+            onChange={(e) => update("generation", e.target.value)}
+            className="w-full rounded-lg border border-foreground/10 bg-background px-3 py-2 text-sm"
+          >
+            <option value="">選択してください</option>
+            {generationOptions.map((g) => (
+              <option key={g} value={g}>
+                {g}期
+              </option>
+            ))}
+          </select>
+          {!values.groupId && (
+            <p className="mt-1 text-xs text-foreground/40">
+              先にグループを選択すると期の候補が表示されます
+            </p>
+          )}
+          {errors.generation && (
+            <p className="mt-1 text-xs text-red-500">{errors.generation}</p>
+          )}
+        </div>
+      )}
 
       <div>
         <div className="mb-2 flex items-center justify-between">

--- a/apps/oshikatsu-web/components/songs/SongBrowser.tsx
+++ b/apps/oshikatsu-web/components/songs/SongBrowser.tsx
@@ -6,10 +6,14 @@ import { SongGrid } from "@/components/songs/SongGrid";
 import { SongSectionList } from "@/components/songs/SongSectionList";
 import { replaceListFilterParams } from "@/lib/listFilterUrl";
 import type { Group } from "@/types/group";
-import type { SongListItem, SongSection } from "@/types/song";
+import type { SongLabel, SongListItem, SongSection } from "@/types/song";
+import { SONG_LABELS, SONG_LABEL_LABELS, isSongLabel } from "@/types/song";
 import {
+  filterSongSectionsByLabel,
   filterSongSectionsByTitle,
+  filterSongsByGeneration,
   filterSongsByGroup,
+  filterSongsByLabel,
   filterSongsByTitle,
 } from "@/usecases/songSearch";
 
@@ -19,35 +23,93 @@ type SongBrowserProps = {
   songSections: SongSection[];
 };
 
+function toLabel(value: string | null): SongLabel | "" {
+  return value && isSongLabel(value) ? value : "";
+}
+
 export function SongBrowser({ groups, songs, songSections }: SongBrowserProps) {
   // 即時反映は local state、戻る/リロード等の URL 変化は useEffect で同期する
   const searchParams = useSearchParams();
   const urlGroupId = searchParams.get("groupId") ?? "";
+  const urlLabel = toLabel(searchParams.get("label"));
+  const urlGeneration = searchParams.get("generation") ?? "";
   const [groupId, setGroupId] = useState(urlGroupId);
+  const [label, setLabel] = useState<SongLabel | "">(urlLabel);
+  const [generation, setGeneration] = useState(urlGeneration);
   // タイトル検索は URL 非同期の一時状態
   const [query, setQuery] = useState("");
 
   useEffect(() => {
     setGroupId(urlGroupId);
   }, [urlGroupId]);
+  useEffect(() => {
+    setLabel(urlLabel);
+  }, [urlLabel]);
+  useEffect(() => {
+    setGeneration(urlGeneration);
+  }, [urlGeneration]);
 
   const isGroupFiltered = groupId !== "";
+  // 期サブ絞り込みはグループ選択かつラベル=期別のときのみ
+  const showGenerationFilter = isGroupFiltered && label === "generation";
 
-  // 件数表示・フラット表示用（グループ＋タイトルで絞り込む）
+  // 期の候補 = そのグループの期別曲に存在する期（昇順）
+  const generationOptions = useMemo(() => {
+    const present = new Set<string>();
+    for (const song of songs) {
+      if (
+        song.groupId === groupId &&
+        song.label === "generation" &&
+        song.generation
+      ) {
+        present.add(song.generation);
+      }
+    }
+    return Array.from(present).sort((a, b) => Number(a) - Number(b));
+  }, [songs, groupId]);
+
+  const effectiveGeneration = showGenerationFilter ? generation : "";
+
+  // 件数表示・フラット表示用（グループ＋ラベル＋期＋タイトル）
   const filteredSongs = useMemo(
-    () => filterSongsByTitle(filterSongsByGroup(songs, groupId), query),
-    [songs, groupId, query]
+    () =>
+      filterSongsByTitle(
+        filterSongsByGeneration(
+          filterSongsByLabel(filterSongsByGroup(songs, groupId), label),
+          effectiveGeneration
+        ),
+        query
+      ),
+    [songs, groupId, label, effectiveGeneration, query]
   );
-  // セクション表示はグループ未選択時のみ使う
+  // セクション表示はグループ未選択時のみ（ラベル＋タイトル）
   const filteredSections = useMemo(
     () =>
-      isGroupFiltered ? [] : filterSongSectionsByTitle(songSections, query),
-    [isGroupFiltered, songSections, query]
+      isGroupFiltered
+        ? []
+        : filterSongSectionsByTitle(
+            filterSongSectionsByLabel(songSections, label),
+            query
+          ),
+    [isGroupFiltered, songSections, label, query]
   );
 
   const handleGroupChange = (nextGroupId: string) => {
     setGroupId(nextGroupId);
-    replaceListFilterParams({ groupId: nextGroupId });
+    setGeneration("");
+    replaceListFilterParams({ groupId: nextGroupId, generation: "" });
+  };
+
+  const handleLabelChange = (nextLabel: SongLabel | "") => {
+    setLabel(nextLabel);
+    const nextGeneration = nextLabel === "generation" ? generation : "";
+    setGeneration(nextGeneration);
+    replaceListFilterParams({ label: nextLabel, generation: nextGeneration });
+  };
+
+  const handleGenerationChange = (nextGeneration: string) => {
+    setGeneration(nextGeneration);
+    replaceListFilterParams({ generation: nextGeneration });
   };
 
   return (
@@ -66,6 +128,36 @@ export function SongBrowser({ groups, songs, songSections }: SongBrowserProps) {
             </option>
           ))}
         </select>
+        <select
+          value={label}
+          onChange={(event) =>
+            handleLabelChange(event.target.value as SongLabel | "")
+          }
+          aria-label="ラベルで絞り込み"
+          className="rounded-lg border border-foreground/10 bg-background px-3 py-1.5 text-sm text-foreground"
+        >
+          <option value="">全ラベル</option>
+          {SONG_LABELS.map((value) => (
+            <option key={value} value={value}>
+              {SONG_LABEL_LABELS[value]}
+            </option>
+          ))}
+        </select>
+        {showGenerationFilter && (
+          <select
+            value={generation}
+            onChange={(event) => handleGenerationChange(event.target.value)}
+            aria-label="期で絞り込み"
+            className="rounded-lg border border-foreground/10 bg-background px-3 py-1.5 text-sm text-foreground"
+          >
+            <option value="">全期</option>
+            {generationOptions.map((g) => (
+              <option key={g} value={g}>
+                {g}期
+              </option>
+            ))}
+          </select>
+        )}
         <input
           type="search"
           value={query}

--- a/apps/oshikatsu-web/components/songs/SongCard.tsx
+++ b/apps/oshikatsu-web/components/songs/SongCard.tsx
@@ -1,8 +1,12 @@
 import { PendingLink } from "@/components/ui/PendingLink";
+import { Badge } from "@/components/ui/Badge";
 import type { SongListItem } from "@/types/song";
+import { formatSongLabel } from "@/types/song";
 import { formatReleaseTypeLabel } from "@/types/release";
 import { formatDate } from "@/lib/formatters";
 import { APP_ROUTES } from "@/lib/routes";
+
+const SONG_LABEL_COLOR = "#8B5CF6";
 
 type SongCardProps = {
   showGroupName?: boolean;
@@ -10,6 +14,7 @@ type SongCardProps = {
 };
 
 export function SongCard({ showGroupName = true, song }: SongCardProps) {
+  const labelText = formatSongLabel(song.label, song.generation, song.groupNameJa);
   return (
     <PendingLink
       href={`/songs/${song.id}`}
@@ -22,13 +27,18 @@ export function SongCard({ showGroupName = true, song }: SongCardProps) {
           {song.groupNameJa}
         </p>
       )}
-      {song.representativeReleaseType && (
-        <p className="mt-1 text-xs text-foreground/50">
-          {formatReleaseTypeLabel(
-            song.representativeReleaseType,
-            song.representativeNumbering
+      {(song.representativeReleaseType || labelText) && (
+        <div className="mt-1 flex flex-wrap items-center gap-2">
+          {song.representativeReleaseType && (
+            <span className="text-xs text-foreground/50">
+              {formatReleaseTypeLabel(
+                song.representativeReleaseType,
+                song.representativeNumbering
+              )}
+            </span>
           )}
-        </p>
+          {labelText && <Badge label={labelText} color={SONG_LABEL_COLOR} />}
+        </div>
       )}
       {song.firstReleaseDate && (
         <p className="mt-1 text-xs text-foreground/50">

--- a/apps/oshikatsu-web/components/songs/SongDetail.tsx
+++ b/apps/oshikatsu-web/components/songs/SongDetail.tsx
@@ -1,9 +1,11 @@
 import type { Song } from "@/types/song";
 import Link from "next/link";
 import { Card } from "@/components/ui/Card";
+import { Badge } from "@/components/ui/Badge";
 import { FormationDisplay } from "@/components/songs/FormationDisplay";
 import { formatDate } from "@/lib/formatters";
 import { RELEASE_TYPE_LABELS } from "@/types/release";
+import { formatSongLabel } from "@/types/song";
 
 const CREDIT_LABELS: Record<string, string> = {
   lyrics: "作詞",
@@ -12,13 +14,10 @@ const CREDIT_LABELS: Record<string, string> = {
   choreography: "振付",
 };
 
-function formatDuration(seconds: number): string {
-  const minutes = Math.floor(seconds / 60);
-  const remain = seconds % 60;
-  return `${minutes}:${String(remain).padStart(2, "0")}`;
-}
+const SONG_LABEL_COLOR = "#8B5CF6";
 
 export function SongDetail({ song }: { song: Song }) {
+  const labelText = formatSongLabel(song.label, song.generation, song.groupNameJa);
   const creditsByRole = new Map<string, string[]>();
   for (const credit of song.credits) {
     const list = creditsByRole.get(credit.role) ?? [];
@@ -30,9 +29,12 @@ export function SongDetail({ song }: { song: Song }) {
     <div className="space-y-6">
       <div>
         <h1 className="text-xl font-bold text-foreground">{song.title}</h1>
-        {song.groupNameJa && (
-          <p className="mt-1 text-sm text-foreground/50">{song.groupNameJa}</p>
-        )}
+        <div className="mt-1 flex flex-wrap items-center gap-2">
+          {song.groupNameJa && (
+            <span className="text-sm text-foreground/50">{song.groupNameJa}</span>
+          )}
+          {labelText && <Badge label={labelText} color={SONG_LABEL_COLOR} />}
+        </div>
       </div>
 
       <Card>
@@ -58,12 +60,6 @@ export function SongDetail({ song }: { song: Song }) {
       <Card>
         <h2 className="mb-3 text-sm font-medium text-foreground/70">楽曲情報</h2>
         <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
-          {song.durationSeconds && (
-            <>
-              <dt className="text-foreground/50">時間</dt>
-              <dd className="text-foreground">{formatDuration(song.durationSeconds)}</dd>
-            </>
-          )}
           {Array.from(creditsByRole.entries()).map(([role, names]) => (
             <>
               <dt key={`${role}-dt`} className="text-foreground/50">{CREDIT_LABELS[role] ?? role}</dt>

--- a/apps/oshikatsu-web/repositories/songRepository.ts
+++ b/apps/oshikatsu-web/repositories/songRepository.ts
@@ -11,7 +11,9 @@ import type {
   SongReleaseLink,
   CreateSongInput,
   SongListItem,
+  SongLabel,
 } from "@/types/song";
+import { isSongLabel } from "@/types/song";
 import type { SongRepository } from "@/types/repositories";
 import type { ReleaseType } from "@/types/release";
 import { RepositoryError } from "@/types/errors";
@@ -129,7 +131,8 @@ type SongRow = {
   title: string;
   group_id: string;
   orbit_groups: SongGroupRel;
-  duration_seconds: number | null;
+  label: string | null;
+  generation: string | null;
   orbit_release_tracks?: TrackReleaseRow[];
   orbit_track_credits?: TrackCreditRow[];
   orbit_track_formations?: FormationRel;
@@ -161,6 +164,8 @@ type SongListRow = {
   title: string;
   group_id: string;
   orbit_groups: SongGroupRel;
+  label: string | null;
+  generation: string | null;
   orbit_release_tracks?: SongListReleaseRow[];
 };
 
@@ -169,7 +174,8 @@ const SONG_LIST_SELECT = `
   title,
   group_id,
   orbit_groups(name_ja, color),
-  duration_seconds,
+  label,
+  generation,
   orbit_release_tracks(
     release_id,
     track_number,
@@ -189,7 +195,8 @@ const SONG_DETAIL_SELECT = `
   title,
   group_id,
   orbit_groups(name_ja, color),
-  duration_seconds,
+  label,
+  generation,
   orbit_release_tracks(
     release_id,
     track_number,
@@ -242,6 +249,8 @@ const SONG_PUBLIC_LIST_SELECT = `
   title,
   group_id,
   orbit_groups(name_ja, color),
+  label,
+  generation,
   orbit_release_tracks(
     release_id,
     track_number,
@@ -390,7 +399,8 @@ function mapSong(row: SongRow): Song {
     groupId: row.group_id,
     groupNameJa: songGroup?.name_ja ?? "",
     groupColor: songGroup?.color ?? "#6B7280",
-    durationSeconds: row.duration_seconds,
+    label: isSongLabel(row.label ?? "") ? (row.label as SongLabel) : null,
+    generation: row.generation,
     releaseDate,
     releases,
     credits: mapCredits(row.orbit_track_credits),
@@ -434,6 +444,8 @@ function mapToSongListItem(row: SongListRow): SongListItem {
     groupId: row.group_id,
     groupNameJa: group?.name_ja ?? "",
     groupColor: group?.color ?? "#6B7280",
+    label: isSongLabel(row.label ?? "") ? (row.label as SongLabel) : null,
+    generation: row.generation,
     releaseCount: releaseTracks.length,
     firstReleaseDate: representative?.releaseDate ?? null,
     representativeReleaseId: representative?.releaseId ?? null,
@@ -443,9 +455,15 @@ function mapToSongListItem(row: SongListRow): SongListItem {
   };
 }
 
-function parseDurationSeconds(value: string): number | null {
-  if (!value) return null;
-  return Number(value);
+// label は許容値のみ、generation は期別のときだけ保持する
+function parseLabel(value: string): string | null {
+  return isSongLabel(value) ? value : null;
+}
+
+function parseGeneration(label: string, generation: string): string | null {
+  if (label !== "generation") return null;
+  const trimmed = generation.trim();
+  return trimmed === "" ? null : trimmed;
 }
 
 function parseReleaseLinks(input: CreateSongInput["releaseLinks"]): Array<{
@@ -657,7 +675,8 @@ export function createSongRepository(
     },
 
     async create(input) {
-      const durationSeconds = parseDurationSeconds(input.durationSeconds);
+      const label = parseLabel(input.label);
+      const generation = parseGeneration(input.label, input.generation);
       const releaseLinks = await resolveReleaseLinkTrackNumbers(
         supabase,
         parseReleaseLinks(input.releaseLinks)
@@ -670,7 +689,8 @@ export function createSongRepository(
       const { data: trackId, error: rpcError } = await supabase.rpc("create_track_with_relations_v2", {
         p_title: input.title.trim(),
         p_group_id: input.groupId,
-        p_duration_seconds: durationSeconds,
+        p_label: label,
+        p_generation: generation,
         p_release_links: releaseLinks,
         p_credits: credits,
         p_formation_rows: formationRows,
@@ -699,7 +719,8 @@ export function createSongRepository(
         throw new RepositoryError("更新対象の楽曲が見つかりません", null);
       }
 
-      const durationSeconds = parseDurationSeconds(input.durationSeconds);
+      const label = parseLabel(input.label);
+      const generation = parseGeneration(input.label, input.generation);
       const releaseLinks = await resolveReleaseLinkTrackNumbers(
         supabase,
         parseReleaseLinks(input.releaseLinks),
@@ -714,7 +735,8 @@ export function createSongRepository(
         p_track_id: id,
         p_title: input.title.trim(),
         p_group_id: input.groupId,
-        p_duration_seconds: durationSeconds,
+        p_label: label,
+        p_generation: generation,
         p_release_links: releaseLinks,
         p_credits: credits,
         p_formation_rows: formationRows,

--- a/apps/oshikatsu-web/supabase/migrations/038_add_song_label_and_drop_duration.sql
+++ b/apps/oshikatsu-web/supabase/migrations/038_add_song_label_and_drop_duration.sql
@@ -1,0 +1,415 @@
+-- ============================================================
+-- 038: 楽曲にラベル/期を追加し、duration_seconds を廃止
+-- ------------------------------------------------------------
+-- - orbit_tracks に label / generation 列を追加
+--   label: title/senbatsu/under/solo/unit/generation（任意）
+--   generation: label = 'generation' のときのみ非NULL
+-- - duration_seconds 列と関連RPCの duration 引数を撤去
+-- ============================================================
+
+-- 1) 列追加 + 制約
+ALTER TABLE public.orbit_tracks
+  ADD COLUMN IF NOT EXISTS label TEXT,
+  ADD COLUMN IF NOT EXISTS generation TEXT;
+
+ALTER TABLE public.orbit_tracks
+  DROP CONSTRAINT IF EXISTS orbit_tracks_label_check;
+ALTER TABLE public.orbit_tracks
+  ADD CONSTRAINT orbit_tracks_label_check CHECK (
+    label IS NULL
+    OR label IN ('title', 'senbatsu', 'under', 'solo', 'unit', 'generation')
+  );
+
+ALTER TABLE public.orbit_tracks
+  DROP CONSTRAINT IF EXISTS orbit_tracks_generation_rule;
+ALTER TABLE public.orbit_tracks
+  ADD CONSTRAINT orbit_tracks_generation_rule CHECK (
+    (COALESCE(label, '') = 'generation' AND generation IS NOT NULL)
+    OR (COALESCE(label, '') <> 'generation' AND generation IS NULL)
+  );
+
+-- 2) duration を参照する旧RPCを差し替え
+DROP FUNCTION IF EXISTS public.create_track_with_relations(
+  TEXT, INT, JSONB, JSONB, JSONB, JSONB, JSONB
+);
+DROP FUNCTION IF EXISTS public.create_track_with_relations_v2(
+  TEXT, UUID, INT, JSONB, JSONB, JSONB, JSONB, JSONB
+);
+DROP FUNCTION IF EXISTS public.update_track_with_relations_v2(
+  UUID, TEXT, UUID, INT, JSONB, JSONB, JSONB, JSONB, JSONB
+);
+DROP FUNCTION IF EXISTS public.update_track_with_relations(
+  UUID, TEXT, INT, JSONB, JSONB, JSONB, JSONB, JSONB
+);
+
+-- 2-1) base: 楽曲のスカラー更新 + 関連の総入れ替え（duration を撤去）
+CREATE FUNCTION public.update_track_with_relations(
+  p_track_id UUID,
+  p_title TEXT,
+  p_release_links JSONB,
+  p_credits JSONB,
+  p_formation_rows JSONB,
+  p_mv JSONB,
+  p_costumes JSONB
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+DECLARE
+  v_formation_id UUID;
+  v_director_person_id UUID;
+  v_mv_url TEXT;
+  v_mv_director_name TEXT;
+  v_mv_location TEXT;
+  v_mv_published_on DATE;
+  v_mv_memo TEXT;
+BEGIN
+  UPDATE public.orbit_tracks
+  SET
+    title = p_title
+  WHERE id = p_track_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'track not found: %', p_track_id USING ERRCODE = 'P0002';
+  END IF;
+
+  DELETE FROM public.orbit_release_tracks
+  WHERE track_id = p_track_id;
+
+  INSERT INTO public.orbit_release_tracks (
+    track_id,
+    release_id,
+    track_number
+  )
+  SELECT
+    p_track_id,
+    link.release_id,
+    link.track_number
+  FROM (
+    SELECT
+      (item->>'releaseId')::UUID AS release_id,
+      (item->>'trackNumber')::INT AS track_number,
+      ord
+    FROM jsonb_array_elements(COALESCE(p_release_links, '[]'::JSONB)) WITH ORDINALITY AS link(item, ord)
+  ) AS link
+  ORDER BY link.ord;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.orbit_release_tracks
+    WHERE track_id = p_track_id
+  ) THEN
+    RAISE EXCEPTION 'track must have at least one release link: %', p_track_id USING ERRCODE = '23514';
+  END IF;
+
+  DELETE FROM public.orbit_track_credits
+  WHERE track_id = p_track_id;
+
+  INSERT INTO public.orbit_people (display_name)
+  SELECT DISTINCT credit.person_name
+  FROM (
+    SELECT NULLIF(BTRIM(item->>'personName'), '') AS person_name
+    FROM jsonb_array_elements(COALESCE(p_credits, '[]'::JSONB)) AS credits(item)
+  ) AS credit
+  WHERE credit.person_name IS NOT NULL
+  ON CONFLICT (display_name) DO NOTHING;
+
+  INSERT INTO public.orbit_track_credits (
+    track_id,
+    credit_role,
+    person_id,
+    sort_order
+  )
+  SELECT
+    p_track_id,
+    (credit.item->>'role')::TEXT,
+    people.id,
+    COALESCE((credit.item->>'sortOrder')::INT, (credit.ord - 1)::INT)
+  FROM jsonb_array_elements(COALESCE(p_credits, '[]'::JSONB)) WITH ORDINALITY AS credit(item, ord)
+  JOIN public.orbit_people people
+    ON people.display_name = NULLIF(BTRIM(credit.item->>'personName'), '')
+  WHERE NULLIF(BTRIM(credit.item->>'personName'), '') IS NOT NULL
+  ORDER BY credit.ord;
+
+  DELETE FROM public.orbit_track_formations
+  WHERE track_id = p_track_id;
+
+  IF EXISTS (
+    SELECT 1
+    FROM jsonb_array_elements(COALESCE(p_formation_rows, '[]'::JSONB))
+  ) THEN
+    IF EXISTS (
+      WITH assigned_members AS (
+        SELECT DISTINCT (member.member_id_text)::UUID AS member_id
+        FROM jsonb_array_elements(COALESCE(p_formation_rows, '[]'::JSONB)) AS formation_row(item)
+        CROSS JOIN LATERAL jsonb_array_elements_text(
+          COALESCE(formation_row.item->'memberIds', '[]'::JSONB)
+        ) AS member(member_id_text)
+      ),
+      allowed_members AS (
+        SELECT DISTINCT rm.member_id
+        FROM public.orbit_release_members rm
+        JOIN public.orbit_release_tracks rt
+          ON rt.release_id = rm.release_id
+        WHERE rt.track_id = p_track_id
+      )
+      SELECT 1
+      FROM assigned_members assigned
+      LEFT JOIN allowed_members allowed
+        ON allowed.member_id = assigned.member_id
+      WHERE allowed.member_id IS NULL
+    ) THEN
+      RAISE EXCEPTION 'formation includes non-participant members' USING ERRCODE = '23514';
+    END IF;
+
+    INSERT INTO public.orbit_track_formations (
+      track_id,
+      column_count
+    )
+    VALUES (
+      p_track_id,
+      (
+        SELECT COUNT(*)
+        FROM jsonb_array_elements(COALESCE(p_formation_rows, '[]'::JSONB))
+      )
+    )
+    RETURNING id INTO v_formation_id;
+
+    WITH rows AS (
+      SELECT
+        COALESCE((row.item->>'rowNumber')::INT, row.ord::INT) AS row_number,
+        COALESCE((row.item->>'memberCount')::INT, 0) AS member_count,
+        COALESCE(row.item->'memberIds', '[]'::JSONB) AS member_ids
+      FROM jsonb_array_elements(COALESCE(p_formation_rows, '[]'::JSONB)) WITH ORDINALITY AS row(item, ord)
+    ),
+    inserted_rows AS (
+      INSERT INTO public.orbit_track_formation_rows (
+        formation_id,
+        row_number,
+        member_count
+      )
+      SELECT
+        v_formation_id,
+        rows.row_number,
+        rows.member_count
+      FROM rows
+      RETURNING id, row_number
+    ),
+    member_items AS (
+      SELECT
+        rows.row_number,
+        (member.member_id_text)::UUID AS member_id,
+        (member.ord - 1)::INT AS slot_order
+      FROM rows
+      CROSS JOIN LATERAL jsonb_array_elements_text(rows.member_ids) WITH ORDINALITY AS member(member_id_text, ord)
+    )
+    INSERT INTO public.orbit_track_formation_members (
+      formation_row_id,
+      member_id,
+      slot_order
+    )
+    SELECT
+      inserted_rows.id,
+      member_items.member_id,
+      member_items.slot_order
+    FROM member_items
+    JOIN inserted_rows
+      ON inserted_rows.row_number = member_items.row_number;
+  END IF;
+
+  v_mv_url := NULL;
+  v_mv_director_name := NULL;
+  v_mv_location := NULL;
+  v_mv_published_on := NULL;
+  v_mv_memo := NULL;
+
+  IF p_mv IS NOT NULL THEN
+    v_mv_url := NULLIF(BTRIM(COALESCE(p_mv->>'url', '')), '');
+    v_mv_director_name := NULLIF(BTRIM(COALESCE(p_mv->>'directorName', '')), '');
+    v_mv_location := NULLIF(BTRIM(COALESCE(p_mv->>'location', '')), '');
+    v_mv_memo := NULLIF(BTRIM(COALESCE(p_mv->>'memo', '')), '');
+
+    IF NULLIF(BTRIM(COALESCE(p_mv->>'publishedOn', '')), '') IS NOT NULL THEN
+      v_mv_published_on := (p_mv->>'publishedOn')::DATE;
+    END IF;
+  END IF;
+
+  IF v_mv_url IS NULL
+    AND v_mv_director_name IS NULL
+    AND v_mv_location IS NULL
+    AND v_mv_published_on IS NULL
+    AND v_mv_memo IS NULL
+  THEN
+    DELETE FROM public.orbit_track_mvs
+    WHERE track_id = p_track_id;
+  ELSE
+    IF v_mv_director_name IS NOT NULL THEN
+      INSERT INTO public.orbit_people (display_name)
+      VALUES (v_mv_director_name)
+      ON CONFLICT (display_name) DO NOTHING;
+
+      SELECT id
+      INTO v_director_person_id
+      FROM public.orbit_people
+      WHERE display_name = v_mv_director_name;
+    ELSE
+      v_director_person_id := NULL;
+    END IF;
+
+    INSERT INTO public.orbit_track_mvs (
+      track_id,
+      mv_url,
+      director_person_id,
+      location,
+      published_on,
+      memo
+    )
+    VALUES (
+      p_track_id,
+      COALESCE(v_mv_url, ''),
+      v_director_person_id,
+      v_mv_location,
+      v_mv_published_on,
+      v_mv_memo
+    )
+    ON CONFLICT (track_id) DO UPDATE
+    SET
+      mv_url = EXCLUDED.mv_url,
+      director_person_id = EXCLUDED.director_person_id,
+      location = EXCLUDED.location,
+      published_on = EXCLUDED.published_on,
+      memo = EXCLUDED.memo;
+  END IF;
+
+  DELETE FROM public.orbit_track_costumes
+  WHERE track_id = p_track_id;
+
+  INSERT INTO public.orbit_people (display_name)
+  SELECT DISTINCT costume.stylist_name
+  FROM (
+    SELECT NULLIF(BTRIM(item->>'stylistName'), '') AS stylist_name
+    FROM jsonb_array_elements(COALESCE(p_costumes, '[]'::JSONB)) AS costumes(item)
+  ) AS costume
+  WHERE costume.stylist_name IS NOT NULL
+  ON CONFLICT (display_name) DO NOTHING;
+
+  INSERT INTO public.orbit_track_costumes (
+    track_id,
+    stylist_person_id,
+    image_path,
+    note,
+    sort_order
+  )
+  SELECT
+    p_track_id,
+    people.id,
+    costume.image_path,
+    costume.note,
+    costume.sort_order
+  FROM (
+    SELECT
+      (ord - 1)::INT AS sort_order,
+      NULLIF(BTRIM(item->>'stylistName'), '') AS stylist_name,
+      NULLIF(BTRIM(item->>'imagePath'), '') AS image_path,
+      NULLIF(BTRIM(item->>'note'), '') AS note
+    FROM jsonb_array_elements(COALESCE(p_costumes, '[]'::JSONB)) WITH ORDINALITY AS costumes(item, ord)
+  ) AS costume
+  JOIN public.orbit_people people
+    ON people.display_name = costume.stylist_name
+  WHERE costume.stylist_name IS NOT NULL
+    AND costume.image_path IS NOT NULL
+  ORDER BY costume.sort_order;
+END;
+$$;
+
+-- 2-2) v2 update: group_id / label / generation を設定して base へ委譲
+CREATE FUNCTION public.update_track_with_relations_v2(
+  p_track_id UUID,
+  p_title TEXT,
+  p_group_id UUID,
+  p_label TEXT,
+  p_generation TEXT,
+  p_release_links JSONB,
+  p_credits JSONB,
+  p_formation_rows JSONB,
+  p_mv JSONB,
+  p_costumes JSONB
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+BEGIN
+  UPDATE public.orbit_tracks
+  SET
+    group_id = p_group_id,
+    label = p_label,
+    generation = p_generation
+  WHERE id = p_track_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'track not found: %', p_track_id USING ERRCODE = 'P0002';
+  END IF;
+
+  PERFORM public.update_track_with_relations(
+    p_track_id,
+    p_title,
+    p_release_links,
+    p_credits,
+    p_formation_rows,
+    p_mv,
+    p_costumes
+  );
+END;
+$$;
+
+-- 2-3) v2 create: 楽曲を作成して update_v2 へ委譲
+CREATE FUNCTION public.create_track_with_relations_v2(
+  p_title TEXT,
+  p_group_id UUID,
+  p_label TEXT,
+  p_generation TEXT,
+  p_release_links JSONB,
+  p_credits JSONB,
+  p_formation_rows JSONB,
+  p_mv JSONB,
+  p_costumes JSONB
+)
+RETURNS UUID
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+DECLARE
+  v_track_id UUID;
+BEGIN
+  INSERT INTO public.orbit_tracks (
+    title,
+    group_id
+  )
+  VALUES (
+    p_title,
+    p_group_id
+  )
+  RETURNING id INTO v_track_id;
+
+  PERFORM public.update_track_with_relations_v2(
+    v_track_id,
+    p_title,
+    p_group_id,
+    p_label,
+    p_generation,
+    p_release_links,
+    p_credits,
+    p_formation_rows,
+    p_mv,
+    p_costumes
+  );
+
+  RETURN v_track_id;
+END;
+$$;
+
+-- 3) duration_seconds 列を削除
+ALTER TABLE public.orbit_tracks
+  DROP COLUMN IF EXISTS duration_seconds;

--- a/apps/oshikatsu-web/supabase/seeds/030_seed_sakamichi_release_tracks_starter.sql
+++ b/apps/oshikatsu-web/supabase/seeds/030_seed_sakamichi_release_tracks_starter.sql
@@ -196,13 +196,11 @@ WHERE NOT EXISTS (
 -- Tracks
 INSERT INTO public.orbit_tracks (
   title,
-  group_id,
-  duration_seconds
+  group_id
 )
 SELECT DISTINCT
   seed.track_title,
-  track_group.id,
-  seed.duration_seconds
+  track_group.id
 FROM orbit_seed_music_items seed
 JOIN public.orbit_groups track_group
   ON track_group.name_ja = seed.track_group_name

--- a/apps/oshikatsu-web/supabase/seeds/031_seed_sakamichi_tracks_expanded.sql
+++ b/apps/oshikatsu-web/supabase/seeds/031_seed_sakamichi_tracks_expanded.sql
@@ -216,13 +216,11 @@ WHERE NOT EXISTS (
 -- Tracks
 INSERT INTO public.orbit_tracks (
   title,
-  group_id,
-  duration_seconds
+  group_id
 )
 SELECT DISTINCT
   seed.track_title,
-  seed.track_group_id,
-  seed.duration_seconds
+  seed.track_group_id
 FROM orbit_seed_resolved_track_items seed
 WHERE NOT EXISTS (
   SELECT 1

--- a/apps/oshikatsu-web/types/song.ts
+++ b/apps/oshikatsu-web/types/song.ts
@@ -178,6 +178,4 @@ export type UpdateSongInput = CreateSongInput;
 
 export type SongFilters = {
   groupId?: string;
-  label?: SongLabel;
-  generation?: string;
 };

--- a/apps/oshikatsu-web/types/song.ts
+++ b/apps/oshikatsu-web/types/song.ts
@@ -1,6 +1,49 @@
 import type { ReleaseType } from "@/types/release";
 import type { Group } from "@/types/group";
 
+export const SONG_LABELS = [
+  "title",
+  "senbatsu",
+  "under",
+  "solo",
+  "unit",
+  "generation",
+] as const;
+
+export type SongLabel = (typeof SONG_LABELS)[number];
+
+export const SONG_LABEL_LABELS: Record<SongLabel, string> = {
+  title: "表題",
+  senbatsu: "選抜",
+  under: "アンダー",
+  solo: "ソロ",
+  unit: "ユニット",
+  generation: "期別",
+};
+
+// アンダーのグループ別表示名（内部値は under 共通）
+const UNDER_LABEL_BY_GROUP: Record<string, string> = {
+  乃木坂46: "アンダー",
+  櫻坂46: "BACKS",
+  日向坂46: "ひなた坂",
+};
+
+export function isSongLabel(value: string): value is SongLabel {
+  return (SONG_LABELS as readonly string[]).includes(value);
+}
+
+// 表示用ラベル文字列（under はグループ別、generation は「N期生曲」）
+export function formatSongLabel(
+  label: SongLabel | null,
+  generation: string | null,
+  groupNameJa: string
+): string | null {
+  if (!label) return null;
+  if (label === "under") return UNDER_LABEL_BY_GROUP[groupNameJa] ?? "アンダー";
+  if (label === "generation") return generation ? `${generation}期生曲` : "期別";
+  return SONG_LABEL_LABELS[label];
+}
+
 export type SongCreditRole = "lyrics" | "music" | "arrangement" | "choreography";
 
 export type SongCredit = {
@@ -54,7 +97,8 @@ export type Song = {
   groupId: string;
   groupNameJa: string;
   groupColor: string;
-  durationSeconds: number | null;
+  label: SongLabel | null;
+  generation: string | null;
   releaseDate: string | null;
   releases: SongReleaseLink[];
   credits: SongCredit[];
@@ -69,6 +113,8 @@ export type SongListItem = {
   groupId: string;
   groupNameJa: string;
   groupColor: string;
+  label: SongLabel | null;
+  generation: string | null;
   releaseCount: number;
   firstReleaseDate: string | null;
   // 一覧の並び替え用：初出（最古）リリースの識別子とトラック番号
@@ -116,7 +162,8 @@ export type CreateSongCostumeInput = {
 export type CreateSongInput = {
   title: string;
   groupId: string;
-  durationSeconds: string;
+  label: string;
+  generation: string;
   releaseLinks: CreateSongReleaseLinkInput[];
   lyricsPeople: string;
   musicPeople: string;
@@ -131,4 +178,6 @@ export type UpdateSongInput = CreateSongInput;
 
 export type SongFilters = {
   groupId?: string;
+  label?: SongLabel;
+  generation?: string;
 };

--- a/apps/oshikatsu-web/usecases/songSearch.ts
+++ b/apps/oshikatsu-web/usecases/songSearch.ts
@@ -1,4 +1,4 @@
-import type { SongListItem, SongSection } from "@/types/song";
+import type { SongLabel, SongListItem, SongSection } from "@/types/song";
 
 export function filterSongsByGroup(
   songs: SongListItem[],
@@ -8,6 +8,28 @@ export function filterSongsByGroup(
     return songs;
   }
   return songs.filter((song) => song.groupId === groupId);
+}
+
+export function filterSongsByLabel(
+  songs: SongListItem[],
+  label: SongLabel | ""
+): SongListItem[] {
+  if (label === "") {
+    return songs;
+  }
+  return songs.filter((song) => song.label === label);
+}
+
+export function filterSongsByGeneration(
+  songs: SongListItem[],
+  generation: string
+): SongListItem[] {
+  if (generation === "") {
+    return songs;
+  }
+  return songs.filter(
+    (song) => song.label === "generation" && song.generation === generation
+  );
 }
 
 function normalizeQuery(query: string): string {
@@ -27,6 +49,21 @@ export function filterSongsByTitle(
     return songs;
   }
   return songs.filter((song) => matchesTitle(song.title, normalizedQuery));
+}
+
+export function filterSongSectionsByLabel(
+  sections: SongSection[],
+  label: SongLabel | ""
+): SongSection[] {
+  if (label === "") {
+    return sections;
+  }
+  return sections
+    .map((section) => ({
+      ...section,
+      songs: section.songs.filter((song) => song.label === label),
+    }))
+    .filter((section) => section.songs.length > 0);
 }
 
 export function filterSongSectionsByTitle(

--- a/apps/oshikatsu-web/usecases/validateSong.ts
+++ b/apps/oshikatsu-web/usecases/validateSong.ts
@@ -2,6 +2,7 @@ import type {
   CreateSongInput,
   SongCreditRole,
 } from "@/types/song";
+import { isSongLabel } from "@/types/song";
 import type { ValidationError } from "@/types/errors";
 import { isValidDateString, isValidHttpUrl } from "@/lib/validation";
 import { isTrackCostumeImagePath } from "@/lib/releaseImage";
@@ -27,14 +28,15 @@ export function validateSong(input: CreateSongInput): ValidationError[] {
     errors.push({ field: "groupId", message: "楽曲グループを選択してください" });
   }
 
-  if (input.durationSeconds) {
-    const seconds = Number(input.durationSeconds);
-    if (!Number.isInteger(seconds) || seconds <= 0) {
-      errors.push({
-        field: "durationSeconds",
-        message: "時間は1以上の整数（秒）で入力してください",
-      });
+  // ラベルは任意。値が許容外ならエラー。期別のときは期が必須。
+  if (input.label) {
+    if (!isSongLabel(input.label)) {
+      errors.push({ field: "label", message: "ラベルの値が不正です" });
+    } else if (input.label === "generation" && !input.generation.trim()) {
+      errors.push({ field: "generation", message: "期別曲は期を選択してください" });
     }
+  } else if (input.generation.trim()) {
+    errors.push({ field: "generation", message: "期はラベルが期別のときのみ指定できます" });
   }
 
   if (input.releaseLinks.length === 0) {

--- a/apps/oshikatsu-web/usecases/validateSong.ts
+++ b/apps/oshikatsu-web/usecases/validateSong.ts
@@ -28,12 +28,20 @@ export function validateSong(input: CreateSongInput): ValidationError[] {
     errors.push({ field: "groupId", message: "楽曲グループを選択してください" });
   }
 
-  // ラベルは任意。値が許容外ならエラー。期別のときは期が必須。
+  // ラベルは任意。値が許容外ならエラー。期別のときは期（正の整数）が必須。
   if (input.label) {
     if (!isSongLabel(input.label)) {
       errors.push({ field: "label", message: "ラベルの値が不正です" });
-    } else if (input.label === "generation" && !input.generation.trim()) {
-      errors.push({ field: "generation", message: "期別曲は期を選択してください" });
+    } else if (input.label === "generation") {
+      const generationRaw = input.generation.trim();
+      if (!generationRaw) {
+        errors.push({ field: "generation", message: "期別曲は期を選択してください" });
+      } else {
+        const generation = Number(generationRaw);
+        if (!Number.isInteger(generation) || generation <= 0) {
+          errors.push({ field: "generation", message: "期は1以上の整数で指定してください" });
+        }
+      }
     }
   } else if (input.generation.trim()) {
     errors.push({ field: "generation", message: "期はラベルが期別のときのみ指定できます" });

--- a/docs/orbit-roadmap.md
+++ b/docs/orbit-roadmap.md
@@ -214,6 +214,12 @@
 - [x] メンバー一覧に期（世代）絞り込みを追加（Issue #96）
   - [x] グループ選択時のみ表示。選択肢は `Group.maxGeneration`（無ければ実在世代から導出）。グループスコープで絞り込み、グループ変更時はリセット。URL `generation` を同期
 
+### 楽曲ラベル（#141）
+
+- [x] 楽曲に単一ラベル（表題/選抜/アンダー/ソロ/ユニット/期別、任意）を追加し一覧で絞り込み
+  - [x] アンダーはグループ別表示（乃木坂=アンダー/櫻坂=BACKS/日向坂=ひなた坂）、期別は「N期生曲」表示＋期サブ絞り込み（候補は group.maxGeneration）
+  - [x] duration_seconds を廃止（列削除・入力/表示撤去）。migration 038、RPC は label/generation 対応に再生成
+
 ### リリース種別にベスト/コンピレーションを追加（#129）
 
 - [x] `release_type` に `best` / `compilation` を追加（ナンバリング無し）。一覧フィルタ「アルバム」でアルバム系（album/best/compilation）をまとめて表示、ラベルは `BEST Album` / `Compilation Album`（migration 037）


### PR DESCRIPTION
Closes #141

## 概要
楽曲に単一ラベル（任意）を追加し、一覧で絞り込めるようにします。あわせて未使用の duration(秒) を完全廃止します。

## 変更内容

### データモデル / RPC（migration 038）
- `orbit_tracks` に `label` / `generation` 列を追加（CHECK 制約：label は許容値、generation は label=generation のときのみ）
- `duration_seconds` 列を削除
- track 関連 RPC を再生成（`update_track_with_relations` base ＋ `create/update_track_with_relations_v2`）。duration 引数を撤去し `p_label` / `p_generation` を追加（v2 が group_id とともに設定）
- 死蔵の非v2 `create_track_with_relations` を削除

### 仕様
- **単一ラベル**：表題/選抜/アンダー/ソロ/ユニット/期別
- **アンダー**：内部値 `under` 共通、表示はグループ名で固定（乃木坂=アンダー / 櫻坂=BACKS / 日向坂=ひなた坂 / その他=アンダー）
- **期別**：`generation` を別保持。表示「N期生曲」。入力は候補提示（`group.maxGeneration` から 1..max ＝メンバー登録と同じ供給源）
- **絞り込み**：ラベル（全ラベル/各値）。ラベル=期別かつグループ選択時に「期」サブ絞り込み（候補はその群の期別曲に存在する期）
- **表示**：一覧は「21st Single」の右、詳細はグループ名の近くにバッジ

### コード
- `types/song`：`SONG_LABELS` / `SONG_LABEL_LABELS` / `formatSongLabel` / `isSongLabel`、`Song`・`SongListItem`・`CreateSongInput`・`SongFilters` を更新（duration 撤去）
- `songRepository`：select/map/create/update を label・generation 対応に
- `validateSong`：duration 検証撤去、label 許容値＆期別時の期必須
- `songSearch`：`filterSongsByLabel` / `filterSongsByGeneration` / `filterSongSectionsByLabel`
- UI：`SongForm`（duration→ラベル＋期Select）、`SongBrowser`（ラベル＋期絞り込み）、`SongCard`/`SongDetail`（バッジ・duration表示撤去）
- seed 030/031 の `orbit_tracks` INSERT から duration_seconds を除去

## 受け入れ条件
- [x] 楽曲にラベルを任意設定・保存できる
- [x] 期別曲は期を候補から選べ、一覧で「N期生曲」表示・期で絞り込める
- [x] アンダーがグループ別表示名で出る
- [x] ラベルで一覧を絞り込める
- [x] duration の入力欄・表示が無い
- [x] `pnpm --filter oshikatsu-web typecheck` / `lint` / `build` 通過

## 確認方法
> **migration 038 の適用が必要です。**（duration_seconds 列を削除します）

1. 管理→楽曲でラベルを設定（期別なら期を選択）して保存
2. 一覧でラベル絞り込み、期別＋グループで期サブ絞り込み
3. アンダー曲が乃木坂=アンダー/櫻坂=BACKS/日向坂=ひなた坂 で表示
4. 詳細・一覧に duration が無い

🤖 Generated with [Claude Code](https://claude.com/claude-code)
