### PR TITLE
feat: シングルの選抜ポジション登録（#161 PR1/2・リリースフォーム）

### DIFF
--- a/apps/oshikatsu-web/app/(authenticated)/admin/releases/[id]/edit/page.tsx
+++ b/apps/oshikatsu-web/app/(authenticated)/admin/releases/[id]/edit/page.tsx
@@ -37,6 +37,13 @@ export default async function EditReleasePage({
     artworkPath: release.artworkPath ?? "",
     artworkPersonName: release.artworkPersonName ?? "",
     participantMemberIds: release.participantMemberIds,
+    memberPositions: release.memberPositions.map((position) => ({
+      memberId: position.memberId,
+      tier: position.tier,
+      rowNumber: position.rowNumber != null ? String(position.rowNumber) : "",
+      isCenter: position.isCenter,
+      isFrontSpecial: position.isFrontSpecial,
+    })),
     bonusVideos: release.bonusVideos.map((bonus) => ({
       edition: bonus.edition,
       title: bonus.title,

--- a/apps/oshikatsu-web/components/admin/ReleaseForm.tsx
+++ b/apps/oshikatsu-web/components/admin/ReleaseForm.tsx
@@ -19,6 +19,19 @@ const FRONT_SPECIAL_LABEL_BY_GROUP: Record<string, string> = {
   "乃木坂46": "福神",
   "櫻坂46": "櫻エイト",
 };
+
+// tier に応じてUIで表現できない従属フィールドをクリアし、保存内容を正規化する。
+function normalizePosition(
+  position: CreateReleaseMemberPositionInput
+): CreateReleaseMemberPositionInput {
+  if (position.tier === "" || position.tier === "generation") {
+    return { ...position, rowNumber: "", isCenter: false, isFrontSpecial: false };
+  }
+  if (position.tier === "under") {
+    return { ...position, isFrontSpecial: false };
+  }
+  return position;
+}
 import type { ValidationError } from "@/types/errors";
 import { Input } from "@/components/ui/Input";
 import { Select } from "@/components/ui/Select";
@@ -328,7 +341,7 @@ export function ReleaseForm({
         isCenter: false,
         isFrontSpecial: false,
       };
-      const nextPosition = { ...base, ...patch };
+      const nextPosition = normalizePosition({ ...base, ...patch });
       return {
         ...prev,
         memberPositions: exists

--- a/apps/oshikatsu-web/components/admin/ReleaseForm.tsx
+++ b/apps/oshikatsu-web/components/admin/ReleaseForm.tsx
@@ -109,7 +109,10 @@ function toFormValues(input: CreateReleaseInput): FormValues {
   };
 }
 
-function toSubmitValues(input: FormValues): CreateReleaseInput {
+function toSubmitValues(
+  input: FormValues,
+  supportsFrontSpecial: boolean
+): CreateReleaseInput {
   return {
     title: input.title,
     groupId: input.groupId,
@@ -122,9 +125,17 @@ function toSubmitValues(input: FormValues): CreateReleaseInput {
     // 選抜ポジションはシングルのみ・参加メンバーに限定して保存する
     memberPositions:
       input.releaseType === "single"
-        ? input.memberPositions.filter((position) =>
-            input.participantMemberIds.includes(position.memberId)
-          )
+        ? input.memberPositions
+            .filter((position) =>
+              input.participantMemberIds.includes(position.memberId)
+            )
+            // グループが福神/櫻エイト非対応なら front_special をクリア
+            .map((position) => ({
+              ...position,
+              isFrontSpecial: supportsFrontSpecial
+                ? position.isFrontSpecial
+                : false,
+            }))
         : [],
     bonusVideos: input.bonusVideos.map((bonus) => ({
       edition: bonus.edition,
@@ -511,7 +522,10 @@ export function ReleaseForm({
         }
       }
 
-      const result = await onSubmit(toSubmitValues(values), imageFile);
+      const result = await onSubmit(
+        toSubmitValues(values, frontSpecialLabel !== null),
+        imageFile
+      );
       if (result.errors) {
         const errorMap: Record<string, string> = {};
         for (const err of result.errors) {

--- a/apps/oshikatsu-web/components/admin/ReleaseForm.tsx
+++ b/apps/oshikatsu-web/components/admin/ReleaseForm.tsx
@@ -9,9 +9,16 @@ import {
   RELEASE_TYPE_LABELS,
   type CreateReleaseInput,
   type CreateReleaseBonusVideoInput,
+  type CreateReleaseMemberPositionInput,
   type CreateReleaseTrackLinkInput,
   type ReleaseImageUploadInput,
 } from "@/types/release";
+
+// 福神(乃木坂)/櫻エイト(櫻坂) のグループ別呼称。該当しないグループは front_special なし。
+const FRONT_SPECIAL_LABEL_BY_GROUP: Record<string, string> = {
+  "乃木坂46": "福神",
+  "櫻坂46": "櫻エイト",
+};
 import type { ValidationError } from "@/types/errors";
 import { Input } from "@/components/ui/Input";
 import { Select } from "@/components/ui/Select";
@@ -75,6 +82,7 @@ function getDefaultValues(): FormValues {
     artworkPath: "",
     artworkPersonName: "",
     participantMemberIds: [],
+    memberPositions: [],
     bonusVideos: [],
     trackLinks: [],
   };
@@ -98,6 +106,13 @@ function toSubmitValues(input: FormValues): CreateReleaseInput {
     artworkPath: input.artworkPath,
     artworkPersonName: input.artworkPersonName,
     participantMemberIds: input.participantMemberIds,
+    // 選抜ポジションはシングルのみ・参加メンバーに限定して保存する
+    memberPositions:
+      input.releaseType === "single"
+        ? input.memberPositions.filter((position) =>
+            input.participantMemberIds.includes(position.memberId)
+          )
+        : [],
     bonusVideos: input.bonusVideos.map((bonus) => ({
       edition: bonus.edition,
       title: bonus.title,
@@ -272,6 +287,56 @@ export function ReleaseForm({
       const next = { ...prev };
       delete next.participantMemberIds;
       return next;
+    });
+  };
+
+  const memberNameById = useMemo(
+    () => new Map(members.map((member) => [member.id, member.nameJa])),
+    [members]
+  );
+
+  const selectedGroupName = groups.find(
+    (group) => group.id === values.groupId
+  )?.nameJa;
+  const frontSpecialLabel = selectedGroupName
+    ? (FRONT_SPECIAL_LABEL_BY_GROUP[selectedGroupName] ?? null)
+    : null;
+
+  const getPosition = (memberId: string): CreateReleaseMemberPositionInput =>
+    values.memberPositions.find((position) => position.memberId === memberId) ?? {
+      memberId,
+      tier: "",
+      rowNumber: "",
+      isCenter: false,
+      isFrontSpecial: false,
+    };
+
+  const updatePosition = (
+    memberId: string,
+    patch: Partial<CreateReleaseMemberPositionInput>
+  ) => {
+    setValues((prev) => {
+      const exists = prev.memberPositions.some(
+        (position) => position.memberId === memberId
+      );
+      const base = prev.memberPositions.find(
+        (position) => position.memberId === memberId
+      ) ?? {
+        memberId,
+        tier: "" as CreateReleaseMemberPositionInput["tier"],
+        rowNumber: "",
+        isCenter: false,
+        isFrontSpecial: false,
+      };
+      const nextPosition = { ...base, ...patch };
+      return {
+        ...prev,
+        memberPositions: exists
+          ? prev.memberPositions.map((position) =>
+              position.memberId === memberId ? nextPosition : position
+            )
+          : [...prev.memberPositions, nextPosition],
+      };
     });
   };
 
@@ -792,6 +857,94 @@ export function ReleaseForm({
           )}
         </div>
       </div>
+
+      {values.releaseType === "single" &&
+        values.participantMemberIds.length > 0 && (
+          <div className="space-y-2">
+            <label className="block text-sm font-medium text-foreground/70">
+              選抜ポジション
+            </label>
+            <p className="text-xs text-foreground/50">
+              参加メンバーごとに位置を登録します（未設定はメンバー詳細に表示されません）。
+            </p>
+            <div className="space-y-2">
+              {values.participantMemberIds.map((memberId) => {
+                const position = getPosition(memberId);
+                const hasRow =
+                  position.tier === "senbatsu" || position.tier === "under";
+                return (
+                  <div
+                    key={memberId}
+                    className="rounded-lg border border-foreground/10 p-2"
+                  >
+                    <p className="mb-1 text-sm text-foreground">
+                      {memberNameById.get(memberId) ?? memberId}
+                    </p>
+                    <div className="flex flex-wrap items-center gap-2 text-xs">
+                      <select
+                        value={position.tier}
+                        onChange={(e) =>
+                          updatePosition(memberId, {
+                            tier: e.target
+                              .value as CreateReleaseMemberPositionInput["tier"],
+                          })
+                        }
+                        className="rounded-lg border border-foreground/10 bg-background px-2 py-1"
+                      >
+                        <option value="">未設定</option>
+                        <option value="senbatsu">選抜</option>
+                        <option value="under">アンダー</option>
+                        <option value="generation">期生</option>
+                      </select>
+                      {hasRow && (
+                        <input
+                          type="number"
+                          min={1}
+                          placeholder="列"
+                          value={position.rowNumber}
+                          onChange={(e) =>
+                            updatePosition(memberId, {
+                              rowNumber: e.target.value,
+                            })
+                          }
+                          className="w-16 rounded-lg border border-foreground/10 bg-background px-2 py-1"
+                        />
+                      )}
+                      {hasRow && (
+                        <label className="flex items-center gap-1">
+                          <input
+                            type="checkbox"
+                            checked={position.isCenter}
+                            onChange={(e) =>
+                              updatePosition(memberId, {
+                                isCenter: e.target.checked,
+                              })
+                            }
+                          />
+                          センター
+                        </label>
+                      )}
+                      {position.tier === "senbatsu" && frontSpecialLabel && (
+                        <label className="flex items-center gap-1">
+                          <input
+                            type="checkbox"
+                            checked={position.isFrontSpecial}
+                            onChange={(e) =>
+                              updatePosition(memberId, {
+                                isFrontSpecial: e.target.checked,
+                              })
+                            }
+                          />
+                          {frontSpecialLabel}
+                        </label>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
 
       <Button type="submit" disabled={isSubmitting || isUploadingImage} className="w-full">
         {isSubmitting || isUploadingImage

--- a/apps/oshikatsu-web/repositories/releaseRepository.ts
+++ b/apps/oshikatsu-web/repositories/releaseRepository.ts
@@ -5,7 +5,9 @@ import type {
   ReleaseType,
   ReleaseListItem,
   ReleaseOption,
+  SelectionTier,
 } from "@/types/release";
+import { SELECTION_TIERS } from "@/types/release";
 import type { ReleaseRepository } from "@/types/repositories";
 import { RepositoryError } from "@/types/errors";
 import { compareByGenerationThenName } from "@/lib/memberOrder";
@@ -58,6 +60,14 @@ type ReleaseMemberRow = {
   orbit_members: ReleaseMemberNameRow;
 };
 
+type ReleaseMemberPositionRow = {
+  member_id: string;
+  tier: string;
+  row_number: number | null;
+  is_center: boolean;
+  is_front_special: boolean;
+};
+
 type ReleaseTrackRow = {
   track_number: number;
   orbit_tracks?:
@@ -84,6 +94,7 @@ type ReleaseRow = {
   orbit_groups: ReleaseGroupRow;
   orbit_release_bonus_videos?: ReleaseBonusVideoRow[];
   orbit_release_members?: ReleaseMemberRow[];
+  orbit_release_member_positions?: ReleaseMemberPositionRow[];
   orbit_release_tracks?: ReleaseTrackRow[];
 };
 
@@ -139,6 +150,7 @@ const RELEASE_DETAIL_SELECT = `
   orbit_groups(name_ja, color),
   orbit_release_bonus_videos(id, edition, title, description, sort_order),
   orbit_release_members(member_id, orbit_members(name_ja, name_kana, orbit_member_groups(group_id, generation))),
+  orbit_release_member_positions(member_id, tier, row_number, is_center, is_front_special),
   orbit_release_tracks(track_number, orbit_tracks(id, title))
 `;
 
@@ -208,6 +220,17 @@ function mapToRelease(row: ReleaseRow): Release {
     participantMemberIds: participants.map((member) => member.memberId),
     participantMemberNames: participants.map((member) => member.memberNameJa),
     participantMemberGenerations: participants.map((member) => member.generation),
+    memberPositions: (row.orbit_release_member_positions ?? [])
+      .filter((position): position is ReleaseMemberPositionRow & { tier: SelectionTier } =>
+        (SELECTION_TIERS as readonly string[]).includes(position.tier)
+      )
+      .map((position) => ({
+        memberId: position.member_id,
+        tier: position.tier,
+        rowNumber: position.row_number,
+        isCenter: position.is_center,
+        isFrontSpecial: position.is_front_special,
+      })),
     bonusVideos: (row.orbit_release_bonus_videos ?? [])
       .map((bonus) => ({
         id: bonus.id,
@@ -289,6 +312,27 @@ function toTrackLinkRpcInput(
     trackId: trackLink.trackId,
     trackNumber: Number(trackLink.trackNumber),
   }));
+}
+
+function toMemberPositionRpcInput(
+  positions: CreateReleaseInput["memberPositions"]
+): Array<{
+  memberId: string;
+  tier: string;
+  rowNumber: number | null;
+  isCenter: boolean;
+  isFrontSpecial: boolean;
+}> {
+  return positions
+    .filter((position) => position.tier !== "")
+    .map((position) => ({
+      memberId: position.memberId,
+      tier: position.tier,
+      rowNumber:
+        position.rowNumber.trim() === "" ? null : Number(position.rowNumber),
+      isCenter: position.isCenter,
+      isFrontSpecial: position.isFrontSpecial,
+    }));
 }
 
 function toNumbering(
@@ -438,6 +482,17 @@ export function createReleaseRepository(
         throw new RepositoryError("作成したリリースIDの取得に失敗しました", null);
       }
 
+      const { error: positionsError } = await supabase.rpc(
+        "set_release_member_positions",
+        {
+          p_release_id: releaseId,
+          p_positions: toMemberPositionRpcInput(input.memberPositions),
+        }
+      );
+      if (positionsError) {
+        throw new RepositoryError("選抜ポジションの保存に失敗しました", positionsError);
+      }
+
       const created = await this.findById(releaseId);
       if (!created) {
         throw new RepositoryError("作成したリリースの取得に失敗しました", null);
@@ -469,6 +524,17 @@ export function createReleaseRepository(
 
       if (rpcError) {
         throw new RepositoryError("リリースの更新に失敗しました", rpcError);
+      }
+
+      const { error: positionsError } = await supabase.rpc(
+        "set_release_member_positions",
+        {
+          p_release_id: id,
+          p_positions: toMemberPositionRpcInput(input.memberPositions),
+        }
+      );
+      if (positionsError) {
+        throw new RepositoryError("選抜ポジションの保存に失敗しました", positionsError);
       }
 
       const updated = await this.findById(id);

--- a/apps/oshikatsu-web/supabase/migrations/040_add_release_member_positions.sql
+++ b/apps/oshikatsu-web/supabase/migrations/040_add_release_member_positions.sql
@@ -1,0 +1,73 @@
+-- ============================================================
+-- 040: シングルの選抜ポジション（メンバー × リリース）
+-- ------------------------------------------------------------
+-- - 選抜はシングルでのみ発生。リリース単位で各メンバーの位置を保持する
+-- - tier(選抜/アンダー/期生) + 列 + センター + 福神/櫻エイト の分解モデル
+-- - 巨大RPCは変更せず、専用関数で総入れ替えする
+-- ============================================================
+
+CREATE TABLE public.orbit_release_member_positions (
+  id               UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  release_id       UUID NOT NULL REFERENCES public.orbit_releases(id) ON DELETE CASCADE,
+  member_id        UUID NOT NULL REFERENCES public.orbit_members(id) ON DELETE CASCADE,
+  tier             TEXT NOT NULL CHECK (tier IN ('senbatsu', 'under', 'generation')),
+  row_number       INT CHECK (row_number IS NULL OR row_number > 0),
+  is_center        BOOLEAN NOT NULL DEFAULT false,
+  is_front_special BOOLEAN NOT NULL DEFAULT false,
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX idx_orbit_release_member_positions_unique
+  ON public.orbit_release_member_positions (release_id, member_id);
+CREATE INDEX idx_orbit_release_member_positions_member
+  ON public.orbit_release_member_positions (member_id);
+
+ALTER TABLE public.orbit_release_member_positions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "orbit_release_member_positions_select"
+  ON public.orbit_release_member_positions FOR SELECT
+  USING ((select auth.role()) = 'authenticated');
+CREATE POLICY "orbit_release_member_positions_insert"
+  ON public.orbit_release_member_positions FOR INSERT
+  WITH CHECK ((select auth.role()) = 'authenticated');
+CREATE POLICY "orbit_release_member_positions_update"
+  ON public.orbit_release_member_positions FOR UPDATE
+  USING ((select auth.role()) = 'authenticated');
+CREATE POLICY "orbit_release_member_positions_delete"
+  ON public.orbit_release_member_positions FOR DELETE
+  USING ((select auth.role()) = 'authenticated');
+
+-- リリースの選抜ポジションを総入れ替えする。
+-- tier が無い項目は無視（=未設定メンバーは保持しない）。
+CREATE OR REPLACE FUNCTION public.set_release_member_positions(
+  p_release_id UUID,
+  p_positions JSONB
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+BEGIN
+  DELETE FROM public.orbit_release_member_positions
+  WHERE release_id = p_release_id;
+
+  INSERT INTO public.orbit_release_member_positions (
+    release_id,
+    member_id,
+    tier,
+    row_number,
+    is_center,
+    is_front_special
+  )
+  SELECT
+    p_release_id,
+    (item->>'memberId')::UUID,
+    item->>'tier',
+    NULLIF(item->>'rowNumber', '')::INT,
+    COALESCE((item->>'isCenter')::BOOLEAN, false),
+    COALESCE((item->>'isFrontSpecial')::BOOLEAN, false)
+  FROM jsonb_array_elements(COALESCE(p_positions, '[]'::JSONB)) AS item
+  WHERE NULLIF(item->>'tier', '') IS NOT NULL
+    AND NULLIF(item->>'memberId', '') IS NOT NULL;
+END;
+$$;

--- a/apps/oshikatsu-web/supabase/migrations/040_add_release_member_positions.sql
+++ b/apps/oshikatsu-web/supabase/migrations/040_add_release_member_positions.sql
@@ -68,6 +68,17 @@ BEGIN
     COALESCE((item->>'isFrontSpecial')::BOOLEAN, false)
   FROM jsonb_array_elements(COALESCE(p_positions, '[]'::JSONB)) AS item
   WHERE NULLIF(item->>'tier', '') IS NOT NULL
-    AND NULLIF(item->>'memberId', '') IS NOT NULL;
+    AND NULLIF(item->>'memberId', '') IS NOT NULL
+    -- 防御: シングルのみ
+    AND EXISTS (
+      SELECT 1 FROM public.orbit_releases r
+      WHERE r.id = p_release_id AND r.release_type = 'single'
+    )
+    -- 防御: 当該リリースの参加メンバーに限定
+    AND EXISTS (
+      SELECT 1 FROM public.orbit_release_members rm
+      WHERE rm.release_id = p_release_id
+        AND rm.member_id = (item->>'memberId')::UUID
+    );
 END;
 $$;

--- a/apps/oshikatsu-web/types/release.ts
+++ b/apps/oshikatsu-web/types/release.ts
@@ -98,8 +98,29 @@ export type Release = {
   participantMemberIds: string[];
   participantMemberNames: string[];
   participantMemberGenerations: Array<string | null>;
+  memberPositions: ReleaseMemberPosition[];
   bonusVideos: ReleaseBonusVideo[];
   tracks: ReleaseTrack[];
+};
+
+// シングルの選抜ポジション（メンバー × リリース）
+export const SELECTION_TIERS = ["senbatsu", "under", "generation"] as const;
+export type SelectionTier = (typeof SELECTION_TIERS)[number];
+
+export type ReleaseMemberPosition = {
+  memberId: string;
+  tier: SelectionTier;
+  rowNumber: number | null;
+  isCenter: boolean;
+  isFrontSpecial: boolean;
+};
+
+export type CreateReleaseMemberPositionInput = {
+  memberId: string;
+  tier: SelectionTier | "";
+  rowNumber: string;
+  isCenter: boolean;
+  isFrontSpecial: boolean;
 };
 
 export type ReleaseListItem = {
@@ -148,6 +169,7 @@ export type CreateReleaseInput = {
   artworkPath: string;
   artworkPersonName: string;
   participantMemberIds: string[];
+  memberPositions: CreateReleaseMemberPositionInput[];
   bonusVideos: CreateReleaseBonusVideoInput[];
   trackLinks: CreateReleaseTrackLinkInput[];
 };

--- a/apps/oshikatsu-web/usecases/validateRelease.ts
+++ b/apps/oshikatsu-web/usecases/validateRelease.ts
@@ -1,11 +1,15 @@
 import type { CreateReleaseInput } from "@/types/release";
 import type { ValidationError } from "@/types/errors";
-import { RELEASE_TYPES } from "@/types/release";
+import { RELEASE_TYPES, SELECTION_TIERS } from "@/types/release";
 import { isValidDateString } from "@/lib/validation";
 import { isReleaseArtworkPath } from "@/lib/releaseImage";
 
 function isReleaseType(value: string): boolean {
   return (RELEASE_TYPES as readonly string[]).includes(value);
+}
+
+function isSelectionTier(value: string): boolean {
+  return (SELECTION_TIERS as readonly string[]).includes(value);
 }
 
 export function validateRelease(input: CreateReleaseInput): ValidationError[] {
@@ -129,6 +133,73 @@ export function validateRelease(input: CreateReleaseInput): ValidationError[] {
       break;
     }
     seenMemberIds.add(memberId);
+  }
+
+  // 選抜ポジション：シングルのみ・参加メンバー限定・組み合わせ妥当性
+  const participantMemberIdSet = new Set(input.participantMemberIds);
+  const seenPositionMemberIds = new Set<string>();
+  for (const position of input.memberPositions) {
+    if (position.tier === "") continue; // 未設定は保存対象外
+
+    if (input.releaseType !== "single") {
+      errors.push({
+        field: "memberPositions",
+        message: "選抜ポジションはシングルでのみ設定できます",
+      });
+      break;
+    }
+    if (!isSelectionTier(position.tier)) {
+      errors.push({ field: "memberPositions", message: "選抜区分の値が不正です" });
+      break;
+    }
+    if (!participantMemberIdSet.has(position.memberId)) {
+      errors.push({
+        field: "memberPositions",
+        message: "選抜ポジションは参加メンバーにのみ設定できます",
+      });
+      break;
+    }
+    if (seenPositionMemberIds.has(position.memberId)) {
+      errors.push({
+        field: "memberPositions",
+        message: "同じメンバーの選抜ポジションが重複しています",
+      });
+      break;
+    }
+    seenPositionMemberIds.add(position.memberId);
+
+    const hasRow = position.tier === "senbatsu" || position.tier === "under";
+    if (position.rowNumber.trim() !== "") {
+      if (!hasRow) {
+        errors.push({
+          field: "memberPositions",
+          message: "列は選抜/アンダーのみ指定できます",
+        });
+        break;
+      }
+      const rowNumber = Number(position.rowNumber);
+      if (!Number.isInteger(rowNumber) || rowNumber <= 0) {
+        errors.push({
+          field: "memberPositions",
+          message: "列は1以上の整数で入力してください",
+        });
+        break;
+      }
+    }
+    if (position.isCenter && !hasRow) {
+      errors.push({
+        field: "memberPositions",
+        message: "センターは選抜/アンダーのみ設定できます",
+      });
+      break;
+    }
+    if (position.isFrontSpecial && position.tier !== "senbatsu") {
+      errors.push({
+        field: "memberPositions",
+        message: "福神/櫻エイトは選抜のみ設定できます",
+      });
+      break;
+    }
   }
 
   const seenTrackIds = new Set<string>();


### PR DESCRIPTION
## 概要
#161 の **登録基盤（PR1）**。メンバー × リリースの「選抜ポジション」を保持・登録できるようにします。表示（メンバー詳細）は **PR2** で実装します。

## ⚠️ マイグレーション適用が必要
`040_add_release_member_positions.sql` を Supabase に適用してください（ローカル実行検証不可のため、適用＋保存往復テストはお手元でお願いします）。
- 新規 `orbit_release_member_positions`（release_id, member_id, tier, row_number, is_center, is_front_special、UNIQUE(release_id, member_id)）
- `set_release_member_positions(release_id, positions[])`（巨大RPCは不変、後段で総入れ替え）

## データモデル（確定）
分解モデル: `tier`(senbatsu/under/generation) ＋ `row_number` ＋ `is_center` ＋ `is_front_special`。
- 福神(乃木坂)/櫻エイト(櫻坂)は `is_front_special`。日向坂は無し。
- 期は所属から自動（このテーブルには持たない）。
- 選抜はシングルのみ → 登録UIはシングル時のみ表示。

## 変更
- 型: `ReleaseMemberPosition` / `CreateReleaseMemberPositionInput` / `Release.memberPositions`
- repository: 詳細取得に positions を含め、`create`/`update` で `set_release_member_positions` 呼び出し（参加メンバー・シングルに限定）
- `ReleaseForm`: シングル時に参加メンバーごとの位置入力（tier / 列 / センター / 福神・櫻エイト）。福神・櫻エイトは乃木坂/櫻坂のみ表示。

## 確認
- `tsc --noEmit` / `eslint` 通過
- 手動（要マイグレーション適用後）: シングルのリリース編集で各メンバーに tier/列/センター/福神 を設定→保存→再編集で復元

## 次（PR2）
メンバー詳細に「選抜ポジション履歴」を numbering 順（20th/42nd…）で表示。ラベル文字列は #161 のコメント案をベースに最終調整。

Refs #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)