### PR TITLE
feat: メンバー参加楽曲のサマリ＋トグル展開（センター曲数含む）

### DIFF
--- a/apps/oshikatsu-web/app/(authenticated)/members/[id]/page.tsx
+++ b/apps/oshikatsu-web/app/(authenticated)/members/[id]/page.tsx
@@ -19,7 +19,8 @@ export default async function MemberDetailPage({
   if (!data) {
     notFound();
   }
-  const { histories, mainGroupPenlightColorNames, member, songs } = data;
+  const { histories, mainGroupPenlightColorNames, member, songs, centerTrackIds } =
+    data;
 
   return (
     <div className="space-y-4">
@@ -41,6 +42,7 @@ export default async function MemberDetailPage({
         member={member}
         histories={histories}
         songs={songs}
+        centerTrackIds={centerTrackIds}
         mainGroupPenlightColorNames={mainGroupPenlightColorNames}
       />
     </div>

--- a/apps/oshikatsu-web/components/members/MemberProfile.tsx
+++ b/apps/oshikatsu-web/components/members/MemberProfile.tsx
@@ -1,10 +1,10 @@
 import Image from "next/image";
-import Link from "next/link";
 import type { ReactNode } from "react";
 import type { MemberWithGroups, MemberHistory } from "@/types/member";
 import type { Song } from "@/types/song";
 import { GroupBadge } from "@/components/ui/GroupBadge";
 import { Card } from "@/components/ui/Card";
+import { MemberSongsSection } from "@/components/members/MemberSongsSection";
 import { formatBirthday, calculateAge, formatDate } from "@/lib/formatters";
 import { resolveMemberImageSrc } from "@/lib/memberImage";
 import {
@@ -17,6 +17,7 @@ type MemberProfileProps = {
   member: MemberWithGroups;
   histories: MemberHistory[];
   songs: Song[];
+  centerTrackIds: string[];
   mainGroupPenlightColorNames?: string[];
 };
 
@@ -144,6 +145,7 @@ export function MemberProfile({
   member,
   histories,
   songs,
+  centerTrackIds,
   mainGroupPenlightColorNames = [],
 }: MemberProfileProps) {
   const age = member.dateOfBirth ? calculateAge(member.dateOfBirth) : null;
@@ -359,25 +361,7 @@ export function MemberProfile({
       )}
 
       {/* 参加楽曲 */}
-      {songs.length > 0 && (
-        <Card>
-          <h2 className="mb-3 text-sm font-medium text-foreground/70">参加楽曲</h2>
-          <div className="space-y-2">
-            {songs.map((song) => (
-              <Link
-                key={song.id}
-                href={`/songs/${song.id}`}
-                className="block rounded-lg border border-foreground/10 px-3 py-2 text-sm text-foreground hover:bg-foreground/5"
-              >
-                <p className="font-medium">{song.title}</p>
-                {song.groupNameJa && (
-                  <p className="mt-1 text-xs text-foreground/50">{song.groupNameJa}</p>
-                )}
-              </Link>
-            ))}
-          </div>
-        </Card>
-      )}
+      <MemberSongsSection songs={songs} centerTrackIds={centerTrackIds} />
 
       {/* 来歴 */}
       {histories.length > 0 && (

--- a/apps/oshikatsu-web/components/members/MemberSongsSection.tsx
+++ b/apps/oshikatsu-web/components/members/MemberSongsSection.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { Card } from "@/components/ui/Card";
+import type { Song } from "@/types/song";
+import { SONG_LABELS, SONG_LABEL_LABELS } from "@/types/song";
+
+type MemberSongsSectionProps = {
+  songs: Song[];
+  centerTrackIds: string[];
+};
+
+// 参加楽曲は曲数が増えるため、初期はサマリ（合計＋ラベル別内訳＋センター曲数）のみ表示し、
+// トグルで全曲一覧を展開する。
+export function MemberSongsSection({
+  songs,
+  centerTrackIds,
+}: MemberSongsSectionProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  if (songs.length === 0) {
+    return null;
+  }
+
+  const centerTrackIdSet = new Set(centerTrackIds);
+  const centerCount = songs.filter((song) =>
+    centerTrackIdSet.has(song.id)
+  ).length;
+
+  const countByLabel = new Map<string, number>();
+  let noLabelCount = 0;
+  for (const song of songs) {
+    if (song.label) {
+      countByLabel.set(song.label, (countByLabel.get(song.label) ?? 0) + 1);
+    } else {
+      noLabelCount += 1;
+    }
+  }
+
+  const breakdown = SONG_LABELS.filter(
+    (label) => (countByLabel.get(label) ?? 0) > 0
+  ).map((label) => `${SONG_LABEL_LABELS[label]}${countByLabel.get(label)}曲`);
+  if (noLabelCount > 0) {
+    breakdown.push(`その他${noLabelCount}曲`);
+  }
+
+  return (
+    <Card>
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <h2 className="text-sm font-medium text-foreground/70">参加楽曲</h2>
+        <span className="text-sm font-medium text-foreground">
+          {songs.length}曲
+        </span>
+      </div>
+
+      {breakdown.length > 0 && (
+        <p className="text-xs text-foreground/60">{breakdown.join("、")}</p>
+      )}
+      {centerCount > 0 && (
+        <p className="mt-1 text-xs font-medium text-amber-600">
+          ★ センター {centerCount}曲
+        </p>
+      )}
+
+      <button
+        type="button"
+        onClick={() => setIsExpanded((prev) => !prev)}
+        className="mt-3 text-xs text-foreground/60 hover:text-foreground"
+      >
+        {isExpanded ? "閉じる ▲" : "全曲を表示 ▼"}
+      </button>
+
+      {isExpanded && (
+        <div className="mt-2 space-y-2">
+          {songs.map((song) => {
+            const isCenter = centerTrackIdSet.has(song.id);
+            return (
+              <Link
+                key={song.id}
+                href={`/songs/${song.id}`}
+                className="block rounded-lg border border-foreground/10 px-3 py-2 text-sm text-foreground hover:bg-foreground/5"
+              >
+                <p className="font-medium">
+                  {isCenter && <span className="text-amber-600">★ </span>}
+                  {song.title}
+                </p>
+                {song.groupNameJa && (
+                  <p className="mt-1 text-xs text-foreground/50">
+                    {song.groupNameJa}
+                  </p>
+                )}
+              </Link>
+            );
+          })}
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/apps/oshikatsu-web/repositories/songRepository.ts
+++ b/apps/oshikatsu-web/repositories/songRepository.ts
@@ -645,6 +645,41 @@ export function createSongRepository(
     return (data as unknown as SongRow[]).map(mapSong);
   }
 
+  // フォーメーション列(formation_row)の集合から、所属する楽曲(track)IDを解決する
+  async function resolveTrackIdsFromRowIds(rowIds: string[]): Promise<string[]> {
+    if (rowIds.length === 0) return [];
+
+    const { data: formationRows, error: formationRowsError } = await supabase
+      .from("orbit_track_formation_rows")
+      .select("formation_id")
+      .in("id", rowIds);
+
+    if (formationRowsError) {
+      throw new RepositoryError("参加楽曲の取得に失敗しました", formationRowsError);
+    }
+
+    const formationIds = uniqueStrings(
+      ((formationRows as Array<{ formation_id: string }>) ?? []).map(
+        (row) => row.formation_id
+      )
+    );
+
+    if (formationIds.length === 0) return [];
+
+    const { data: formations, error: formationsError } = await supabase
+      .from("orbit_track_formations")
+      .select("track_id")
+      .in("id", formationIds);
+
+    if (formationsError) {
+      throw new RepositoryError("参加楽曲の取得に失敗しました", formationsError);
+    }
+
+    return uniqueStrings(
+      ((formations as Array<{ track_id: string }>) ?? []).map((row) => row.track_id)
+    );
+  }
+
   return {
     async findAll(filters) {
       let query = supabase
@@ -839,41 +874,27 @@ export function createSongRepository(
         ((memberRows as Array<{ formation_row_id: string }>) ?? []).map((row) => row.formation_row_id)
       );
 
-      if (formationRowIds.length === 0) {
-        return [];
-      }
-
-      const { data: formationRows, error: formationRowsError } = await supabase
-        .from("orbit_track_formation_rows")
-        .select("formation_id")
-        .in("id", formationRowIds);
-
-      if (formationRowsError) {
-        throw new RepositoryError("参加楽曲の取得に失敗しました", formationRowsError);
-      }
-
-      const formationIds = uniqueStrings(
-        ((formationRows as Array<{ formation_id: string }>) ?? []).map((row) => row.formation_id)
-      );
-
-      if (formationIds.length === 0) {
-        return [];
-      }
-
-      const { data: formations, error: formationsError } = await supabase
-        .from("orbit_track_formations")
-        .select("track_id")
-        .in("id", formationIds);
-
-      if (formationsError) {
-        throw new RepositoryError("参加楽曲の取得に失敗しました", formationsError);
-      }
-
-      const trackIds = uniqueStrings(
-        ((formations as Array<{ track_id: string }>) ?? []).map((row) => row.track_id)
-      );
+      const trackIds = await resolveTrackIdsFromRowIds(formationRowIds);
 
       return findManyByIds(trackIds, SONG_LIST_SELECT);
+    },
+
+    async findCenterTrackIdsByMemberId(memberId) {
+      const { data: centerRows, error: centerRowsError } = await supabase
+        .from("orbit_track_formation_members")
+        .select("formation_row_id")
+        .eq("member_id", memberId)
+        .eq("is_center", true);
+
+      if (centerRowsError) {
+        throw new RepositoryError("センター楽曲の取得に失敗しました", centerRowsError);
+      }
+
+      const centerRowIds = uniqueStrings(
+        ((centerRows as Array<{ formation_row_id: string }>) ?? []).map((row) => row.formation_row_id)
+      );
+
+      return resolveTrackIdsFromRowIds(centerRowIds);
     },
   };
 }

--- a/apps/oshikatsu-web/types/repositories.ts
+++ b/apps/oshikatsu-web/types/repositories.ts
@@ -142,6 +142,7 @@ export type SongRepository = {
   update(id: string, input: UpdateSongInput): Promise<Song>;
   delete(id: string): Promise<void>;
   findByMemberId(memberId: string): Promise<Song[]>;
+  findCenterTrackIdsByMemberId(memberId: string): Promise<string[]>;
 };
 
 export type MemberImageRepository = {

--- a/apps/oshikatsu-web/usecases/readOrbitData.ts
+++ b/apps/oshikatsu-web/usecases/readOrbitData.ts
@@ -132,9 +132,10 @@ const loadMemberDetailPageData = createSharedReadLoader(
         return null;
       }
 
-      const [histories, songs] = await Promise.all([
+      const [histories, songs, centerTrackIds] = await Promise.all([
         eventRepo.findHistoryByMemberId(member.id),
         songRepo.findByMemberId(member.id),
+        songRepo.findCenterTrackIdsByMemberId(member.id),
       ]);
 
       const mainGroupId = member.groups[0]?.groupId;
@@ -149,6 +150,7 @@ const loadMemberDetailPageData = createSharedReadLoader(
         mainGroupPenlightColorNames,
         member,
         songs,
+        centerTrackIds,
       };
     })
 );


### PR DESCRIPTION
## 概要
メンバー詳細の「参加楽曲」を、初期は **サマリ（合計＋ラベル別内訳＋センター曲数）** のみ表示し、トグルで全曲一覧を展開できるようにします。

## 変更
- `songRepository`:
  - `findCenterTrackIdsByMemberId` を追加（メンバーが `is_center=true` の楽曲IDを取得。#159 の `is_center` を利用）
  - 列ID→楽曲ID解決を `resolveTrackIdsFromRowIds` に共通化し、`findByMemberId` をリファクタ
  - `SongRepository` 型に新メソッド追加
- `loadMemberDetailPageData`: `centerTrackIds` を返す
- `MemberSongsSection`（新規 client component）: 合計◯曲・ラベル別内訳（表題/選抜/…、ラベル無しは「その他」）・**★センター◯曲**、トグルで全曲展開（センター曲は★表示）
- `MemberProfile`: 参加楽曲セクションを上記コンポーネントに置換

## 確認
- `tsc --noEmit` / `eslint` 通過
- 手動: メンバー詳細でサマリ表示→トグルで全曲展開、センター曲数/★が出ること

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)