### PR TITLE
feat: 参加メンバーに人数表示（期別内訳つき）

### DIFF
--- a/apps/oshikatsu-web/components/releases/ReleaseDetail.tsx
+++ b/apps/oshikatsu-web/components/releases/ReleaseDetail.tsx
@@ -6,6 +6,7 @@ import { GroupBadge } from "@/components/ui/GroupBadge";
 import { Card } from "@/components/ui/Card";
 import { formatDate } from "@/lib/formatters";
 import { resolveReleaseImageSrc } from "@/lib/releaseImage";
+import { formatMemberCountSummary } from "@/lib/memberCountSummary";
 
 type ReleaseDetailProps = {
   release: Release;
@@ -118,7 +119,12 @@ export function ReleaseDetail({ release }: ReleaseDetailProps) {
 
       {release.participantMemberNames.length > 0 && (
         <Card>
-          <h2 className="mb-3 text-sm font-medium text-foreground/70">参加メンバー</h2>
+          <div className="mb-3 flex items-baseline justify-between gap-2">
+            <h2 className="text-sm font-medium text-foreground/70">参加メンバー</h2>
+            <span className="text-xs text-foreground/60">
+              {formatMemberCountSummary(release.participantMemberGenerations)}
+            </span>
+          </div>
           <p className="text-sm text-foreground">{release.participantMemberNames.join(" / ")}</p>
         </Card>
       )}

--- a/apps/oshikatsu-web/lib/memberCountSummary.ts
+++ b/apps/oshikatsu-web/lib/memberCountSummary.ts
@@ -1,0 +1,38 @@
+// 参加メンバーの人数を「◯人（1期生◯人、2期生◯人…）」形式に整形する。
+// generation は数値想定の文字列。null/非数値（期不明）は「他◯人」として末尾にまとめる。
+export function formatMemberCountSummary(
+  generations: Array<string | null>
+): string {
+  const total = generations.length;
+  if (total === 0) return "0人";
+
+  const countByGeneration = new Map<number, number>();
+  let unknownCount = 0;
+
+  for (const generation of generations) {
+    const parsed =
+      generation != null && generation.trim() !== ""
+        ? Number(generation)
+        : NaN;
+    if (Number.isInteger(parsed) && parsed > 0) {
+      countByGeneration.set(parsed, (countByGeneration.get(parsed) ?? 0) + 1);
+    } else {
+      unknownCount += 1;
+    }
+  }
+
+  // 期が1つも特定できない場合は内訳を出さず総数のみ
+  if (countByGeneration.size === 0) {
+    return `${total}人`;
+  }
+
+  const parts = Array.from(countByGeneration.entries())
+    .sort((a, b) => a[0] - b[0])
+    .map(([generation, count]) => `${generation}期生${count}人`);
+
+  if (unknownCount > 0) {
+    parts.push(`他${unknownCount}人`);
+  }
+
+  return `${total}人（${parts.join("、")}）`;
+}

--- a/apps/oshikatsu-web/repositories/releaseRepository.ts
+++ b/apps/oshikatsu-web/repositories/releaseRepository.ts
@@ -207,6 +207,7 @@ function mapToRelease(row: ReleaseRow): Release {
     trackCount: row.orbit_release_tracks?.length ?? 0,
     participantMemberIds: participants.map((member) => member.memberId),
     participantMemberNames: participants.map((member) => member.memberNameJa),
+    participantMemberGenerations: participants.map((member) => member.generation),
     bonusVideos: (row.orbit_release_bonus_videos ?? [])
       .map((bonus) => ({
         id: bonus.id,

--- a/apps/oshikatsu-web/types/release.ts
+++ b/apps/oshikatsu-web/types/release.ts
@@ -97,6 +97,7 @@ export type Release = {
   trackCount: number;
   participantMemberIds: string[];
   participantMemberNames: string[];
+  participantMemberGenerations: Array<string | null>;
   bonusVideos: ReleaseBonusVideo[];
   tracks: ReleaseTrack[];
 };


### PR DESCRIPTION
## 概要
リリース詳細の「参加メンバー」に **合計人数＋期別内訳**「◯人（1期生◯人、2期生◯人…）」を表示します。

## 変更
- `lib/memberCountSummary.ts` を追加（共通整形ヘルパー）。期不明は「他◯人」に集約、期が1つも特定できなければ総数のみ。
- `Release` に `participantMemberGenerations` を公開（`mapToRelease` は所属期を算出済みだったため公開のみ。スキーマ変更なし）。
- `ReleaseDetail` の参加メンバー見出し横にサマリを表示。

## スコープ / フォローアップ
- 本PRは **リリース詳細**（参加メンバーの主表示）に適用。
- 楽曲フォームの参加候補・ライブ出演メンバーは generation を現状未公開のため別PR候補（ヘルパーは再利用可能）。必要なら続けて対応します。

## 確認
- `tsc --noEmit` / `eslint` 通過
- 手動: リリース詳細で「◯人（◯期生◯人…）」が表示されること

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)