### PR TITLE
feat: 選抜ポジションに休業中を追加

### DIFF
--- a/apps/oshikatsu-web/components/admin/ReleaseForm.tsx
+++ b/apps/oshikatsu-web/components/admin/ReleaseForm.tsx
@@ -23,7 +23,11 @@ import {
 function normalizePosition(
   position: CreateReleaseMemberPositionInput
 ): CreateReleaseMemberPositionInput {
-  if (position.tier === "" || position.tier === "generation") {
+  if (
+    position.tier === "" ||
+    position.tier === "generation" ||
+    position.tier === "hiatus"
+  ) {
     return { ...position, rowNumber: "", isCenter: false, isFrontSpecial: false };
   }
   if (position.tier === "under") {
@@ -68,7 +72,10 @@ function createSummarySortKey(
       "",
     ];
   }
-  return [2, generationRank(generation), 0, generation ?? ""];
+  if (position.tier === "generation") {
+    return [2, generationRank(generation), 0, generation ?? ""];
+  }
+  return [3, 0, 0, ""];
 }
 
 function compareSummaryItems(
@@ -1062,6 +1069,7 @@ export function ReleaseForm({
                         <option value="senbatsu">選抜</option>
                         <option value="under">{underLabel}</option>
                         <option value="generation">期生</option>
+                        <option value="hiatus">休業中</option>
                       </select>
                       {hasRow && (
                         <input

--- a/apps/oshikatsu-web/lib/selectionPositionLabel.ts
+++ b/apps/oshikatsu-web/lib/selectionPositionLabel.ts
@@ -36,12 +36,16 @@ export function getFrontSpecialSelectionLabel(
 }
 
 // 選抜ポジションを表示用ラベルに変換する。
-// 優先度: センター → 福神/櫻エイト → 選抜(列) / アンダー(列) / ◯期生
+// 優先度: センター → 福神/櫻エイト → 選抜(列) / アンダー(列) / ◯期生 / 休業中
 export function formatSelectionPositionLabel(
   position: SelectionPositionLabelInput,
   generation: string | null
 ): string {
   const rowSuffix = position.rowNumber != null ? `${position.rowNumber}列目` : "";
+
+  if (position.tier === "hiatus") {
+    return "休業中";
+  }
 
   if (position.tier === "generation") {
     return generation ? `${generation}期生` : "期生";

--- a/apps/oshikatsu-web/supabase/migrations/041_add_hiatus_selection_tier.sql
+++ b/apps/oshikatsu-web/supabase/migrations/041_add_hiatus_selection_tier.sql
@@ -1,0 +1,10 @@
+-- ============================================================
+-- 041: 選抜ポジションに休業中 tier を追加
+-- ============================================================
+
+ALTER TABLE public.orbit_release_member_positions
+  DROP CONSTRAINT IF EXISTS orbit_release_member_positions_tier_check;
+
+ALTER TABLE public.orbit_release_member_positions
+  ADD CONSTRAINT orbit_release_member_positions_tier_check
+  CHECK (tier IN ('senbatsu', 'under', 'generation', 'hiatus'));

--- a/apps/oshikatsu-web/types/release.ts
+++ b/apps/oshikatsu-web/types/release.ts
@@ -104,7 +104,12 @@ export type Release = {
 };
 
 // シングルの選抜ポジション（メンバー × リリース）
-export const SELECTION_TIERS = ["senbatsu", "under", "generation"] as const;
+export const SELECTION_TIERS = [
+  "senbatsu",
+  "under",
+  "generation",
+  "hiatus",
+] as const;
 export type SelectionTier = (typeof SELECTION_TIERS)[number];
 
 export type ReleaseMemberPosition = {


### PR DESCRIPTION
## 概要

選抜ポジションに「休業中」を追加します。

Closes #173

## 変更内容

- 選抜ポジションの tier に `hiatus` を追加
- リリース入力フォームに「休業中」選択肢を追加
- 「休業中」選択時は列・センター・福神/櫻エイトの従属値をクリア
- 選択状況サマリーとメンバー詳細の表示ラベルを `休業中` に対応
- `orbit_release_member_positions.tier` の CHECK 制約を拡張する migration を追加

## Decision

- 「休業中」は選抜ポジションの新しい tier 値 `hiatus` として扱う
- 列・センター・福神/櫻エイトとは独立した状態のため、`rowNumber` / `isCenter` / `isFrontSpecial` は UI 正規化と既存 validation で無効扱いにする
- 表示ラベルは固定で `休業中` とする

## 確認

- `pnpm --filter oshikatsu-web typecheck`
- `pnpm --filter oshikatsu-web lint`