### PR TITLE
feat: フォーメーションにセンター指定（1列目限定・Wセンター可）

### DIFF
--- a/apps/oshikatsu-web/app/(authenticated)/admin/songs/[id]/edit/page.tsx
+++ b/apps/oshikatsu-web/app/(authenticated)/admin/songs/[id]/edit/page.tsx
@@ -57,6 +57,9 @@ export default async function EditSongPage({
       memberCount: String(row.memberCount),
       memberIds: row.members.map((member) => member.memberId),
     })),
+    centerMemberIds: song.formationRows.flatMap((row) =>
+      row.members.filter((member) => member.isCenter).map((member) => member.memberId)
+    ),
     mv: {
       url: song.mv?.url ?? "",
       directorName: song.mv?.directorName ?? "",

--- a/apps/oshikatsu-web/components/admin/SongForm.tsx
+++ b/apps/oshikatsu-web/components/admin/SongForm.tsx
@@ -100,6 +100,7 @@ function getDefaultValues(): FormValues {
     arrangementPeople: "",
     choreographyPeople: "",
     formationRows: [],
+    centerMemberIds: [],
     mv: {
       url: "",
       directorName: "",
@@ -138,6 +139,7 @@ function toSubmitValues(values: FormValues): CreateSongInput {
       memberCount: row.memberCount,
       memberIds: row.memberIds,
     })),
+    centerMemberIds: values.centerMemberIds,
     mv: values.mv,
     costumes: values.costumes.map((costume) => ({
       stylistName: costume.stylistName,
@@ -336,6 +338,19 @@ export function SongForm({
     }));
   }, [participantOptions]);
 
+  // 1列目(最前列)に居なくなったメンバーはセンター指定から外す
+  useEffect(() => {
+    setValues((prev) => {
+      const frontRow = prev.formationRows[0];
+      const allowed = new Set(frontRow ? frontRow.memberIds : []);
+      const filtered = prev.centerMemberIds.filter((memberId) =>
+        allowed.has(memberId)
+      );
+      if (filtered.length === prev.centerMemberIds.length) return prev;
+      return { ...prev, centerMemberIds: filtered };
+    });
+  }, [values.formationRows]);
+
   const update = <K extends keyof FormValues>(
     field: K,
     value: FormValues[K]
@@ -502,6 +517,25 @@ export function SongForm({
         };
       }),
     }));
+  };
+
+  // センター（1列目・最大2人）の指定を切り替える
+  const toggleCenter = (memberId: string) => {
+    setValues((prev) => {
+      if (prev.centerMemberIds.includes(memberId)) {
+        return {
+          ...prev,
+          centerMemberIds: prev.centerMemberIds.filter((id) => id !== memberId),
+        };
+      }
+      if (prev.centerMemberIds.length >= 2) return prev;
+      return { ...prev, centerMemberIds: [...prev.centerMemberIds, memberId] };
+    });
+    setErrors((prev) => {
+      const next = { ...prev };
+      delete next.centerMemberIds;
+      return next;
+    });
   };
 
   // 列内のメンバー順（= slot_order = 左→右）をドラッグ&ドロップで入れ替える
@@ -965,6 +999,42 @@ export function SongForm({
                         </ul>
                       </SortableContext>
                     </DndContext>
+                  </div>
+                )}
+
+                {index === 0 && row.memberIds.length > 0 && (
+                  <div className="mt-2">
+                    <p className="mb-1 text-xs text-foreground/60">
+                      センター（1列目・最大2人）
+                    </p>
+                    <div className="flex flex-wrap gap-1.5">
+                      {row.memberIds.map((memberId) => {
+                        const isCenter = values.centerMemberIds.includes(memberId);
+                        const disabled =
+                          !isCenter && values.centerMemberIds.length >= 2;
+                        return (
+                          <button
+                            type="button"
+                            key={memberId}
+                            onClick={() => toggleCenter(memberId)}
+                            disabled={disabled}
+                            className={`rounded-full border px-2.5 py-1 text-xs transition-colors disabled:cursor-not-allowed disabled:opacity-40 ${
+                              isCenter
+                                ? "border-amber-400 bg-amber-100 text-amber-700"
+                                : "border-foreground/10 bg-background text-foreground hover:bg-foreground/5"
+                            }`}
+                          >
+                            {isCenter ? "★ " : ""}
+                            {participantNameById.get(memberId) ?? memberId}
+                          </button>
+                        );
+                      })}
+                    </div>
+                    {errors.centerMemberIds && (
+                      <p className="mt-1 text-xs text-red-500">
+                        {errors.centerMemberIds}
+                      </p>
+                    )}
                   </div>
                 )}
               </div>

--- a/apps/oshikatsu-web/components/songs/FormationDisplay.tsx
+++ b/apps/oshikatsu-web/components/songs/FormationDisplay.tsx
@@ -24,7 +24,13 @@ export function FormationDisplay({ rows }: FormationDisplayProps) {
             {row.members.map((member, index) => (
               <span key={`${row.rowNumber}-${member.memberId}`}>
                 {index > 0 && " ・ "}
-                {member.memberNameJa}
+                {member.isCenter ? (
+                  <span className="font-bold text-amber-600">
+                    ★{member.memberNameJa}
+                  </span>
+                ) : (
+                  member.memberNameJa
+                )}
               </span>
             ))}
           </p>

--- a/apps/oshikatsu-web/repositories/songRepository.ts
+++ b/apps/oshikatsu-web/repositories/songRepository.ts
@@ -84,6 +84,7 @@ type TrackCreditRow = {
 type FormationMemberRow = {
   member_id: string;
   slot_order: number;
+  is_center: boolean;
   orbit_members:
     | {
         name_ja: string;
@@ -240,6 +241,7 @@ const SONG_DETAIL_SELECT = `
       orbit_track_formation_members(
         member_id,
         slot_order,
+        is_center,
         orbit_members(name_ja)
       )
     )
@@ -371,6 +373,7 @@ function mapFormation(formationRel: FormationRel | undefined): SongFormationRow[
             memberId: member.member_id,
             memberNameJa: orbitMember?.name_ja ?? "",
             slotOrder: member.slot_order,
+            isCenter: member.is_center ?? false,
           };
         })
         .sort((a, b) => a.slotOrder - b.slotOrder);
@@ -746,6 +749,14 @@ export function createSongRepository(
         throw new RepositoryError("作成した楽曲IDの取得に失敗しました", null);
       }
 
+      const { error: centerError } = await supabase.rpc("set_track_centers", {
+        p_track_id: trackId,
+        p_center_member_ids: input.centerMemberIds,
+      });
+      if (centerError) {
+        throw new RepositoryError("センターの設定に失敗しました", centerError);
+      }
+
       const created = await this.findById(trackId);
       if (!created) {
         throw new RepositoryError("作成した楽曲の取得に失敗しました", null);
@@ -786,6 +797,14 @@ export function createSongRepository(
 
       if (rpcError) {
         throw new RepositoryError("楽曲の更新に失敗しました", rpcError);
+      }
+
+      const { error: centerError } = await supabase.rpc("set_track_centers", {
+        p_track_id: id,
+        p_center_member_ids: input.centerMemberIds,
+      });
+      if (centerError) {
+        throw new RepositoryError("センターの更新に失敗しました", centerError);
       }
 
       const updated = await this.findById(id);

--- a/apps/oshikatsu-web/supabase/migrations/039_add_formation_center.sql
+++ b/apps/oshikatsu-web/supabase/migrations/039_add_formation_center.sql
@@ -1,0 +1,45 @@
+-- ============================================================
+-- 039: フォーメーションにセンター(is_center)を追加
+-- ------------------------------------------------------------
+-- - センターは最前列(1列目 = row_number = 1)のメンバー限定
+-- - Wセンターを許容（最大2人。件数上限はアプリ側で検証）
+-- - 巨大RPCは変更せず、メイン更新の後に呼ぶ専用関数で設定する
+-- ============================================================
+
+ALTER TABLE public.orbit_track_formation_members
+  ADD COLUMN IF NOT EXISTS is_center BOOLEAN NOT NULL DEFAULT false;
+
+-- 楽曲のセンターを設定する。
+-- 既存指定を解除し、1列目(row_number = 1)のメンバーのうち指定IDのみ is_center=true にする。
+CREATE OR REPLACE FUNCTION public.set_track_centers(
+  p_track_id UUID,
+  p_center_member_ids JSONB
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+BEGIN
+  -- 既存のセンター指定を解除
+  UPDATE public.orbit_track_formation_members AS fm
+  SET is_center = false
+  FROM public.orbit_track_formation_rows AS fr
+  JOIN public.orbit_track_formations AS f ON f.id = fr.formation_id
+  WHERE fm.formation_row_id = fr.id
+    AND f.track_id = p_track_id
+    AND fm.is_center;
+
+  -- 1列目のメンバーのうち、指定IDをセンターに設定
+  UPDATE public.orbit_track_formation_members AS fm
+  SET is_center = true
+  FROM public.orbit_track_formation_rows AS fr
+  JOIN public.orbit_track_formations AS f ON f.id = fr.formation_id
+  WHERE fm.formation_row_id = fr.id
+    AND f.track_id = p_track_id
+    AND fr.row_number = 1
+    AND fm.member_id IN (
+      SELECT (value)::UUID
+      FROM jsonb_array_elements_text(COALESCE(p_center_member_ids, '[]'::JSONB)) AS t(value)
+    );
+END;
+$$;

--- a/apps/oshikatsu-web/types/song.ts
+++ b/apps/oshikatsu-web/types/song.ts
@@ -68,6 +68,7 @@ export type SongFormationMember = {
   memberId: string;
   memberNameJa: string;
   slotOrder: number;
+  isCenter: boolean;
 };
 
 export type SongFormationRow = {
@@ -173,6 +174,8 @@ export type CreateSongInput = {
   arrangementPeople: string;
   choreographyPeople: string;
   formationRows: CreateSongFormationRowInput[];
+  // フォーメーション1列目のセンター（Wセンター可・最大2人）
+  centerMemberIds: string[];
   mv: CreateSongMvInput;
   costumes: CreateSongCostumeInput[];
 };

--- a/apps/oshikatsu-web/usecases/validateSong.ts
+++ b/apps/oshikatsu-web/usecases/validateSong.ts
@@ -150,6 +150,27 @@ export function validateSong(input: CreateSongInput): ValidationError[] {
     }
   }
 
+  // センターは1列目(最前列)のメンバーから最大2人（Wセンター可）
+  if (input.centerMemberIds.length > 0) {
+    if (input.centerMemberIds.length > 2) {
+      errors.push({
+        field: "centerMemberIds",
+        message: "センターは最大2人まで指定できます",
+      });
+    }
+
+    const frontRowMemberIds = new Set(input.formationRows[0]?.memberIds ?? []);
+    const hasInvalidCenter = input.centerMemberIds.some(
+      (memberId) => !frontRowMemberIds.has(memberId)
+    );
+    if (hasInvalidCenter) {
+      errors.push({
+        field: "centerMemberIds",
+        message: "センターは1列目のメンバーから選んでください",
+      });
+    }
+  }
+
   const hasMvAnyField =
     input.mv.url.trim() ||
     input.mv.directorName.trim() ||


### PR DESCRIPTION
## 概要
楽曲フォーメーションの **センター**（最前列=1列目のメンバー、Wセンター=最大2人）を指定・表示できるようにします。

## ⚠️ マイグレーション適用が必要
`039_add_formation_center.sql` を Supabase に適用してください（ローカルでの実行検証は不可のため、**適用と保存往復テストはお手元でお願いします**）。
- `orbit_track_formation_members.is_center` 追加
- `set_track_centers(p_track_id, p_center_member_ids)` 追加（既存指定を解除し、1列目=`row_number=1` のメンバーのうち指定IDのみ `is_center=true`）

## 設計
- 巨大RPC（`update_track_with_relations`）は**変更せず**、メイン更新の後に `set_track_centers` を呼ぶ（リスク最小化）。`is_center` の UPDATE ポリシーは既存。
- センターの妥当性（**最大2人・1列目メンバーのみ**）は `validateSong` で検証（Wセンター許容）。

## 変更
- 型: `SongFormationMember.isCenter` / `CreateSongInput.centerMemberIds`
- repository: `SONG_DETAIL_SELECT` に `is_center`、`mapFormation` で読み出し、`create`/`update` で `set_track_centers` 呼び出し
- `SongForm`: 1列目に「センター（最大2人）」選択UI。列構成変更で1列目から外れたメンバーは自動的にセンター解除。
- `FormationDisplay`: センターを ★＋強調表示

## スコープ
- track（楽曲）単位のセンター。メンバー詳細の選抜履歴(#161)の「シングル単位センター」とは別レイヤー。
- `#160`（センター曲数）は本PRの `isCenter` を利用予定。

## 確認
- `tsc --noEmit` / `eslint` 通過
- 手動（要マイグレーション適用後）: 1列目からセンター1〜2人を指定→保存→詳細で★表示、再編集で復元

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)