### PR TITLE
feat: フォーメーション表示から「◯列目」表記を削除（名前のみ）

### DIFF
--- a/apps/oshikatsu-web/components/songs/FormationDisplay.tsx
+++ b/apps/oshikatsu-web/components/songs/FormationDisplay.tsx
@@ -18,23 +18,16 @@ export function FormationDisplay({ rows }: FormationDisplayProps) {
       <h2 className="mb-4 text-sm font-medium text-foreground/70">
         フォーメーション
       </h2>
-      <div className="space-y-4">
+      <div className="space-y-3">
         {orderedRows.map((row) => (
-          <div key={row.rowNumber} className="space-y-1">
-            <div className="flex items-center gap-3">
-              <div className="h-px flex-1 bg-foreground/10" />
-              <span className="text-xs text-foreground/50">{row.rowNumber}列目</span>
-              <div className="h-px flex-1 bg-foreground/10" />
-            </div>
-            <p className="text-center text-sm text-foreground">
-              {row.members.map((member, index) => (
-                <span key={`${row.rowNumber}-${member.memberId}`}>
-                  {index > 0 && " ・ "}
-                  {member.memberNameJa}
-                </span>
-              ))}
-            </p>
-          </div>
+          <p key={row.rowNumber} className="text-center text-sm text-foreground">
+            {row.members.map((member, index) => (
+              <span key={`${row.rowNumber}-${member.memberId}`}>
+                {index > 0 && " ・ "}
+                {member.memberNameJa}
+              </span>
+            ))}
+          </p>
         ))}
       </div>
     </Card>


### PR DESCRIPTION
## 概要
楽曲詳細のフォーメーション表示から「◯列目」ラベル・区切り線を削除し、各段を中央寄せの名前の並びのみで表示します。

## 変更
- `FormationDisplay`: 段ラベル（`{row.rowNumber}列目` の区切りブロック）を削除。
- 段間の余白は `space-y-3` で維持。段の上下順（1列目=最下段, #154）は維持。
- 編集UI（`SongForm`）の「N列目」見出しは編集の手掛かりとして据え置き（表示側のみ変更）。

## 確認
- `tsc --noEmit` / `eslint` 通過
- 手動: 詳細フォーメーションが段ラベル無し・名前のみで表示されること

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)