### PR TITLE
feat: フォーメーション編集のメンバー候補をかな順で並べる

### DIFF
--- a/apps/oshikatsu-web/components/admin/SongForm.tsx
+++ b/apps/oshikatsu-web/components/admin/SongForm.tsx
@@ -197,7 +197,7 @@ export function SongForm({
   );
 
   const participantOptions = useMemo(() => {
-    const options = new Map<string, string>();
+    const options = new Map<string, { name: string; kana: string }>();
 
     for (const link of values.releaseLinks) {
       if (!link.releaseId) continue;
@@ -207,20 +207,28 @@ export function SongForm({
       for (let i = 0; i < release.participantMemberIds.length; i++) {
         const memberId = release.participantMemberIds[i];
         const name = release.participantMemberNames[i] ?? memberNameById.get(memberId) ?? "";
-        options.set(memberId, name || memberId);
+        const kana = release.participantMemberKanas[i] ?? "";
+        options.set(memberId, { name: name || memberId, kana });
       }
     }
 
     return Array.from(options.entries())
-      .map(([memberId, memberName]) => ({
+      .map(([memberId, { name, kana }]) => ({
         memberId,
-        memberName,
+        memberName: name,
+        memberKana: kana,
         isInSongGroup:
           values.groupId.length > 0
             ? (memberGroupIdsById.get(memberId)?.has(values.groupId) ?? false)
             : true,
       }))
-      .sort((a, b) => a.memberName.localeCompare(b.memberName));
+      // メンバー一覧/リリースと同じく、かな読み順で安定ソートする
+      .sort((a, b) => {
+        const kanaCompare = a.memberKana.localeCompare(b.memberKana, "ja");
+        return kanaCompare !== 0
+          ? kanaCompare
+          : a.memberName.localeCompare(b.memberName, "ja");
+      });
   }, [memberGroupIdsById, memberNameById, releaseMap, values.groupId, values.releaseLinks]);
 
   const selectedFormationMemberIds = useMemo(() => {

--- a/apps/oshikatsu-web/repositories/releaseRepository.ts
+++ b/apps/oshikatsu-web/repositories/releaseRepository.ts
@@ -100,7 +100,10 @@ type ReleaseListRow = {
 
 type ReleaseOptionMemberRow = {
   member_id: string;
-  orbit_members: { name_ja: string } | { name_ja: string }[] | null;
+  orbit_members:
+    | { name_ja: string; name_kana: string }
+    | { name_ja: string; name_kana: string }[]
+    | null;
 };
 
 type ReleaseOptionRow = {
@@ -154,7 +157,7 @@ const RELEASE_OPTION_SELECT = `
   id,
   title,
   release_type,
-  orbit_release_members(member_id, orbit_members(name_ja))
+  orbit_release_members(member_id, orbit_members(name_ja, name_kana))
 `;
 
 function mapToRelease(row: ReleaseRow): Release {
@@ -261,6 +264,7 @@ function mapToReleaseOption(row: ReleaseOptionRow): ReleaseOption {
     return {
       memberId: member.member_id,
       memberNameJa: orbitMember?.name_ja ?? "",
+      memberNameKana: orbitMember?.name_kana ?? "",
     };
   });
 
@@ -270,6 +274,7 @@ function mapToReleaseOption(row: ReleaseOptionRow): ReleaseOption {
     releaseType: row.release_type,
     participantMemberIds: participants.map((member) => member.memberId),
     participantMemberNames: participants.map((member) => member.memberNameJa),
+    participantMemberKanas: participants.map((member) => member.memberNameKana),
   };
 }
 

--- a/apps/oshikatsu-web/types/release.ts
+++ b/apps/oshikatsu-web/types/release.ts
@@ -124,6 +124,7 @@ export type ReleaseOption = {
   releaseType: ReleaseType;
   participantMemberIds: string[];
   participantMemberNames: string[];
+  participantMemberKanas: string[];
 };
 
 export type CreateReleaseBonusVideoInput = {


### PR DESCRIPTION
## 概要
フォーメーション編集（`SongForm`）のメンバー候補を **かな読み順（name_kana）** で並べ、選びやすくします（#143 と同じ並び規則）。

## 原因
候補が `name_ja` の `localeCompare` でソートされており、漢字コード順でバラバラに見えていました。供給源 `ReleaseOption`（`RELEASE_OPTION_SELECT`）が `name_ja` のみ保持していたため。

## 変更
- `ReleaseOption` に `participantMemberKanas` を追加（型 + `RELEASE_OPTION_SELECT` に `name_kana` + `mapToReleaseOption`）
- `SongForm.participantOptions` を かな順（`localeCompare(_, "ja")`、同かなは name_ja でタイブレーク）でソート
- スキーマ変更なし（READ 拡張のみ）

## Non-goals
- 期別グルーピングは所属期が楽曲/リリースで曖昧になるため今回はスコープ外

## 確認
- `tsc --noEmit` / `eslint` 通過
- 手動: リリースを紐づけ、フォーメーションの候補がかな順で並ぶことを確認

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)