### PR TITLE
chore: 楽曲詳細の堅牢化（エラーバウンダリ/保存ログ/Fragment整理）

### DIFF
--- a/apps/oshikatsu-web/app/(authenticated)/admin/songs/[id]/edit/actions.ts
+++ b/apps/oshikatsu-web/app/(authenticated)/admin/songs/[id]/edit/actions.ts
@@ -39,6 +39,11 @@ export async function updateSongAction(
     return {};
   } catch (e) {
     if (e instanceof RepositoryError) {
+      console.error("updateSongAction: repository error", {
+        id,
+        message: e.message,
+        cause: e.cause,
+      });
       if (isDuplicateTrackNumberError(e)) {
         return {
           errors: [{ field: "_form", message: DUPLICATE_TRACK_NUMBER_MESSAGE }],

--- a/apps/oshikatsu-web/app/(authenticated)/admin/songs/new/actions.ts
+++ b/apps/oshikatsu-web/app/(authenticated)/admin/songs/new/actions.ts
@@ -37,6 +37,10 @@ export async function createSongAction(
     return {};
   } catch (e) {
     if (e instanceof RepositoryError) {
+      console.error("createSongAction: repository error", {
+        message: e.message,
+        cause: e.cause,
+      });
       if (isDuplicateTrackNumberError(e)) {
         return {
           errors: [{ field: "_form", message: DUPLICATE_TRACK_NUMBER_MESSAGE }],

--- a/apps/oshikatsu-web/app/(authenticated)/songs/[id]/error.tsx
+++ b/apps/oshikatsu-web/app/(authenticated)/songs/[id]/error.tsx
@@ -14,7 +14,8 @@ type SongDetailErrorProps = {
 // 回復可能な表示に留める（原因調査用に digest をログへ残す）。
 export default function SongDetailError({ error, reset }: SongDetailErrorProps) {
   useEffect(() => {
-    console.error("song detail render error", error);
+    // クライアントコンソールへの露出を最小化し、サーバーログ突合用の digest のみ記録する
+    console.error("song detail render error", { digest: error.digest });
   }, [error]);
 
   return (

--- a/apps/oshikatsu-web/app/(authenticated)/songs/[id]/error.tsx
+++ b/apps/oshikatsu-web/app/(authenticated)/songs/[id]/error.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+import { Button } from "@/components/ui/Button";
+import { APP_ROUTES } from "@/lib/routes";
+
+type SongDetailErrorProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+// 楽曲詳細の読み込み/描画で例外が出ても、ページ全体を 500 にせず
+// 回復可能な表示に留める（原因調査用に digest をログへ残す）。
+export default function SongDetailError({ error, reset }: SongDetailErrorProps) {
+  useEffect(() => {
+    console.error("song detail render error", error);
+  }, [error]);
+
+  return (
+    <div className="space-y-4">
+      <Link
+        href={APP_ROUTES.songs}
+        className="text-sm text-foreground/60 hover:text-foreground"
+      >
+        ← 楽曲一覧
+      </Link>
+      <div className="rounded-lg border border-foreground/10 p-6 text-center">
+        <p className="text-sm text-foreground">楽曲情報の読み込みに失敗しました。</p>
+        <p className="mt-1 text-xs text-foreground/50">
+          時間をおいて再度お試しください。
+        </p>
+        <div className="mt-4">
+          <Button onClick={reset}>再試行</Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/oshikatsu-web/components/songs/SongDetail.tsx
+++ b/apps/oshikatsu-web/components/songs/SongDetail.tsx
@@ -1,4 +1,5 @@
 import type { Song } from "@/types/song";
+import { Fragment } from "react";
 import Link from "next/link";
 import { Card } from "@/components/ui/Card";
 import { Badge } from "@/components/ui/Badge";
@@ -61,10 +62,10 @@ export function SongDetail({ song }: { song: Song }) {
         <h2 className="mb-3 text-sm font-medium text-foreground/70">楽曲情報</h2>
         <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
           {Array.from(creditsByRole.entries()).map(([role, names]) => (
-            <>
-              <dt key={`${role}-dt`} className="text-foreground/50">{CREDIT_LABELS[role] ?? role}</dt>
-              <dd key={`${role}-dd`} className="text-foreground">{names.join(" / ")}</dd>
-            </>
+            <Fragment key={role}>
+              <dt className="text-foreground/50">{CREDIT_LABELS[role] ?? role}</dt>
+              <dd className="text-foreground">{names.join(" / ")}</dd>
+            </Fragment>
           ))}
         </dl>
       </Card>


### PR DESCRIPTION
## 概要
#147 と同じ不具合調査からの**再発防止・診断性改善**のフォローアップです（#147 は不具合の直接修正、本PRは周辺の堅牢化）。機能挙動は変えません。

## 変更
- **`app/(authenticated)/songs/[id]/error.tsx` を追加**
  楽曲詳細の読み込み/描画で例外が出ても、ページ全体を500にせず回復可能な表示（再試行ボタン＋一覧導線）に留める。`digest` を `console.error` に出力し原因調査を容易にする。
- **保存アクションのログ追加**（`admin/songs/[id]/edit/actions.ts`, `admin/songs/new/actions.ts`）
  `RepositoryError` を `console.error` に記録し、保存失敗の原因をサーバーログから追えるようにする。
- **`SongDetail` のクレジット一覧整理**
  無キーの `<>`（`key` を子に付与）を `<Fragment key={role}>` に修正し、Reactのkey警告を解消。

## 確認
- `tsc --noEmit` 通過 / `eslint` (error.tsx) 通過
- 手動: 詳細読み込みを意図的に失敗させると500ではなくエラーバウンダリ表示になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)