### PR TITLE
feat: メンバー詳細にシングル別の選抜ポジションを表示（#161 PR2/2）

### DIFF
--- a/apps/oshikatsu-web/app/(authenticated)/members/[id]/page.tsx
+++ b/apps/oshikatsu-web/app/(authenticated)/members/[id]/page.tsx
@@ -19,8 +19,14 @@ export default async function MemberDetailPage({
   if (!data) {
     notFound();
   }
-  const { histories, mainGroupPenlightColorNames, member, songs, centerTrackIds } =
-    data;
+  const {
+    histories,
+    mainGroupPenlightColorNames,
+    member,
+    songs,
+    centerTrackIds,
+    selectionPositions,
+  } = data;
 
   return (
     <div className="space-y-4">
@@ -43,6 +49,7 @@ export default async function MemberDetailPage({
         histories={histories}
         songs={songs}
         centerTrackIds={centerTrackIds}
+        selectionPositions={selectionPositions}
         mainGroupPenlightColorNames={mainGroupPenlightColorNames}
       />
     </div>

--- a/apps/oshikatsu-web/components/members/MemberProfile.tsx
+++ b/apps/oshikatsu-web/components/members/MemberProfile.tsx
@@ -2,6 +2,7 @@ import Image from "next/image";
 import type { ReactNode } from "react";
 import type { MemberWithGroups, MemberHistory } from "@/types/member";
 import type { Song } from "@/types/song";
+import { ordinalNumber } from "@/types/release";
 import { GroupBadge } from "@/components/ui/GroupBadge";
 import { Card } from "@/components/ui/Card";
 import { MemberSongsSection } from "@/components/members/MemberSongsSection";
@@ -13,11 +14,18 @@ import {
   isHttpUrl,
 } from "@/lib/linkParser";
 
+type MemberSelectionPositionView = {
+  releaseId: string;
+  numbering: number | null;
+  label: string;
+};
+
 type MemberProfileProps = {
   member: MemberWithGroups;
   histories: MemberHistory[];
   songs: Song[];
   centerTrackIds: string[];
+  selectionPositions: MemberSelectionPositionView[];
   mainGroupPenlightColorNames?: string[];
 };
 
@@ -146,6 +154,7 @@ export function MemberProfile({
   histories,
   songs,
   centerTrackIds,
+  selectionPositions,
   mainGroupPenlightColorNames = [],
 }: MemberProfileProps) {
   const age = member.dateOfBirth ? calculateAge(member.dateOfBirth) : null;
@@ -357,6 +366,25 @@ export function MemberProfile({
               );
             })}
           </div>
+        </Card>
+      )}
+
+      {/* 選抜ポジション（シングル別） */}
+      {selectionPositions.length > 0 && (
+        <Card>
+          <h2 className="mb-3 text-sm font-medium text-foreground/70">選抜ポジション</h2>
+          <ul className="space-y-1 text-sm">
+            {selectionPositions.map((position) => (
+              <li key={position.releaseId} className="flex items-baseline gap-3">
+                <span className="w-12 shrink-0 text-foreground/50">
+                  {position.numbering != null
+                    ? ordinalNumber(position.numbering)
+                    : "—"}
+                </span>
+                <span className="text-foreground">{position.label}</span>
+              </li>
+            ))}
+          </ul>
         </Card>
       )}
 

--- a/apps/oshikatsu-web/lib/selectionPositionLabel.ts
+++ b/apps/oshikatsu-web/lib/selectionPositionLabel.ts
@@ -1,0 +1,41 @@
+import type { MemberSelectionPosition } from "@/types/release";
+
+// アンダーのグループ別呼称（乃木坂=アンダー / 櫻坂=BACKS / 日向坂=ひなた坂）
+const UNDER_LABEL_BY_GROUP: Record<string, string> = {
+  "乃木坂46": "アンダー",
+  "櫻坂46": "BACKS",
+  "日向坂46": "ひなた坂",
+};
+
+// 福神(乃木坂) / 櫻エイト(櫻坂)。該当しないグループは front_special なし
+const FRONT_SPECIAL_LABEL_BY_GROUP: Record<string, string> = {
+  "乃木坂46": "福神",
+  "櫻坂46": "櫻エイト",
+};
+
+// 選抜ポジションを表示用ラベルに変換する。
+// 優先度: センター → 福神/櫻エイト → 選抜(列) / アンダー(列) / ◯期生
+export function formatSelectionPositionLabel(
+  position: MemberSelectionPosition,
+  generation: string | null
+): string {
+  const rowSuffix = position.rowNumber != null ? `${position.rowNumber}列目` : "";
+
+  if (position.tier === "generation") {
+    return generation ? `${generation}期生` : "期生";
+  }
+
+  if (position.tier === "under") {
+    const underLabel = UNDER_LABEL_BY_GROUP[position.groupNameJa] ?? "アンダー";
+    if (position.isCenter) return `${underLabel}センター`;
+    return rowSuffix ? `${underLabel}${rowSuffix}` : underLabel;
+  }
+
+  // senbatsu
+  if (position.isCenter) return "センター";
+  if (position.isFrontSpecial) {
+    const frontLabel = FRONT_SPECIAL_LABEL_BY_GROUP[position.groupNameJa];
+    if (frontLabel) return rowSuffix ? `${frontLabel}${rowSuffix}` : frontLabel;
+  }
+  return rowSuffix ? `選抜${rowSuffix}` : "選抜";
+}

--- a/apps/oshikatsu-web/repositories/releaseRepository.ts
+++ b/apps/oshikatsu-web/repositories/releaseRepository.ts
@@ -6,6 +6,7 @@ import type {
   ReleaseListItem,
   ReleaseOption,
   SelectionTier,
+  MemberSelectionPosition,
 } from "@/types/release";
 import { SELECTION_TIERS } from "@/types/release";
 import type { ReleaseRepository } from "@/types/repositories";
@@ -314,6 +315,59 @@ function toTrackLinkRpcInput(
   }));
 }
 
+const MEMBER_POSITION_SELECT = `
+  tier,
+  row_number,
+  is_center,
+  is_front_special,
+  orbit_releases(id, title, numbering, release_type, group_id, orbit_groups(name_ja))
+`;
+
+type MemberPositionReleaseRow = {
+  id: string;
+  title: string;
+  numbering: number | null;
+  release_type: ReleaseType;
+  group_id: string;
+  orbit_groups: { name_ja: string } | { name_ja: string }[] | null;
+};
+
+type MemberPositionRow = {
+  tier: string;
+  row_number: number | null;
+  is_center: boolean;
+  is_front_special: boolean;
+  orbit_releases: MemberPositionReleaseRow | MemberPositionReleaseRow[] | null;
+};
+
+function mapMemberPosition(
+  row: MemberPositionRow
+): MemberSelectionPosition | null {
+  const release = Array.isArray(row.orbit_releases)
+    ? row.orbit_releases[0]
+    : row.orbit_releases;
+  if (!release) return null;
+  // 選抜はシングルのみ。tier が不正な行も除外する
+  if (release.release_type !== "single") return null;
+  if (!(SELECTION_TIERS as readonly string[]).includes(row.tier)) return null;
+
+  const group = Array.isArray(release.orbit_groups)
+    ? release.orbit_groups[0]
+    : release.orbit_groups;
+
+  return {
+    releaseId: release.id,
+    releaseTitle: release.title,
+    numbering: release.numbering,
+    groupId: release.group_id,
+    groupNameJa: group?.name_ja ?? "",
+    tier: row.tier as SelectionTier,
+    rowNumber: row.row_number,
+    isCenter: row.is_center,
+    isFrontSpecial: row.is_front_special,
+  };
+}
+
 function toMemberPositionRpcInput(
   positions: CreateReleaseInput["memberPositions"]
 ): Array<{
@@ -456,6 +510,24 @@ export function createReleaseRepository(
       }
 
       return mapToRelease(data as ReleaseRow);
+    },
+
+    async findSelectionPositionsByMemberId(memberId) {
+      const { data, error } = await supabase
+        .from("orbit_release_member_positions")
+        .select(MEMBER_POSITION_SELECT)
+        .eq("member_id", memberId);
+
+      if (error) {
+        throw new RepositoryError("選抜ポジションの取得に失敗しました", error);
+      }
+
+      return ((data as unknown as MemberPositionRow[]) ?? [])
+        .map(mapMemberPosition)
+        .filter(
+          (position): position is MemberSelectionPosition => position !== null
+        )
+        .sort((a, b) => (a.numbering ?? 0) - (b.numbering ?? 0));
     },
 
     async create(input) {

--- a/apps/oshikatsu-web/types/release.ts
+++ b/apps/oshikatsu-web/types/release.ts
@@ -123,6 +123,19 @@ export type CreateReleaseMemberPositionInput = {
   isFrontSpecial: boolean;
 };
 
+// メンバー詳細で表示する、シングルごとの選抜ポジション
+export type MemberSelectionPosition = {
+  releaseId: string;
+  releaseTitle: string;
+  numbering: number | null;
+  groupId: string;
+  groupNameJa: string;
+  tier: SelectionTier;
+  rowNumber: number | null;
+  isCenter: boolean;
+  isFrontSpecial: boolean;
+};
+
 export type ReleaseListItem = {
   id: string;
   title: string;

--- a/apps/oshikatsu-web/types/repositories.ts
+++ b/apps/oshikatsu-web/types/repositories.ts
@@ -46,6 +46,7 @@ import type {
   ReleaseFilters,
   ReleaseListItem,
   ReleaseOption,
+  MemberSelectionPosition,
 } from "./release";
 
 export type GroupRepository = {
@@ -128,6 +129,9 @@ export type ReleaseRepository = {
   findCalendarItems(): Promise<ReleaseCalendarItem[]>;
   findOptions(): Promise<ReleaseOption[]>;
   findById(id: string): Promise<Release | null>;
+  findSelectionPositionsByMemberId(
+    memberId: string
+  ): Promise<MemberSelectionPosition[]>;
   create(input: CreateReleaseInput): Promise<Release>;
   update(id: string, input: UpdateReleaseInput): Promise<Release>;
   delete(id: string): Promise<void>;

--- a/apps/oshikatsu-web/usecases/readOrbitData.ts
+++ b/apps/oshikatsu-web/usecases/readOrbitData.ts
@@ -6,6 +6,7 @@ import {
   isReadOnlyServerClientAvailable,
 } from "@personal-hub/supabase/read-only-server";
 import { ORBIT_CACHE_TAGS } from "@/lib/cacheTags";
+import { formatSelectionPositionLabel } from "@/lib/selectionPositionLabel";
 import { createEventRepository } from "@/repositories/eventRepository";
 import { createGroupRepository } from "@/repositories/groupRepository";
 import { createMemberRepository } from "@/repositories/memberRepository";
@@ -122,6 +123,7 @@ const loadMemberDetailPageData = createSharedReadLoader(
       const groupRepo = createGroupRepository(supabase);
       const eventRepo = createEventRepository(supabase);
       const songRepo = createSongRepository(supabase);
+      const releaseRepo = createReleaseRepository(supabase);
 
       const [member, groups] = await Promise.all([
         getMember(memberRepo, id),
@@ -132,11 +134,24 @@ const loadMemberDetailPageData = createSharedReadLoader(
         return null;
       }
 
-      const [histories, songs, centerTrackIds] = await Promise.all([
-        eventRepo.findHistoryByMemberId(member.id),
-        songRepo.findByMemberId(member.id),
-        songRepo.findCenterTrackIdsByMemberId(member.id),
-      ]);
+      const [histories, songs, centerTrackIds, rawSelectionPositions] =
+        await Promise.all([
+          eventRepo.findHistoryByMemberId(member.id),
+          songRepo.findByMemberId(member.id),
+          songRepo.findCenterTrackIdsByMemberId(member.id),
+          releaseRepo.findSelectionPositionsByMemberId(member.id),
+        ]);
+
+      // シングルごとの選抜ポジションを表示用ラベルに整形する（期は所属から）
+      const selectionPositions = rawSelectionPositions.map((position) => ({
+        releaseId: position.releaseId,
+        numbering: position.numbering,
+        label: formatSelectionPositionLabel(
+          position,
+          member.groups.find((group) => group.groupId === position.groupId)
+            ?.generation ?? null
+        ),
+      }));
 
       const mainGroupId = member.groups[0]?.groupId;
       const mainGroupPenlightColorNames = mainGroupId
@@ -151,6 +166,7 @@ const loadMemberDetailPageData = createSharedReadLoader(
         member,
         songs,
         centerTrackIds,
+        selectionPositions,
       };
     })
 );


### PR DESCRIPTION
## 概要
#161 の **表示（PR2）**。PR1(#168) で登録した選抜ポジションを、メンバー詳細に **シングル別（numbering順）** で表示します。マイグレーション不要（PR1のテーブルを利用）。

## 変更
- `releaseRepository.findSelectionPositionsByMemberId`: メンバーの選抜ポジションをリリース情報付きで取得（シングル限定・numbering昇順）
- `lib/selectionPositionLabel`: 表示ラベル導出
- `loadMemberDetailPageData`: `selectionPositions`（releaseId / numbering / label）を返す。期は所属から自動。
- `MemberProfile`: 「選抜ポジション」セクション（`20th / 42nd` 形式 ＋ ラベル）

## 表示ラベルの導出（要確認・調整可）
| 区分 | 表示 |
|---|---|
| センター（選抜） | `センター` |
| 福神(乃木坂)/櫻エイト(櫻坂) | `福神◯列目` / `櫻エイト◯列目` |
| 選抜 | `選抜◯列目` |
| アンダー center | `アンダーセンター`（櫻坂=`BACKSセンター`、日向坂=`ひなた坂センター`） |
| アンダー | `アンダー◯列目`（呼称はグループ別） |
| 期生枠 | `◯期生`（所属期から自動） |

> ご要望の「表題センター」等、ラベル文字列の希望があれば反映します（`lib/selectionPositionLabel.ts` の1か所）。

## 確認
- `tsc --noEmit` / `eslint` 通過
- 手動: シングルで選抜ポジションを登録したメンバーの詳細で、numbering順にラベル表示されること

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)