### PR TITLE
fix: 楽曲詳細でMV登録済み楽曲を開くと500になる不具合を修正

### DIFF
--- a/apps/oshikatsu-web/repositories/songRepository.ts
+++ b/apps/oshikatsu-web/repositories/songRepository.ts
@@ -118,6 +118,10 @@ type MvRow = {
   orbit_people: PersonRel | null;
 };
 
+// orbit_track_mvs は track_id が UNIQUE のため to-one として
+// 単一オブジェクト（リレーションが無ければ null）で返る。配列で返る場合にも備える。
+type MvRel = MvRow | MvRow[] | null;
+
 type CostumeRow = {
   id: string;
   image_path: string;
@@ -136,7 +140,7 @@ type SongRow = {
   orbit_release_tracks?: TrackReleaseRow[];
   orbit_track_credits?: TrackCreditRow[];
   orbit_track_formations?: FormationRel;
-  orbit_track_mvs?: MvRow[];
+  orbit_track_mvs?: MvRel;
   orbit_track_costumes?: CostumeRow[];
 };
 
@@ -335,9 +339,9 @@ function mapFormation(formationRel: FormationRel | undefined): SongFormationRow[
     .sort((a, b) => a.rowNumber - b.rowNumber);
 }
 
-function mapMv(rows: MvRow[] | undefined): SongMv | null {
-  if (!rows || rows.length === 0) return null;
-  const row = rows[0];
+function mapMv(mvRel: MvRel | undefined): SongMv | null {
+  const row = pickFirst(mvRel);
+  if (!row) return null;
   const director = pickFirst(row.orbit_people);
 
   return {


### PR DESCRIPTION
## 概要
MVを登録した楽曲の詳細ページ（`/songs/[id]`）を開くと `Runtime TypeError: Cannot read properties of undefined (reading 'orbit_people')` で500になる不具合を修正します。

## 原因
`orbit_track_mvs` は `track_id` が UNIQUE のため、PostgREST はこれを **to-one** とみなし、埋め込み結果を**配列ではなく単一オブジェクト**（リレーション無しなら `null`）で返します。
ところが `mapMv` は配列前提（`rows.length` / `rows[0]`）で実装されており、オブジェクトに対し `rows[0]` が `undefined` となって `undefined.orbit_people` で例外になっていました。
MVが無い間は早期returnで隠れており、**MVを初めて登録した楽曲の詳細を開いた瞬間に必ず再現**します。

同じく `track_id` UNIQUE の `orbit_track_formations` は既に `pickFirst` でオブジェクト/配列の両方に対応済みで、**MVだけ対応が漏れていた**のが実態です。

## 変更
- `mapMv` を `pickFirst` でオブジェクト/配列/null を正規化する実装に変更（`mapFormation` と同じ流儀に統一）
- 型 `MvRel = MvRow | MvRow[] | null` を追加し `SongRow.orbit_track_mvs` に適用

## 確認
- `tsc --noEmit` 通過
- 手動: MV登録済み楽曲の詳細表示で500が解消／MV無し楽曲は従来通り表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)