### PR TITLE
feat: 参加メンバー人数表示を楽曲フォーム候補・ライブ出演へ展開

### DIFF
--- a/apps/oshikatsu-web/components/admin/SongForm.tsx
+++ b/apps/oshikatsu-web/components/admin/SongForm.tsx
@@ -16,6 +16,7 @@ import { Input } from "@/components/ui/Input";
 import { Textarea } from "@/components/ui/Textarea";
 import { Button } from "@/components/ui/Button";
 import { RELEASE_TYPE_LABELS } from "@/types/release";
+import { formatMemberCountSummary } from "@/lib/memberCountSummary";
 import {
   DndContext,
   KeyboardSensor,
@@ -798,7 +799,10 @@ export function SongForm({
                 </div>
                 {selectedRelease && (
                   <p className="mt-2 text-xs text-foreground/50">
-                    参加メンバー {selectedRelease.participantMemberIds.length}人
+                    参加メンバー{" "}
+                    {formatMemberCountSummary(
+                      selectedRelease.participantMemberGenerations
+                    )}
                   </p>
                 )}
               </div>

--- a/apps/oshikatsu-web/components/lives/LiveDetail.tsx
+++ b/apps/oshikatsu-web/components/lives/LiveDetail.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/types/live";
 import { GroupBadge } from "@/components/ui/GroupBadge";
 import { formatMonthDayWithWeekday } from "@/lib/formatters";
+import { formatMemberCountSummary } from "@/lib/memberCountSummary";
 
 type LiveDetailProps = {
   live: Live;
@@ -120,6 +121,14 @@ export function LiveDetail({ live }: LiveDetailProps) {
               />
             ))}
           </div>
+        )}
+        {live.performerMembers.length > 0 && (
+          <p className="text-xs text-foreground/50">
+            出演メンバー{" "}
+            {formatMemberCountSummary(
+              live.performerMembers.map((member) => member.generation)
+            )}
+          </p>
         )}
       </div>
 

--- a/apps/oshikatsu-web/repositories/liveRepository.ts
+++ b/apps/oshikatsu-web/repositories/liveRepository.ts
@@ -223,7 +223,11 @@ function mapLive(row: LiveRow): Live {
           { generation: b.generation, nameKana: b.memberNameKana }
         )
       )
-      .map(({ memberId, memberNameJa }) => ({ memberId, memberNameJa })),
+      .map(({ memberId, memberNameJa, generation }) => ({
+        memberId,
+        memberNameJa,
+        generation,
+      })),
     performances: (row.orbit_live_performances ?? [])
       .map(mapPerformance)
       .sort((a, b) => {

--- a/apps/oshikatsu-web/repositories/releaseRepository.ts
+++ b/apps/oshikatsu-web/repositories/releaseRepository.ts
@@ -113,8 +113,16 @@ type ReleaseListRow = {
 type ReleaseOptionMemberRow = {
   member_id: string;
   orbit_members:
-    | { name_ja: string; name_kana: string }
-    | { name_ja: string; name_kana: string }[]
+    | {
+        name_ja: string;
+        name_kana: string;
+        orbit_member_groups: ReleaseMemberGroupRow[] | null;
+      }
+    | {
+        name_ja: string;
+        name_kana: string;
+        orbit_member_groups: ReleaseMemberGroupRow[] | null;
+      }[]
     | null;
 };
 
@@ -122,6 +130,7 @@ type ReleaseOptionRow = {
   id: string;
   title: string;
   release_type: ReleaseType;
+  group_id: string;
   orbit_release_members?: ReleaseOptionMemberRow[];
 };
 
@@ -170,7 +179,8 @@ const RELEASE_OPTION_SELECT = `
   id,
   title,
   release_type,
-  orbit_release_members(member_id, orbit_members(name_ja, name_kana))
+  group_id,
+  orbit_release_members(member_id, orbit_members(name_ja, name_kana, orbit_member_groups(group_id, generation)))
 `;
 
 function mapToRelease(row: ReleaseRow): Release {
@@ -285,11 +295,16 @@ function mapToReleaseOption(row: ReleaseOptionRow): ReleaseOption {
     const orbitMember = Array.isArray(member.orbit_members)
       ? member.orbit_members[0]
       : member.orbit_members;
+    // リリースのグループでの期を採用（無ければ null）
+    const membership = (orbitMember?.orbit_member_groups ?? []).find(
+      (mg) => mg.group_id === row.group_id
+    );
 
     return {
       memberId: member.member_id,
       memberNameJa: orbitMember?.name_ja ?? "",
       memberNameKana: orbitMember?.name_kana ?? "",
+      generation: membership?.generation ?? null,
     };
   });
 
@@ -300,6 +315,7 @@ function mapToReleaseOption(row: ReleaseOptionRow): ReleaseOption {
     participantMemberIds: participants.map((member) => member.memberId),
     participantMemberNames: participants.map((member) => member.memberNameJa),
     participantMemberKanas: participants.map((member) => member.memberNameKana),
+    participantMemberGenerations: participants.map((member) => member.generation),
   };
 }
 

--- a/apps/oshikatsu-web/types/live.ts
+++ b/apps/oshikatsu-web/types/live.ts
@@ -29,6 +29,7 @@ export type LivePerformerGroup = {
 export type LivePerformerMember = {
   memberId: string;
   memberNameJa: string;
+  generation: string | null;
 };
 
 export const SETLIST_ITEM_TYPE_VALUES = [

--- a/apps/oshikatsu-web/types/release.ts
+++ b/apps/oshikatsu-web/types/release.ts
@@ -160,6 +160,7 @@ export type ReleaseOption = {
   participantMemberIds: string[];
   participantMemberNames: string[];
   participantMemberKanas: string[];
+  participantMemberGenerations: Array<string | null>;
 };
 
 export type CreateReleaseBonusVideoInput = {


### PR DESCRIPTION
## 概要
#162 で導入した `formatMemberCountSummary` を、**楽曲フォームの参加候補**と**ライブ詳細の出演メンバー**にも展開します。マイグレーション不要。

## 変更
**楽曲フォーム**
- `ReleaseOption` に `participantMemberGenerations` を公開（`RELEASE_OPTION_SELECT` に `group_id` と `orbit_member_groups(group_id, generation)` を追加し、リリースのグループでの期を採用）
- `SongForm` の紐づけリリースの「参加メンバー N人」を **「◯人（◯期生◯人…）」** に

**ライブ**
- `LivePerformerMember` に `generation` を公開（既に `liveRepository` で算出済みだったが破棄していたものを保持）
- `LiveDetail` のヘッダに **「出演メンバー ◯人（◯期生◯人…）」** を表示（出演メンバーがいる場合）

## 確認
- `tsc --noEmit` / `eslint` 通過
- 手動: 楽曲フォームでリリース選択時の参加メンバー表示／ライブ詳細の出演メンバー人数が期別内訳付きで出ること

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)