### PR TITLE
参加メンバーの並びをかな順に修正 (#143)

### DIFF
--- a/apps/oshikatsu-web/lib/memberOrder.ts
+++ b/apps/oshikatsu-web/lib/memberOrder.ts
@@ -1,9 +1,10 @@
-// 参加メンバーの並びを「期(generation)昇順 → 名前順」に統一するための比較関数。
+// 参加メンバーの並びを「期(generation)昇順 → かな(name_kana)順」に統一するための比較関数。
 // generation は数値（"1","2"...）想定。数値化できない/未設定は末尾に置く。
+// 氏名は漢字だと読み順に並ばないため、かな読み(name_kana)で比較する。
 
 export type MemberOrderInput = {
   generation: string | null;
-  name: string;
+  nameKana: string;
 };
 
 function generationRank(generation: string | null): number {
@@ -19,11 +20,11 @@ export function compareByGenerationThenName(
   const rankA = generationRank(a.generation);
   const rankB = generationRank(b.generation);
   if (rankA !== rankB) return rankA - rankB;
-  // 同順位（同期 or どちらも未設定/非数値）は generation 文字列→名前で安定化
+  // 同順位（同期 or どちらも未設定/非数値）は generation 文字列→かな読みで安定化
   if ((a.generation ?? "") !== (b.generation ?? "")) {
     return (a.generation ?? "").localeCompare(b.generation ?? "", "ja");
   }
-  return a.name.localeCompare(b.name, "ja");
+  return a.nameKana.localeCompare(b.nameKana, "ja");
 }
 
 type MembershipGeneration = {

--- a/apps/oshikatsu-web/repositories/liveRepository.ts
+++ b/apps/oshikatsu-web/repositories/liveRepository.ts
@@ -35,8 +35,16 @@ type PerformerMemberGroupRow = {
 };
 
 type PerformerMemberRel =
-  | { name_ja: string; orbit_member_groups: PerformerMemberGroupRow[] | null }
-  | { name_ja: string; orbit_member_groups: PerformerMemberGroupRow[] | null }[]
+  | {
+      name_ja: string;
+      name_kana: string;
+      orbit_member_groups: PerformerMemberGroupRow[] | null;
+    }
+  | {
+      name_ja: string;
+      name_kana: string;
+      orbit_member_groups: PerformerMemberGroupRow[] | null;
+    }[]
   | null;
 
 type PerformerMemberRow = {
@@ -108,7 +116,7 @@ const DETAIL_SELECT = `
   live_type,
   description,
   orbit_live_performer_groups(group_id, orbit_groups(name_ja, color)),
-  orbit_live_performer_members(member_id, orbit_members(name_ja, orbit_member_groups(group_id, generation))),
+  orbit_live_performer_members(member_id, orbit_members(name_ja, name_kana, orbit_member_groups(group_id, generation))),
   orbit_live_performances(
     id,
     venue_id,
@@ -205,13 +213,14 @@ function mapLive(row: LiveRow): Live {
         return {
           memberId: pm.member_id,
           memberNameJa: member?.name_ja ?? "",
+          memberNameKana: member?.name_kana ?? "",
           generation: pickMembershipGeneration(memberships, performerGroupIds),
         };
       })
       .sort((a, b) =>
         compareByGenerationThenName(
-          { generation: a.generation, name: a.memberNameJa },
-          { generation: b.generation, name: b.memberNameJa }
+          { generation: a.generation, nameKana: a.memberNameKana },
+          { generation: b.generation, nameKana: b.memberNameKana }
         )
       )
       .map(({ memberId, memberNameJa }) => ({ memberId, memberNameJa })),

--- a/apps/oshikatsu-web/repositories/releaseRepository.ts
+++ b/apps/oshikatsu-web/repositories/releaseRepository.ts
@@ -44,10 +44,12 @@ type ReleaseMemberGroupRow = {
 type ReleaseMemberNameRow =
   | {
       name_ja: string;
+      name_kana: string;
       orbit_member_groups: ReleaseMemberGroupRow[] | null;
     }
   | Array<{
       name_ja: string;
+      name_kana: string;
       orbit_member_groups: ReleaseMemberGroupRow[] | null;
     }>;
 
@@ -118,7 +120,7 @@ const RELEASE_LIST_SELECT = `
   artwork_path,
   orbit_people(display_name),
   orbit_groups(name_ja, color),
-  orbit_release_members(member_id, orbit_members(name_ja, orbit_member_groups(group_id, generation))),
+  orbit_release_members(member_id, orbit_members(name_ja, name_kana, orbit_member_groups(group_id, generation))),
   orbit_release_tracks(track_number)
 `;
 
@@ -133,7 +135,7 @@ const RELEASE_DETAIL_SELECT = `
   orbit_people(display_name),
   orbit_groups(name_ja, color),
   orbit_release_bonus_videos(id, edition, title, description, sort_order),
-  orbit_release_members(member_id, orbit_members(name_ja, orbit_member_groups(group_id, generation))),
+  orbit_release_members(member_id, orbit_members(name_ja, name_kana, orbit_member_groups(group_id, generation))),
   orbit_release_tracks(track_number, orbit_tracks(id, title))
 `;
 
@@ -177,13 +179,14 @@ function mapToRelease(row: ReleaseRow): Release {
       return {
         memberId: member.member_id,
         memberNameJa: orbitMember?.name_ja ?? "",
+        memberNameKana: orbitMember?.name_kana ?? "",
         generation: membership?.generation ?? null,
       };
     })
     .sort((a, b) =>
       compareByGenerationThenName(
-        { generation: a.generation, name: a.memberNameJa },
-        { generation: b.generation, name: b.memberNameJa }
+        { generation: a.generation, nameKana: a.memberNameKana },
+        { generation: b.generation, nameKana: b.memberNameKana }
       )
     );
 


### PR DESCRIPTION
Closes #143

## 概要
リリース/ライブ詳細の参加メンバーの並びを **かな(name_kana)順**に修正します。漢字 `name_ja` の `localeCompare` は読み順にならないため、読みで比較します。

## 変更内容
- `lib/memberOrder.ts`：`compareByGenerationThenName` の名前比較を `name`(漢字) → `nameKana`(かな) に変更
- `repositories/releaseRepository.ts` / `repositories/liveRepository.ts`：参加メンバー取得に `name_kana` を追加し、ソートに使用
- メンバーマスタ一覧/候補は既に `.order("name_kana")` のため対象外

## 受け入れ条件
- [x] リリース/ライブ詳細の参加メンバーが読み順（あいうえお順）で並ぶ
- [x] `pnpm --filter oshikatsu-web typecheck` / `lint` / `build` 通過

## 確認方法
> migration 追加なし。

1. リリース/ライブ詳細の参加メンバーが、漢字に依らず読み順で並ぶ

🤖 Generated with [Claude Code](https://claude.com/claude-code)
