### PR TITLE
fix: 楽曲詳細のクレジットを 作詞→作曲→編曲→振付 の順で表示

### DIFF
--- a/apps/oshikatsu-web/repositories/songRepository.ts
+++ b/apps/oshikatsu-web/repositories/songRepository.ts
@@ -292,6 +292,19 @@ function mapRelease(row: TrackReleaseRow): SongReleaseLink | null {
   };
 }
 
+// クレジットの表示順（作詞→作曲→編曲→振付）。未知ロールは末尾へ回す。
+const CREDIT_ROLE_ORDER: SongCreditRole[] = [
+  "lyrics",
+  "music",
+  "arrangement",
+  "choreography",
+];
+
+function creditRoleRank(role: SongCreditRole): number {
+  const index = CREDIT_ROLE_ORDER.indexOf(role);
+  return index === -1 ? CREDIT_ROLE_ORDER.length : index;
+}
+
 function mapCredits(rows: TrackCreditRow[] | undefined): SongCredit[] {
   if (!rows) return [];
 
@@ -308,7 +321,7 @@ function mapCredits(rows: TrackCreditRow[] | undefined): SongCredit[] {
     })
     .filter((credit): credit is SongCredit => Boolean(credit))
     .sort((a, b) => {
-      if (a.role !== b.role) return a.role.localeCompare(b.role);
+      if (a.role !== b.role) return creditRoleRank(a.role) - creditRoleRank(b.role);
       return a.sortOrder - b.sortOrder;
     });
 }


### PR DESCRIPTION
## 概要
楽曲詳細のクレジット表示順を **作詞 → 作曲 → 編曲 → 振付** に固定します。

## 原因
`mapCredits`（`repositories/songRepository.ts`）が `role.localeCompare(role)` でソートしており、英字順（arrangement → choreography → lyrics → music）になっていました。

## 変更
- ロール優先度 `["lyrics","music","arrangement","choreography"]` でソート（`creditRoleRank`）。未知ロールは末尾。
- 同一ロール内は既存 `sort_order` を維持。スキーマ変更なし。

## 確認
- `tsc --noEmit` 通過
- 手動: 複数ロール登録曲の詳細で 作詞→作曲→編曲→振付 の順を確認

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)