### PR TITLE
スマホのハンバーガーメニューを全ナビ項目に (#144)

### DIFF
--- a/apps/oshikatsu-web/components/layout/Header.tsx
+++ b/apps/oshikatsu-web/components/layout/Header.tsx
@@ -4,7 +4,11 @@ import { useState } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import { createClient } from "@personal-hub/supabase/client";
 import { PendingLink } from "@/components/ui/PendingLink";
-import { HEADER_NAV_ITEMS, isNavigationItemActive } from "@/lib/navigation";
+import {
+  HEADER_NAV_ITEMS,
+  TOP_NAV_ITEMS,
+  isNavigationItemActive,
+} from "@/lib/navigation";
 
 export function Header() {
   const pathname = usePathname();
@@ -80,7 +84,7 @@ export function Header() {
       {isMenuOpen && (
         <div className="border-t border-foreground/10 px-4 py-3 md:hidden">
           <nav className="flex flex-col gap-2">
-            {HEADER_NAV_ITEMS.map((item) => (
+            {TOP_NAV_ITEMS.map((item) => (
               <PendingLink
                 key={item.href}
                 href={item.href}


### PR DESCRIPTION
Closes #144

## 概要
スマホのハンバーガーメニューに**会場・制作陣を含む全項目**を表示します。

## 変更内容
- `components/layout/Header.tsx` のモバイルメニューを `HEADER_NAV_ITEMS` → `TOP_NAV_ITEMS` に変更（メンバー/楽曲/リリース/ライブ/制作陣/会場/管理）
- デスクトップ上部ナビは `HEADER_NAV_ITEMS` のまま据え置き

## 受け入れ条件
- [x] スマホ幅でハンバーガーを開くと会場・制作陣を含む全項目が出る
- [x] デスクトップ表示は従来どおり
- [x] `pnpm --filter oshikatsu-web typecheck` / `lint` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)
