### PR TITLE
feat: 選抜ポジションのアンダー呼称をグループ別表示

### DIFF
--- a/apps/oshikatsu-web/components/admin/ReleaseForm.tsx
+++ b/apps/oshikatsu-web/components/admin/ReleaseForm.tsx
@@ -13,12 +13,10 @@ import {
   type CreateReleaseTrackLinkInput,
   type ReleaseImageUploadInput,
 } from "@/types/release";
-
-// 福神(乃木坂)/櫻エイト(櫻坂) のグループ別呼称。該当しないグループは front_special なし。
-const FRONT_SPECIAL_LABEL_BY_GROUP: Record<string, string> = {
-  "乃木坂46": "福神",
-  "櫻坂46": "櫻エイト",
-};
+import {
+  getFrontSpecialSelectionLabel,
+  getUnderSelectionLabel,
+} from "@/lib/selectionPositionLabel";
 
 // tier に応じてUIで表現できない従属フィールドをクリアし、保存内容を正規化する。
 function normalizePosition(
@@ -322,9 +320,8 @@ export function ReleaseForm({
   const selectedGroupName = groups.find(
     (group) => group.id === values.groupId
   )?.nameJa;
-  const frontSpecialLabel = selectedGroupName
-    ? (FRONT_SPECIAL_LABEL_BY_GROUP[selectedGroupName] ?? null)
-    : null;
+  const underLabel = getUnderSelectionLabel(selectedGroupName);
+  const frontSpecialLabel = getFrontSpecialSelectionLabel(selectedGroupName);
 
   const getPosition = (memberId: string): CreateReleaseMemberPositionInput =>
     values.memberPositions.find((position) => position.memberId === memberId) ?? {
@@ -920,7 +917,7 @@ export function ReleaseForm({
                       >
                         <option value="">未設定</option>
                         <option value="senbatsu">選抜</option>
-                        <option value="under">アンダー</option>
+                        <option value="under">{underLabel}</option>
                         <option value="generation">期生</option>
                       </select>
                       {hasRow && (

--- a/apps/oshikatsu-web/lib/selectionPositionLabel.ts
+++ b/apps/oshikatsu-web/lib/selectionPositionLabel.ts
@@ -13,6 +13,20 @@ const FRONT_SPECIAL_LABEL_BY_GROUP: Record<string, string> = {
   "櫻坂46": "櫻エイト",
 };
 
+export function getUnderSelectionLabel(
+  groupNameJa: string | null | undefined
+): string {
+  return groupNameJa
+    ? (UNDER_LABEL_BY_GROUP[groupNameJa] ?? "アンダー")
+    : "アンダー";
+}
+
+export function getFrontSpecialSelectionLabel(
+  groupNameJa: string | null | undefined
+): string | null {
+  return groupNameJa ? (FRONT_SPECIAL_LABEL_BY_GROUP[groupNameJa] ?? null) : null;
+}
+
 // 選抜ポジションを表示用ラベルに変換する。
 // 優先度: センター → 福神/櫻エイト → 選抜(列) / アンダー(列) / ◯期生
 export function formatSelectionPositionLabel(
@@ -26,7 +40,7 @@ export function formatSelectionPositionLabel(
   }
 
   if (position.tier === "under") {
-    const underLabel = UNDER_LABEL_BY_GROUP[position.groupNameJa] ?? "アンダー";
+    const underLabel = getUnderSelectionLabel(position.groupNameJa);
     if (position.isCenter) return `${underLabel}センター`;
     return rowSuffix ? `${underLabel}${rowSuffix}` : underLabel;
   }
@@ -34,7 +48,7 @@ export function formatSelectionPositionLabel(
   // senbatsu
   if (position.isCenter) return "センター";
   if (position.isFrontSpecial) {
-    const frontLabel = FRONT_SPECIAL_LABEL_BY_GROUP[position.groupNameJa];
+    const frontLabel = getFrontSpecialSelectionLabel(position.groupNameJa);
     if (frontLabel) return rowSuffix ? `${frontLabel}${rowSuffix}` : frontLabel;
   }
   return rowSuffix ? `選抜${rowSuffix}` : "選抜";


### PR DESCRIPTION
## 概要
選抜ポジション入力の `under` 選択肢を、選択中のグループに応じた呼称で表示するようにしました。

## 変更内容
- `selectionPositionLabel` のアンダー/福神・櫻エイト呼称マップをヘルパー化
- `ReleaseForm` の選抜ポジション入力で `under` の表示を以下に切り替え
  - 乃木坂46: アンダー
  - 櫻坂46: BACKS
  - 日向坂46: ひなた坂
  - その他/未選択: アンダー
- 保存値は既存どおり `tier: "under"` のまま維持

## 確認
- `pnpm --filter oshikatsu-web typecheck`
- `pnpm --filter oshikatsu-web lint`

Closes #172