### PR TITLE
feat: 選抜ポジションをフォーメーションから導出（一元管理・案A, #178）

### DIFF
--- a/apps/oshikatsu-web/app/(authenticated)/admin/releases/[id]/edit/page.tsx
+++ b/apps/oshikatsu-web/app/(authenticated)/admin/releases/[id]/edit/page.tsx
@@ -39,10 +39,8 @@ export default async function EditReleasePage({
     participantMemberIds: release.participantMemberIds,
     memberPositions: release.memberPositions.map((position) => ({
       memberId: position.memberId,
-      tier: position.tier,
-      rowNumber: position.rowNumber != null ? String(position.rowNumber) : "",
-      isCenter: position.isCenter,
       isFrontSpecial: position.isFrontSpecial,
+      isHiatus: position.isHiatus,
     })),
     bonusVideos: release.bonusVideos.map((bonus) => ({
       edition: bonus.edition,

--- a/apps/oshikatsu-web/components/admin/ReleaseForm.tsx
+++ b/apps/oshikatsu-web/components/admin/ReleaseForm.tsx
@@ -869,6 +869,9 @@ export function ReleaseForm({
             <p className="text-xs text-foreground/50">
               選抜/アンダー/列/センターは楽曲のフォーメーションから自動表示されます。
               ここでは{frontSpecialLabel ? `${frontSpecialLabel}・` : ""}休業中のみ指定します。
+              {frontSpecialLabel
+                ? `（${frontSpecialLabel}は選抜=表題曲のメンバーにのみ反映されます）`
+                : ""}
             </p>
             <div className="space-y-1">
               {values.participantMemberIds.map((memberId) => {

--- a/apps/oshikatsu-web/components/admin/ReleaseForm.tsx
+++ b/apps/oshikatsu-web/components/admin/ReleaseForm.tsx
@@ -13,127 +13,7 @@ import {
   type CreateReleaseTrackLinkInput,
   type ReleaseImageUploadInput,
 } from "@/types/release";
-import {
-  formatSelectionPositionLabel,
-  getFrontSpecialSelectionLabel,
-  getUnderSelectionLabel,
-} from "@/lib/selectionPositionLabel";
-
-// tier に応じてUIで表現できない従属フィールドをクリアし、保存内容を正規化する。
-function normalizePosition(
-  position: CreateReleaseMemberPositionInput
-): CreateReleaseMemberPositionInput {
-  if (
-    position.tier === "" ||
-    position.tier === "generation" ||
-    position.tier === "hiatus"
-  ) {
-    return { ...position, rowNumber: "", isCenter: false, isFrontSpecial: false };
-  }
-  if (position.tier === "under") {
-    return { ...position, isFrontSpecial: false };
-  }
-  return position;
-}
-
-type SelectionPositionSummaryItem = {
-  label: string;
-  count: number;
-  sortKey: [number, number, number, string];
-};
-
-function parseRowNumber(rowNumber: string): number | null {
-  const trimmed = rowNumber.trim();
-  if (trimmed === "") return null;
-  const parsed = Number(trimmed);
-  return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
-}
-
-function generationRank(generation: string | null): number {
-  if (!generation) return Number.POSITIVE_INFINITY;
-  const parsed = Number(generation);
-  return Number.isFinite(parsed) ? parsed : Number.POSITIVE_INFINITY;
-}
-
-function createSummarySortKey(
-  position: CreateReleaseMemberPositionInput,
-  generation: string | null
-): [number, number, number, string] {
-  const rowNumber = parseRowNumber(position.rowNumber);
-  if (position.tier === "senbatsu") {
-    const flagRank = position.isCenter ? 0 : position.isFrontSpecial ? 1 : 2;
-    return [0, rowNumber ?? Number.POSITIVE_INFINITY, flagRank, ""];
-  }
-  if (position.tier === "under") {
-    return [
-      1,
-      rowNumber ?? Number.POSITIVE_INFINITY,
-      position.isCenter ? 0 : 1,
-      "",
-    ];
-  }
-  if (position.tier === "generation") {
-    return [2, generationRank(generation), 0, generation ?? ""];
-  }
-  return [3, 0, 0, ""];
-}
-
-function compareSummaryItems(
-  a: SelectionPositionSummaryItem,
-  b: SelectionPositionSummaryItem
-): number {
-  const tierDiff = a.sortKey[0] - b.sortKey[0];
-  if (tierDiff !== 0) return tierDiff;
-  const rowDiff = a.sortKey[1] - b.sortKey[1];
-  if (rowDiff !== 0) return rowDiff;
-  const flagDiff = a.sortKey[2] - b.sortKey[2];
-  if (flagDiff !== 0) return flagDiff;
-  const generationDiff = a.sortKey[3].localeCompare(b.sortKey[3], "ja");
-  if (generationDiff !== 0) return generationDiff;
-  return a.label.localeCompare(b.label, "ja");
-}
-
-function buildSelectionPositionSummary(
-  memberPositions: CreateReleaseMemberPositionInput[],
-  participantMemberIds: string[],
-  memberGenerationById: Map<string, string | null>,
-  groupNameJa: string
-): SelectionPositionSummaryItem[] {
-  const positionByMemberId = new Map(
-    memberPositions.map((position) => [position.memberId, position])
-  );
-  const summaryByLabel = new Map<string, SelectionPositionSummaryItem>();
-
-  for (const memberId of participantMemberIds) {
-    const position = positionByMemberId.get(memberId);
-    if (!position || position.tier === "") continue;
-
-    const rowNumber = parseRowNumber(position.rowNumber);
-    const generation = memberGenerationById.get(memberId) ?? null;
-    const label = formatSelectionPositionLabel(
-      {
-        groupNameJa,
-        tier: position.tier,
-        rowNumber,
-        isCenter: position.isCenter,
-        isFrontSpecial: position.isFrontSpecial,
-      },
-      generation
-    );
-    const existing = summaryByLabel.get(label);
-    if (existing) {
-      existing.count += 1;
-      continue;
-    }
-    summaryByLabel.set(label, {
-      label,
-      count: 1,
-      sortKey: createSummarySortKey(position, generation),
-    });
-  }
-
-  return Array.from(summaryByLabel.values()).sort(compareSummaryItems);
-}
+import { getFrontSpecialSelectionLabel } from "@/lib/selectionPositionLabel";
 import type { ValidationError } from "@/types/errors";
 import { Input } from "@/components/ui/Input";
 import { Select } from "@/components/ui/Select";
@@ -231,13 +111,16 @@ function toSubmitValues(
             .filter((position) =>
               input.participantMemberIds.includes(position.memberId)
             )
-            // グループが福神/櫻エイト非対応なら front_special をクリア
             .map((position) => ({
-              ...position,
+              memberId: position.memberId,
+              // グループが福神/櫻エイト非対応なら front_special をクリア
               isFrontSpecial: supportsFrontSpecial
                 ? position.isFrontSpecial
                 : false,
+              isHiatus: position.isHiatus,
             }))
+            // 福神/休業中いずれかが立つメンバーのみ保持（overlay）
+            .filter((position) => position.isFrontSpecial || position.isHiatus)
         : [],
     bonusVideos: input.bonusVideos.map((bonus) => ({
       edition: bonus.edition,
@@ -420,47 +303,17 @@ export function ReleaseForm({
     () => new Map(members.map((member) => [member.id, member.nameJa])),
     [members]
   );
-  const memberGenerationById = useMemo(
-    () =>
-      new Map(
-        members.map((member) => [
-          member.id,
-          member.groupGenerations.find(
-            (group) => group.groupId === values.groupId
-          )?.generation ?? null,
-        ])
-      ),
-    [members, values.groupId]
-  );
 
   const selectedGroupName = groups.find(
     (group) => group.id === values.groupId
   )?.nameJa;
-  const underLabel = getUnderSelectionLabel(selectedGroupName);
   const frontSpecialLabel = getFrontSpecialSelectionLabel(selectedGroupName);
-  const selectionPositionSummary = useMemo(
-    () =>
-      buildSelectionPositionSummary(
-        values.memberPositions,
-        values.participantMemberIds,
-        memberGenerationById,
-        selectedGroupName ?? ""
-      ),
-    [
-      memberGenerationById,
-      selectedGroupName,
-      values.memberPositions,
-      values.participantMemberIds,
-    ]
-  );
 
   const getPosition = (memberId: string): CreateReleaseMemberPositionInput =>
     values.memberPositions.find((position) => position.memberId === memberId) ?? {
       memberId,
-      tier: "",
-      rowNumber: "",
-      isCenter: false,
       isFrontSpecial: false,
+      isHiatus: false,
     };
 
   const updatePosition = (
@@ -473,14 +326,8 @@ export function ReleaseForm({
       );
       const base = prev.memberPositions.find(
         (position) => position.memberId === memberId
-      ) ?? {
-        memberId,
-        tier: "" as CreateReleaseMemberPositionInput["tier"],
-        rowNumber: "",
-        isCenter: false,
-        isFrontSpecial: false,
-      };
-      const nextPosition = normalizePosition({ ...base, ...patch });
+      ) ?? { memberId, isFrontSpecial: false, isHiatus: false };
+      const nextPosition = { ...base, ...patch };
       return {
         ...prev,
         memberPositions: exists
@@ -1017,103 +864,49 @@ export function ReleaseForm({
         values.participantMemberIds.length > 0 && (
           <div className="space-y-2">
             <label className="block text-sm font-medium text-foreground/70">
-              選抜ポジション
+              選抜ポジション（手動指定）
             </label>
             <p className="text-xs text-foreground/50">
-              参加メンバーごとに位置を登録します（未設定はメンバー詳細に表示されません）。
+              選抜/アンダー/列/センターは楽曲のフォーメーションから自動表示されます。
+              ここでは{frontSpecialLabel ? `${frontSpecialLabel}・` : ""}休業中のみ指定します。
             </p>
-            <div className="rounded-lg border border-foreground/10 bg-foreground/[0.03] p-2">
-              <p className="mb-1 text-xs font-medium text-foreground/60">
-                選択状況
-              </p>
-              {selectionPositionSummary.length > 0 ? (
-                <div className="flex flex-wrap gap-1.5">
-                  {selectionPositionSummary.map((item) => (
-                    <span
-                      key={item.label}
-                      className="rounded-full bg-background px-2 py-1 text-xs text-foreground/70 ring-1 ring-foreground/10"
-                    >
-                      {item.label} {item.count}人
-                    </span>
-                  ))}
-                </div>
-              ) : (
-                <p className="text-xs text-foreground/40">未設定</p>
-              )}
-            </div>
-            <div className="space-y-2">
+            <div className="space-y-1">
               {values.participantMemberIds.map((memberId) => {
                 const position = getPosition(memberId);
-                const hasRow =
-                  position.tier === "senbatsu" || position.tier === "under";
                 return (
                   <div
                     key={memberId}
-                    className="rounded-lg border border-foreground/10 p-2"
+                    className="flex flex-wrap items-center gap-3 rounded-lg border border-foreground/10 p-2 text-xs"
                   >
-                    <p className="mb-1 text-sm text-foreground">
+                    <span className="text-sm text-foreground">
                       {memberNameById.get(memberId) ?? memberId}
-                    </p>
-                    <div className="flex flex-wrap items-center gap-2 text-xs">
-                      <select
-                        value={position.tier}
-                        onChange={(e) =>
-                          updatePosition(memberId, {
-                            tier: e.target
-                              .value as CreateReleaseMemberPositionInput["tier"],
-                          })
-                        }
-                        className="rounded-lg border border-foreground/10 bg-background px-2 py-1"
-                      >
-                        <option value="">未設定</option>
-                        <option value="senbatsu">選抜</option>
-                        <option value="under">{underLabel}</option>
-                        <option value="generation">期生</option>
-                        <option value="hiatus">休業中</option>
-                      </select>
-                      {hasRow && (
+                    </span>
+                    {frontSpecialLabel && (
+                      <label className="flex items-center gap-1">
                         <input
-                          type="number"
-                          min={1}
-                          placeholder="列"
-                          value={position.rowNumber}
+                          type="checkbox"
+                          checked={position.isFrontSpecial}
                           onChange={(e) =>
                             updatePosition(memberId, {
-                              rowNumber: e.target.value,
+                              isFrontSpecial: e.target.checked,
                             })
                           }
-                          className="w-16 rounded-lg border border-foreground/10 bg-background px-2 py-1"
                         />
-                      )}
-                      {hasRow && (
-                        <label className="flex items-center gap-1">
-                          <input
-                            type="checkbox"
-                            checked={position.isCenter}
-                            onChange={(e) =>
-                              updatePosition(memberId, {
-                                isCenter: e.target.checked,
-                              })
-                            }
-                          />
-                          センター
-                        </label>
-                      )}
-                      {position.tier === "senbatsu" && frontSpecialLabel && (
-                        <label className="flex items-center gap-1">
-                          <input
-                            type="checkbox"
-                            checked={position.isFrontSpecial}
-                            onChange={(e) =>
-                              updatePosition(memberId, {
-                                isFrontSpecial: e.target.checked,
-                              })
-                            }
-                          />
-                          {frontSpecialLabel}
-                        </label>
-                      )}
-                    </div>
+                        {frontSpecialLabel}
+                      </label>
+                    )}
+                    <label className="flex items-center gap-1">
+                      <input
+                        type="checkbox"
+                        checked={position.isHiatus}
+                        onChange={(e) =>
+                          updatePosition(memberId, {
+                            isHiatus: e.target.checked,
+                          })
+                        }
+                      />
+                      休業中
+                    </label>
                   </div>
                 );
               })}

--- a/apps/oshikatsu-web/repositories/releaseRepository.ts
+++ b/apps/oshikatsu-web/repositories/releaseRepository.ts
@@ -322,17 +322,21 @@ function toTrackLinkRpcInput(
   }));
 }
 
-// 楽曲ラベル → 選抜tier（表題=選抜 / アンダー=アンダー / 期別=期生）。
-// 配列の順序はそのまま導出時の優先度（上ほど優先）にも使う。
-const LABEL_TIER_PRIORITY: ReadonlyArray<{ label: string; tier: SelectionTier }> = [
-  { label: "title", tier: "senbatsu" },
-  { label: "under", tier: "under" },
-  { label: "generation", tier: "generation" },
+// 楽曲ラベル → 導出tierと優先度（priority が小さいほど優先）。
+// 表題(title)と選抜(senbatsu)はどちらも「選抜」。列・センターの代表は表題を優先する。
+const LABEL_DERIVATION: ReadonlyArray<{
+  label: string;
+  tier: SelectionTier;
+  priority: number;
+}> = [
+  { label: "title", tier: "senbatsu", priority: 0 },
+  { label: "senbatsu", tier: "senbatsu", priority: 1 },
+  { label: "under", tier: "under", priority: 2 },
+  { label: "generation", tier: "generation", priority: 3 },
 ];
 
-function tierPriorityIndex(tier: SelectionTier): number {
-  const index = LABEL_TIER_PRIORITY.findIndex((entry) => entry.tier === tier);
-  return index === -1 ? LABEL_TIER_PRIORITY.length : index;
+function labelDerivation(label: string | null | undefined) {
+  return LABEL_DERIVATION.find((entry) => entry.label === label);
 }
 
 // overlay（福神/櫻エイト・休業中）の保存入力。いずれかが立つメンバーのみ送る。
@@ -547,7 +551,7 @@ export function createReleaseRepository(
           .in("id", trackIds);
         if (tErr) throw fail(tErr);
         for (const t of (tracks as Array<{ id: string; label: string | null }>) ?? []) {
-          if (t.label && LABEL_TIER_PRIORITY.some((e) => e.label === t.label)) {
+          if (t.label && labelDerivation(t.label)) {
             labelByTrack.set(t.id, t.label);
           }
         }
@@ -640,12 +644,17 @@ export function createReleaseRepository(
       // 6) リリースごとに最良の導出を選ぶ（tier優先 → 同tierは曲順が若い方）
       const derived = new Map<
         string,
-        { tier: SelectionTier; rowNumber: number | null; isCenter: boolean; trackNumber: number }
+        {
+          tier: SelectionTier;
+          rowNumber: number | null;
+          isCenter: boolean;
+          trackNumber: number;
+          priority: number;
+        }
       >();
       for (const link of links) {
         if (!releaseInfo.has(link.releaseId)) continue; // シングルのみ
-        const label = labelByTrack.get(link.trackId);
-        const entry = LABEL_TIER_PRIORITY.find((e) => e.label === label);
+        const entry = labelDerivation(labelByTrack.get(link.trackId));
         const fm = formationByTrack.get(link.trackId);
         if (!entry || !fm) continue;
         const candidate = {
@@ -653,12 +662,13 @@ export function createReleaseRepository(
           rowNumber: fm.rowNumber as number | null,
           isCenter: fm.isCenter,
           trackNumber: link.trackNumber,
+          priority: entry.priority,
         };
         const current = derived.get(link.releaseId);
         const isBetter =
           !current ||
-          tierPriorityIndex(candidate.tier) < tierPriorityIndex(current.tier) ||
-          (candidate.tier === current.tier &&
+          candidate.priority < current.priority ||
+          (candidate.priority === current.priority &&
             candidate.trackNumber < current.trackNumber);
         if (isBetter) derived.set(link.releaseId, candidate);
       }
@@ -698,7 +708,9 @@ export function createReleaseRepository(
           tier: base.tier,
           rowNumber: base.rowNumber,
           isCenter: base.isCenter,
-          isFrontSpecial: overlay?.isFrontSpecial ?? false,
+          // 福神/櫻エイトは選抜のメンバーにのみ反映する
+          isFrontSpecial:
+            base.tier === "senbatsu" ? (overlay?.isFrontSpecial ?? false) : false,
         });
       }
 

--- a/apps/oshikatsu-web/repositories/releaseRepository.ts
+++ b/apps/oshikatsu-web/repositories/releaseRepository.ts
@@ -8,7 +8,6 @@ import type {
   SelectionTier,
   MemberSelectionPosition,
 } from "@/types/release";
-import { SELECTION_TIERS } from "@/types/release";
 import type { ReleaseRepository } from "@/types/repositories";
 import { RepositoryError } from "@/types/errors";
 import { compareByGenerationThenName } from "@/lib/memberOrder";
@@ -63,10 +62,8 @@ type ReleaseMemberRow = {
 
 type ReleaseMemberPositionRow = {
   member_id: string;
-  tier: string;
-  row_number: number | null;
-  is_center: boolean;
   is_front_special: boolean;
+  is_hiatus: boolean;
 };
 
 type ReleaseTrackRow = {
@@ -160,7 +157,7 @@ const RELEASE_DETAIL_SELECT = `
   orbit_groups(name_ja, color),
   orbit_release_bonus_videos(id, edition, title, description, sort_order),
   orbit_release_members(member_id, orbit_members(name_ja, name_kana, orbit_member_groups(group_id, generation))),
-  orbit_release_member_positions(member_id, tier, row_number, is_center, is_front_special),
+  orbit_release_member_positions(member_id, is_front_special, is_hiatus),
   orbit_release_tracks(track_number, orbit_tracks(id, title))
 `;
 
@@ -231,17 +228,11 @@ function mapToRelease(row: ReleaseRow): Release {
     participantMemberIds: participants.map((member) => member.memberId),
     participantMemberNames: participants.map((member) => member.memberNameJa),
     participantMemberGenerations: participants.map((member) => member.generation),
-    memberPositions: (row.orbit_release_member_positions ?? [])
-      .filter((position): position is ReleaseMemberPositionRow & { tier: SelectionTier } =>
-        (SELECTION_TIERS as readonly string[]).includes(position.tier)
-      )
-      .map((position) => ({
-        memberId: position.member_id,
-        tier: position.tier,
-        rowNumber: position.row_number,
-        isCenter: position.is_center,
-        isFrontSpecial: position.is_front_special,
-      })),
+    memberPositions: (row.orbit_release_member_positions ?? []).map((position) => ({
+      memberId: position.member_id,
+      isFrontSpecial: position.is_front_special,
+      isHiatus: position.is_hiatus,
+    })),
     bonusVideos: (row.orbit_release_bonus_videos ?? [])
       .map((bonus) => ({
         id: bonus.id,
@@ -331,77 +322,33 @@ function toTrackLinkRpcInput(
   }));
 }
 
-const MEMBER_POSITION_SELECT = `
-  tier,
-  row_number,
-  is_center,
-  is_front_special,
-  orbit_releases(id, title, numbering, release_type, group_id, orbit_groups(name_ja))
-`;
+// 楽曲ラベル → 選抜tier（表題=選抜 / アンダー=アンダー / 期別=期生）。
+// 配列の順序はそのまま導出時の優先度（上ほど優先）にも使う。
+const LABEL_TIER_PRIORITY: ReadonlyArray<{ label: string; tier: SelectionTier }> = [
+  { label: "title", tier: "senbatsu" },
+  { label: "under", tier: "under" },
+  { label: "generation", tier: "generation" },
+];
 
-type MemberPositionReleaseRow = {
-  id: string;
-  title: string;
-  numbering: number | null;
-  release_type: ReleaseType;
-  group_id: string;
-  orbit_groups: { name_ja: string } | { name_ja: string }[] | null;
-};
-
-type MemberPositionRow = {
-  tier: string;
-  row_number: number | null;
-  is_center: boolean;
-  is_front_special: boolean;
-  orbit_releases: MemberPositionReleaseRow | MemberPositionReleaseRow[] | null;
-};
-
-function mapMemberPosition(
-  row: MemberPositionRow
-): MemberSelectionPosition | null {
-  const release = Array.isArray(row.orbit_releases)
-    ? row.orbit_releases[0]
-    : row.orbit_releases;
-  if (!release) return null;
-  // 選抜はシングルのみ。tier が不正な行も除外する
-  if (release.release_type !== "single") return null;
-  if (!(SELECTION_TIERS as readonly string[]).includes(row.tier)) return null;
-
-  const group = Array.isArray(release.orbit_groups)
-    ? release.orbit_groups[0]
-    : release.orbit_groups;
-
-  return {
-    releaseId: release.id,
-    releaseTitle: release.title,
-    numbering: release.numbering,
-    groupId: release.group_id,
-    groupNameJa: group?.name_ja ?? "",
-    tier: row.tier as SelectionTier,
-    rowNumber: row.row_number,
-    isCenter: row.is_center,
-    isFrontSpecial: row.is_front_special,
-  };
+function tierPriorityIndex(tier: SelectionTier): number {
+  const index = LABEL_TIER_PRIORITY.findIndex((entry) => entry.tier === tier);
+  return index === -1 ? LABEL_TIER_PRIORITY.length : index;
 }
 
+// overlay（福神/櫻エイト・休業中）の保存入力。いずれかが立つメンバーのみ送る。
 function toMemberPositionRpcInput(
   positions: CreateReleaseInput["memberPositions"]
 ): Array<{
   memberId: string;
-  tier: string;
-  rowNumber: number | null;
-  isCenter: boolean;
   isFrontSpecial: boolean;
+  isHiatus: boolean;
 }> {
   return positions
-    .filter((position) => position.tier !== "")
+    .filter((position) => position.isFrontSpecial || position.isHiatus)
     .map((position) => ({
       memberId: position.memberId,
-      tier: position.tier,
-      rowNumber:
-        position.rowNumber.trim() === "" ? null : Number(position.rowNumber),
-      isCenter: position.isCenter,
       isFrontSpecial: position.isFrontSpecial,
+      isHiatus: position.isHiatus,
     }));
 }
 
@@ -529,21 +476,233 @@ export function createReleaseRepository(
     },
 
     async findSelectionPositionsByMemberId(memberId) {
-      const { data, error } = await supabase
-        .from("orbit_release_member_positions")
-        .select(MEMBER_POSITION_SELECT)
-        .eq("member_id", memberId);
+      const fail = (cause: unknown) =>
+        new RepositoryError("選抜ポジションの取得に失敗しました", cause);
+      const unique = (values: string[]) => Array.from(new Set(values));
 
-      if (error) {
-        throw new RepositoryError("選抜ポジションの取得に失敗しました", error);
+      // 1) メンバーのフォーメーション所属（track別の列・センター）を解決
+      const { data: fmMembers, error: fmErr } = await supabase
+        .from("orbit_track_formation_members")
+        .select("formation_row_id, is_center")
+        .eq("member_id", memberId);
+      if (fmErr) throw fail(fmErr);
+      const memberRows =
+        (fmMembers as Array<{ formation_row_id: string; is_center: boolean }>) ?? [];
+
+      const rowInfo = new Map<string, { rowNumber: number; formationId: string }>();
+      const rowIds = unique(memberRows.map((r) => r.formation_row_id));
+      if (rowIds.length > 0) {
+        const { data: rows, error: rowsErr } = await supabase
+          .from("orbit_track_formation_rows")
+          .select("id, row_number, formation_id")
+          .in("id", rowIds);
+        if (rowsErr) throw fail(rowsErr);
+        for (const r of (rows as Array<{
+          id: string;
+          row_number: number;
+          formation_id: string;
+        }>) ?? []) {
+          rowInfo.set(r.id, { rowNumber: r.row_number, formationId: r.formation_id });
+        }
       }
 
-      return ((data as unknown as MemberPositionRow[]) ?? [])
-        .map(mapMemberPosition)
-        .filter(
-          (position): position is MemberSelectionPosition => position !== null
-        )
-        .sort((a, b) => (a.numbering ?? 0) - (b.numbering ?? 0));
+      const trackByFormation = new Map<string, string>();
+      const formationIds = unique(
+        Array.from(rowInfo.values()).map((v) => v.formationId)
+      );
+      if (formationIds.length > 0) {
+        const { data: formations, error: fErr } = await supabase
+          .from("orbit_track_formations")
+          .select("id, track_id")
+          .in("id", formationIds);
+        if (fErr) throw fail(fErr);
+        for (const f of (formations as Array<{ id: string; track_id: string }>) ?? []) {
+          trackByFormation.set(f.id, f.track_id);
+        }
+      }
+
+      // track_id -> { 列, センター }（メンバーは1トラックにつき1行）
+      const formationByTrack = new Map<
+        string,
+        { rowNumber: number; isCenter: boolean }
+      >();
+      for (const mr of memberRows) {
+        const info = rowInfo.get(mr.formation_row_id);
+        if (!info) continue;
+        const trackId = trackByFormation.get(info.formationId);
+        if (!trackId) continue;
+        formationByTrack.set(trackId, {
+          rowNumber: info.rowNumber,
+          isCenter: mr.is_center,
+        });
+      }
+
+      // 2) 各トラックの label を取り、選抜対象（表題/アンダー/期別）に絞る
+      const labelByTrack = new Map<string, string>();
+      const trackIds = Array.from(formationByTrack.keys());
+      if (trackIds.length > 0) {
+        const { data: tracks, error: tErr } = await supabase
+          .from("orbit_tracks")
+          .select("id, label")
+          .in("id", trackIds);
+        if (tErr) throw fail(tErr);
+        for (const t of (tracks as Array<{ id: string; label: string | null }>) ?? []) {
+          if (t.label && LABEL_TIER_PRIORITY.some((e) => e.label === t.label)) {
+            labelByTrack.set(t.id, t.label);
+          }
+        }
+      }
+
+      // 3) 対象トラック → リリース紐づけ（曲順含む）
+      type Link = { trackId: string; trackNumber: number; releaseId: string };
+      let links: Link[] = [];
+      const labeledTrackIds = Array.from(labelByTrack.keys());
+      if (labeledTrackIds.length > 0) {
+        const { data: rt, error: rtErr } = await supabase
+          .from("orbit_release_tracks")
+          .select("track_id, track_number, release_id")
+          .in("track_id", labeledTrackIds);
+        if (rtErr) throw fail(rtErr);
+        links = (
+          (rt as Array<{
+            track_id: string;
+            track_number: number;
+            release_id: string;
+          }>) ?? []
+        ).map((x) => ({
+          trackId: x.track_id,
+          trackNumber: x.track_number,
+          releaseId: x.release_id,
+        }));
+      }
+
+      // 4) overlay（福神/櫻エイト・休業中）
+      const { data: overlayData, error: ovErr } = await supabase
+        .from("orbit_release_member_positions")
+        .select("release_id, is_front_special, is_hiatus")
+        .eq("member_id", memberId);
+      if (ovErr) throw fail(ovErr);
+      const overlayByRelease = new Map<
+        string,
+        { isFrontSpecial: boolean; isHiatus: boolean }
+      >();
+      for (const o of (overlayData as Array<{
+        release_id: string;
+        is_front_special: boolean;
+        is_hiatus: boolean;
+      }>) ?? []) {
+        overlayByRelease.set(o.release_id, {
+          isFrontSpecial: o.is_front_special,
+          isHiatus: o.is_hiatus,
+        });
+      }
+
+      // 5) 関係するシングルの情報（導出 ＋ overlayのみのリリースも補完）
+      const releaseIds = unique([
+        ...links.map((l) => l.releaseId),
+        ...overlayByRelease.keys(),
+      ]);
+      const releaseInfo = new Map<
+        string,
+        {
+          title: string;
+          numbering: number | null;
+          groupId: string;
+          groupNameJa: string;
+        }
+      >();
+      if (releaseIds.length > 0) {
+        const { data: releases, error: relErr } = await supabase
+          .from("orbit_releases")
+          .select("id, title, numbering, release_type, group_id, orbit_groups(name_ja)")
+          .in("id", releaseIds)
+          .eq("release_type", "single");
+        if (relErr) throw fail(relErr);
+        for (const r of (releases as Array<{
+          id: string;
+          title: string;
+          numbering: number | null;
+          group_id: string;
+          orbit_groups: { name_ja: string } | { name_ja: string }[] | null;
+        }>) ?? []) {
+          const group = Array.isArray(r.orbit_groups)
+            ? r.orbit_groups[0]
+            : r.orbit_groups;
+          releaseInfo.set(r.id, {
+            title: r.title,
+            numbering: r.numbering,
+            groupId: r.group_id,
+            groupNameJa: group?.name_ja ?? "",
+          });
+        }
+      }
+
+      // 6) リリースごとに最良の導出を選ぶ（tier優先 → 同tierは曲順が若い方）
+      const derived = new Map<
+        string,
+        { tier: SelectionTier; rowNumber: number | null; isCenter: boolean; trackNumber: number }
+      >();
+      for (const link of links) {
+        if (!releaseInfo.has(link.releaseId)) continue; // シングルのみ
+        const label = labelByTrack.get(link.trackId);
+        const entry = LABEL_TIER_PRIORITY.find((e) => e.label === label);
+        const fm = formationByTrack.get(link.trackId);
+        if (!entry || !fm) continue;
+        const candidate = {
+          tier: entry.tier,
+          rowNumber: fm.rowNumber as number | null,
+          isCenter: fm.isCenter,
+          trackNumber: link.trackNumber,
+        };
+        const current = derived.get(link.releaseId);
+        const isBetter =
+          !current ||
+          tierPriorityIndex(candidate.tier) < tierPriorityIndex(current.tier) ||
+          (candidate.tier === current.tier &&
+            candidate.trackNumber < current.trackNumber);
+        if (isBetter) derived.set(link.releaseId, candidate);
+      }
+
+      // 7) 組み立て（overlay反映・休業中は上書き／休業中のみのリリースも表示）
+      const result: MemberSelectionPosition[] = [];
+      for (const releaseId of unique([
+        ...derived.keys(),
+        ...overlayByRelease.keys(),
+      ])) {
+        const info = releaseInfo.get(releaseId);
+        if (!info) continue;
+        const overlay = overlayByRelease.get(releaseId);
+        const base = derived.get(releaseId);
+
+        if (overlay?.isHiatus) {
+          result.push({
+            releaseId,
+            releaseTitle: info.title,
+            numbering: info.numbering,
+            groupId: info.groupId,
+            groupNameJa: info.groupNameJa,
+            tier: "hiatus",
+            rowNumber: null,
+            isCenter: false,
+            isFrontSpecial: false,
+          });
+          continue;
+        }
+        if (!base) continue; // 導出が無く休業中でもない（福神のみ等）はスキップ
+        result.push({
+          releaseId,
+          releaseTitle: info.title,
+          numbering: info.numbering,
+          groupId: info.groupId,
+          groupNameJa: info.groupNameJa,
+          tier: base.tier,
+          rowNumber: base.rowNumber,
+          isCenter: base.isCenter,
+          isFrontSpecial: overlay?.isFrontSpecial ?? false,
+        });
+      }
+
+      return result.sort((a, b) => (a.numbering ?? 0) - (b.numbering ?? 0));
     },
 
     async create(input) {

--- a/apps/oshikatsu-web/supabase/migrations/042_positions_overlay_from_formation.sql
+++ b/apps/oshikatsu-web/supabase/migrations/042_positions_overlay_from_formation.sql
@@ -1,0 +1,59 @@
+-- ============================================================
+-- 042: 選抜ポジションをフォーメーション導出＋overlay化（案A, #178）
+-- ------------------------------------------------------------
+-- - 選抜/アンダー/期生・列・センターは楽曲フォーメーションから導出する方針へ
+--   （Decision #177）。よって tier/row_number/is_center 列を撤去。
+-- - overlay として「福神/櫻エイト(is_front_special)」「休業中(is_hiatus)」のみ保持。
+-- - 既存データ移行は不要（運用上ほぼ未投入のため）。
+-- ============================================================
+
+ALTER TABLE public.orbit_release_member_positions
+  DROP COLUMN IF EXISTS tier,
+  DROP COLUMN IF EXISTS row_number,
+  DROP COLUMN IF EXISTS is_center,
+  ADD COLUMN IF NOT EXISTS is_hiatus BOOLEAN NOT NULL DEFAULT false;
+
+-- overlay の総入れ替え。福神 or 休業中 のいずれかが立つ行のみ保持する。
+CREATE OR REPLACE FUNCTION public.set_release_member_positions(
+  p_release_id UUID,
+  p_positions JSONB
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+BEGIN
+  DELETE FROM public.orbit_release_member_positions
+  WHERE release_id = p_release_id;
+
+  INSERT INTO public.orbit_release_member_positions (
+    release_id,
+    member_id,
+    is_front_special,
+    is_hiatus
+  )
+  SELECT
+    p_release_id,
+    (item->>'memberId')::UUID,
+    COALESCE((item->>'isFrontSpecial')::BOOLEAN, false),
+    COALESCE((item->>'isHiatus')::BOOLEAN, false)
+  FROM jsonb_array_elements(COALESCE(p_positions, '[]'::JSONB)) AS item
+  WHERE NULLIF(item->>'memberId', '') IS NOT NULL
+    -- いずれのフラグも立たない行は保持しない
+    AND (
+      COALESCE((item->>'isFrontSpecial')::BOOLEAN, false)
+      OR COALESCE((item->>'isHiatus')::BOOLEAN, false)
+    )
+    -- 防御: シングルのみ
+    AND EXISTS (
+      SELECT 1 FROM public.orbit_releases r
+      WHERE r.id = p_release_id AND r.release_type = 'single'
+    )
+    -- 防御: 当該リリースの参加メンバーに限定
+    AND EXISTS (
+      SELECT 1 FROM public.orbit_release_members rm
+      WHERE rm.release_id = p_release_id
+        AND rm.member_id = (item->>'memberId')::UUID
+    );
+END;
+$$;

--- a/apps/oshikatsu-web/supabase/migrations/042_positions_overlay_from_formation.sql
+++ b/apps/oshikatsu-web/supabase/migrations/042_positions_overlay_from_formation.sql
@@ -7,11 +7,20 @@
 -- - 既存データ移行は不要（運用上ほぼ未投入のため）。
 -- ============================================================
 
+-- 1) is_hiatus を先に追加
+ALTER TABLE public.orbit_release_member_positions
+  ADD COLUMN IF NOT EXISTS is_hiatus BOOLEAN NOT NULL DEFAULT false;
+
+-- 2) 既存の tier='hiatus'（#176）を is_hiatus へ backfill（列削除前に実施）
+UPDATE public.orbit_release_member_positions
+  SET is_hiatus = true
+  WHERE tier = 'hiatus';
+
+-- 3) 導出に委ねる列を撤去（is_front_special は overlay として保持）
 ALTER TABLE public.orbit_release_member_positions
   DROP COLUMN IF EXISTS tier,
   DROP COLUMN IF EXISTS row_number,
-  DROP COLUMN IF EXISTS is_center,
-  ADD COLUMN IF NOT EXISTS is_hiatus BOOLEAN NOT NULL DEFAULT false;
+  DROP COLUMN IF EXISTS is_center;
 
 -- overlay の総入れ替え。福神 or 休業中 のいずれかが立つ行のみ保持する。
 CREATE OR REPLACE FUNCTION public.set_release_member_positions(

--- a/apps/oshikatsu-web/types/release.ts
+++ b/apps/oshikatsu-web/types/release.ts
@@ -112,20 +112,18 @@ export const SELECTION_TIERS = [
 ] as const;
 export type SelectionTier = (typeof SELECTION_TIERS)[number];
 
+// 選抜/アンダー/期生・列・センターはフォーメーションから導出する（Decision #177）。
+// リリース×メンバーで手動保持するのは overlay（福神/櫻エイト・休業中）のみ。
 export type ReleaseMemberPosition = {
   memberId: string;
-  tier: SelectionTier;
-  rowNumber: number | null;
-  isCenter: boolean;
   isFrontSpecial: boolean;
+  isHiatus: boolean;
 };
 
 export type CreateReleaseMemberPositionInput = {
   memberId: string;
-  tier: SelectionTier | "";
-  rowNumber: string;
-  isCenter: boolean;
   isFrontSpecial: boolean;
+  isHiatus: boolean;
 };
 
 // メンバー詳細で表示する、シングルごとの選抜ポジション

--- a/apps/oshikatsu-web/usecases/validateRelease.ts
+++ b/apps/oshikatsu-web/usecases/validateRelease.ts
@@ -1,15 +1,11 @@
 import type { CreateReleaseInput } from "@/types/release";
 import type { ValidationError } from "@/types/errors";
-import { RELEASE_TYPES, SELECTION_TIERS } from "@/types/release";
+import { RELEASE_TYPES } from "@/types/release";
 import { isValidDateString } from "@/lib/validation";
 import { isReleaseArtworkPath } from "@/lib/releaseImage";
 
 function isReleaseType(value: string): boolean {
   return (RELEASE_TYPES as readonly string[]).includes(value);
-}
-
-function isSelectionTier(value: string): boolean {
-  return (SELECTION_TIERS as readonly string[]).includes(value);
 }
 
 export function validateRelease(input: CreateReleaseInput): ValidationError[] {
@@ -135,21 +131,17 @@ export function validateRelease(input: CreateReleaseInput): ValidationError[] {
     seenMemberIds.add(memberId);
   }
 
-  // 選抜ポジション：シングルのみ・参加メンバー限定・組み合わせ妥当性
+  // 選抜ポジション overlay（福神/休業中）：シングルのみ・参加メンバー限定・重複なし
   const participantMemberIdSet = new Set(input.participantMemberIds);
   const seenPositionMemberIds = new Set<string>();
   for (const position of input.memberPositions) {
-    if (position.tier === "") continue; // 未設定は保存対象外
+    if (!position.isFrontSpecial && !position.isHiatus) continue; // 空は保存対象外
 
     if (input.releaseType !== "single") {
       errors.push({
         field: "memberPositions",
         message: "選抜ポジションはシングルでのみ設定できます",
       });
-      break;
-    }
-    if (!isSelectionTier(position.tier)) {
-      errors.push({ field: "memberPositions", message: "選抜区分の値が不正です" });
       break;
     }
     if (!participantMemberIdSet.has(position.memberId)) {
@@ -168,35 +160,11 @@ export function validateRelease(input: CreateReleaseInput): ValidationError[] {
     }
     seenPositionMemberIds.add(position.memberId);
 
-    const hasRow = position.tier === "senbatsu" || position.tier === "under";
-    if (position.rowNumber.trim() !== "") {
-      if (!hasRow) {
-        errors.push({
-          field: "memberPositions",
-          message: "列は選抜/アンダーのみ指定できます",
-        });
-        break;
-      }
-      const rowNumber = Number(position.rowNumber);
-      if (!Number.isInteger(rowNumber) || rowNumber <= 0) {
-        errors.push({
-          field: "memberPositions",
-          message: "列は1以上の整数で入力してください",
-        });
-        break;
-      }
-    }
-    if (position.isCenter && !hasRow) {
+    // 休業中＝出演していない想定。福神（=選抜の前方）とは併存しない。
+    if (position.isFrontSpecial && position.isHiatus) {
       errors.push({
         field: "memberPositions",
-        message: "センターは選抜/アンダーのみ設定できます",
-      });
-      break;
-    }
-    if (position.isFrontSpecial && position.tier !== "senbatsu") {
-      errors.push({
-        field: "memberPositions",
-        message: "福神/櫻エイトは選抜のみ設定できます",
+        message: "休業中のメンバーに福神/櫻エイトは設定できません",
       });
       break;
     }


### PR DESCRIPTION
## 概要
Decision #177（フォーメーション一元管理）の実装。選抜/アンダー/期生・列・センターを **表題/アンダー/期別曲のフォーメーションから導出** し、選抜ポジションの二重管理を解消します。手動保持は **overlay（福神/櫻エイト・休業中）のみ**。

## ⚠️ マイグレーション適用＋動作確認が必要
`042_positions_overlay_from_formation.sql` を適用してください。**導出ロジックはローカルで実行検証できていません**ので、メンバー詳細の表示確認をお願いします。
- `orbit_release_member_positions` を overlay 化（tier/row/center 撤去、is_hiatus 追加）
- `set_release_member_positions` を overlay 総入れ替えに（single＋参加メンバー防御は維持）

## 導出ルール（リリース×メンバー）
- 表題曲(label=title)のフォーメーションに居る → 選抜（列・センターはフォーメーション）
- アンダー曲(label=under) → アンダー（列）
- 期別曲(label=generation) → 期生
- **表題/アンダー曲が複数** → tier優先（選抜>アンダー>期生）→ 同tierは **曲順(track_number)が若い方**
- overlay: 休業中 → 上書き（休業中表示）／福神・櫻エイト → 選抜に付与

## 変更
- repository: `findSelectionPositionsByMemberId` をフォーメーション＋overlay合成へ全面書き換え（フラットな多段クエリ）
- 型: `ReleaseMemberPosition`/`Create…` を overlay(`isFrontSpecial`/`isHiatus`)に
- `ReleaseForm`: 選抜ポジション編集を overlay（福神/休業中チェックのみ）に簡素化（tier/列/センター/サマリは導出に移行し撤去）
- `validateRelease`: overlay 検証に簡素化
- 表示（#169）・ラベル（`selectionPositionLabel`, 休業中含む）は流用

## スコープ外（follow-up）
- **櫻エイト（#179）**: 櫻坂初期 ~5シングルの特別形式。近年はアンダー曲があり本導出で対応可。初期分は #179 で別対応。

## 確認
- `tsc --noEmit` / `eslint` 通過
- 手動（要マイグレーション適用）: 表題/アンダー曲＋フォーメーション登録済みのシングルで、メンバー詳細に 選抜◯列目/センター/アンダー/福神/休業中 等が導出表示されること

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)