### PR TITLE
feat: 櫻エイト期の選抜ポジション導出を追加

### DIFF
--- a/apps/oshikatsu-web/components/admin/ReleaseForm.tsx
+++ b/apps/oshikatsu-web/components/admin/ReleaseForm.tsx
@@ -13,7 +13,7 @@ import {
   type CreateReleaseTrackLinkInput,
   type ReleaseImageUploadInput,
 } from "@/types/release";
-import { getFrontSpecialSelectionLabel } from "@/lib/selectionPositionLabel";
+import { getManualFrontSpecialSelectionLabel } from "@/lib/selectionPositionRules";
 import type { ValidationError } from "@/types/errors";
 import { Input } from "@/components/ui/Input";
 import { Select } from "@/components/ui/Select";
@@ -307,7 +307,8 @@ export function ReleaseForm({
   const selectedGroupName = groups.find(
     (group) => group.id === values.groupId
   )?.nameJa;
-  const frontSpecialLabel = getFrontSpecialSelectionLabel(selectedGroupName);
+  const frontSpecialLabel =
+    getManualFrontSpecialSelectionLabel(selectedGroupName);
 
   const getPosition = (memberId: string): CreateReleaseMemberPositionInput =>
     values.memberPositions.find((position) => position.memberId === memberId) ?? {

--- a/apps/oshikatsu-web/lib/selectionPositionLabel.ts
+++ b/apps/oshikatsu-web/lib/selectionPositionLabel.ts
@@ -1,5 +1,8 @@
 import type { SelectionTier } from "@/types/release";
-import { getFrontSpecialSelectionLabel } from "@/lib/selectionPositionRules";
+import {
+  getFrontSpecialSelectionLabel,
+  isSakurazakaEightEra,
+} from "@/lib/selectionPositionRules";
 
 type SelectionPositionLabelInput = {
   groupNameJa: string;
@@ -55,6 +58,10 @@ export function formatSelectionPositionLabel(
       position.numbering
     );
     if (frontLabel) return rowSuffix ? `${frontLabel}${rowSuffix}` : frontLabel;
+  }
+  // 櫻エイト期は表題曲の後列（3列目以降）を接頭辞なしの「◯列目」で表示する
+  if (isSakurazakaEightEra(position.groupNameJa, position.numbering)) {
+    return rowSuffix || "選抜";
   }
   return rowSuffix ? `選抜${rowSuffix}` : "選抜";
 }

--- a/apps/oshikatsu-web/lib/selectionPositionLabel.ts
+++ b/apps/oshikatsu-web/lib/selectionPositionLabel.ts
@@ -1,7 +1,9 @@
 import type { SelectionTier } from "@/types/release";
+import { getFrontSpecialSelectionLabel } from "@/lib/selectionPositionRules";
 
 type SelectionPositionLabelInput = {
   groupNameJa: string;
+  numbering: number | null;
   tier: SelectionTier;
   rowNumber: number | null;
   isCenter: boolean;
@@ -15,24 +17,12 @@ const UNDER_LABEL_BY_GROUP: Record<string, string> = {
   "日向坂46": "ひなた坂",
 };
 
-// 福神(乃木坂) / 櫻エイト(櫻坂)。該当しないグループは front_special なし
-const FRONT_SPECIAL_LABEL_BY_GROUP: Record<string, string> = {
-  "乃木坂46": "福神",
-  "櫻坂46": "櫻エイト",
-};
-
 export function getUnderSelectionLabel(
   groupNameJa: string | null | undefined
 ): string {
   return groupNameJa
     ? (UNDER_LABEL_BY_GROUP[groupNameJa] ?? "アンダー")
     : "アンダー";
-}
-
-export function getFrontSpecialSelectionLabel(
-  groupNameJa: string | null | undefined
-): string | null {
-  return groupNameJa ? (FRONT_SPECIAL_LABEL_BY_GROUP[groupNameJa] ?? null) : null;
 }
 
 // 選抜ポジションを表示用ラベルに変換する。
@@ -60,7 +50,10 @@ export function formatSelectionPositionLabel(
   // senbatsu
   if (position.isCenter) return "センター";
   if (position.isFrontSpecial) {
-    const frontLabel = getFrontSpecialSelectionLabel(position.groupNameJa);
+    const frontLabel = getFrontSpecialSelectionLabel(
+      position.groupNameJa,
+      position.numbering
+    );
     if (frontLabel) return rowSuffix ? `${frontLabel}${rowSuffix}` : frontLabel;
   }
   return rowSuffix ? `選抜${rowSuffix}` : "選抜";

--- a/apps/oshikatsu-web/lib/selectionPositionRules.ts
+++ b/apps/oshikatsu-web/lib/selectionPositionRules.ts
@@ -1,0 +1,31 @@
+const NOGIZAKA_GROUP_NAME = "乃木坂46";
+const SAKURAZAKA_GROUP_NAME = "櫻坂46";
+const SAKURAZAKA_EIGHT_MIN_SINGLE = 1;
+const SAKURAZAKA_EIGHT_MAX_SINGLE = 5;
+
+export function isSakurazakaEightEra(
+  groupNameJa: string | null | undefined,
+  numbering: number | null | undefined
+): boolean {
+  return (
+    groupNameJa === SAKURAZAKA_GROUP_NAME &&
+    numbering != null &&
+    numbering >= SAKURAZAKA_EIGHT_MIN_SINGLE &&
+    numbering <= SAKURAZAKA_EIGHT_MAX_SINGLE
+  );
+}
+
+export function getFrontSpecialSelectionLabel(
+  groupNameJa: string | null | undefined,
+  numbering: number | null | undefined
+): string | null {
+  if (groupNameJa === NOGIZAKA_GROUP_NAME) return "福神";
+  if (isSakurazakaEightEra(groupNameJa, numbering)) return "櫻エイト";
+  return null;
+}
+
+export function getManualFrontSpecialSelectionLabel(
+  groupNameJa: string | null | undefined
+): string | null {
+  return groupNameJa === NOGIZAKA_GROUP_NAME ? "福神" : null;
+}

--- a/apps/oshikatsu-web/lib/selectionPositionRules.ts
+++ b/apps/oshikatsu-web/lib/selectionPositionRules.ts
@@ -2,6 +2,8 @@ const NOGIZAKA_GROUP_NAME = "乃木坂46";
 const SAKURAZAKA_GROUP_NAME = "櫻坂46";
 const SAKURAZAKA_EIGHT_MIN_SINGLE = 1;
 const SAKURAZAKA_EIGHT_MAX_SINGLE = 5;
+// 櫻エイト期の表題曲フォーメーションで「櫻エイト」となる前方の列数（1・2列目）。
+export const SAKURAZAKA_EIGHT_FRONT_ROW_COUNT = 2;
 
 export function isSakurazakaEightEra(
   groupNameJa: string | null | undefined,

--- a/apps/oshikatsu-web/repositories/releaseRepository.ts
+++ b/apps/oshikatsu-web/repositories/releaseRepository.ts
@@ -345,6 +345,7 @@ type FormationPlacement = { rowNumber: number; isCenter: boolean };
 type RepresentativeTrack = {
   trackId: string;
   trackNumber: number;
+  label: string;
   tier: SelectionTier;
   priority: number;
 };
@@ -782,6 +783,7 @@ export function createReleaseRepository(
             byGroup.set(groupKey, {
               trackId: link.track_id,
               trackNumber: link.track_number,
+              label: info.label,
               tier: entry.tier,
               priority,
             });
@@ -802,10 +804,10 @@ export function createReleaseRepository(
         for (const rep of byGroup.values()) {
           const fm = formationByTrack.get(rep.trackId);
           if (!fm) continue; // 代表トラックにメンバーが居ない → 不該当
-          // 櫻エイト期は表題曲(senbatsu)のみ導出。それ以外（BACKS曲等）は
+          // 櫻エイト期は表題曲(label=title)のみ導出。選抜カップリング/BACKS曲等は
           // 列を使わず、後段で「BACKS」として補完する。
           const candidate = usesSakurazakaEightRule
-            ? rep.tier === "senbatsu"
+            ? rep.label === "title"
               ? toSakurazakaEightCandidate(rep, fm)
               : null
             : toNormalDerivedCandidate(rep, fm);

--- a/apps/oshikatsu-web/repositories/releaseRepository.ts
+++ b/apps/oshikatsu-web/repositories/releaseRepository.ts
@@ -12,6 +12,7 @@ import type { ReleaseRepository } from "@/types/repositories";
 import { RepositoryError } from "@/types/errors";
 import { compareByGenerationThenName } from "@/lib/memberOrder";
 import {
+  SAKURAZAKA_EIGHT_FRONT_ROW_COUNT,
   getManualFrontSpecialSelectionLabel,
   isSakurazakaEightEra,
 } from "@/lib/selectionPositionRules";
@@ -378,13 +379,16 @@ function toSakurazakaEightCandidate(
 ): RankedDerivedSelection | null {
   if (rep.tier !== "senbatsu") return null;
 
-  const isFrontSpecial = placement.rowNumber <= 2;
+  // 表題曲の 1・2列目=櫻エイト、3列目以降=接頭辞なしの「◯列目」（どちらも選抜のまま）。
+  // 表題曲に居ないメンバーは別途 BACKS として補完する。
+  const isFrontSpecial =
+    placement.rowNumber <= SAKURAZAKA_EIGHT_FRONT_ROW_COUNT;
   return {
     priority: rep.priority,
     trackNumber: rep.trackNumber,
-    tier: isFrontSpecial ? "senbatsu" : "under",
+    tier: "senbatsu",
     rowNumber: placement.rowNumber,
-    isCenter: isFrontSpecial ? placement.isCenter : false,
+    isCenter: placement.isCenter,
     isFrontSpecial,
   };
 }
@@ -636,6 +640,16 @@ export function createReleaseRepository(
         );
       }
 
+      // 3.5) メンバーが参加（出演）するリリース（櫻エイト期のBACKS判定に使う）
+      const { data: pm, error: pmErr } = await supabase
+        .from("orbit_release_members")
+        .select("release_id")
+        .eq("member_id", memberId);
+      if (pmErr) throw fail(pmErr);
+      const participationReleaseIds = (
+        (pm as Array<{ release_id: string }>) ?? []
+      ).map((x) => x.release_id);
+
       // 4) overlay（福神・休業中）
       const { data: overlayData, error: ovErr } = await supabase
         .from("orbit_release_member_positions")
@@ -661,6 +675,7 @@ export function createReleaseRepository(
       const releaseIds = unique([
         ...candidateReleaseIds,
         ...overlayByRelease.keys(),
+        ...participationReleaseIds,
       ]);
       const releaseInfo = new Map<
         string,
@@ -697,15 +712,19 @@ export function createReleaseRepository(
         }
       }
       const singleReleaseIds = Array.from(releaseInfo.keys());
+      // 代表トラック算出は「メンバーが選抜対象トラックに居るシングル」に限定（重いクエリ抑制）
+      const formationCandidateSingleIds = unique(
+        candidateReleaseIds.filter((id) => releaseInfo.has(id))
+      );
 
       // 6) 候補シングルの全トラックから、グループごとの代表トラック（最小track_number）を求める。
       // グループキー = ラベル。ただし期別曲は期(generation)ごとに別グループとして潰さない。
       const repByRelease = new Map<string, Map<string, RepresentativeTrack>>();
-      if (singleReleaseIds.length > 0) {
+      if (formationCandidateSingleIds.length > 0) {
         const { data: allRt, error: allRtErr } = await supabase
           .from("orbit_release_tracks")
           .select("track_id, track_number, release_id")
-          .in("release_id", singleReleaseIds);
+          .in("release_id", formationCandidateSingleIds);
         if (allRtErr) throw fail(allRtErr);
         const allLinks =
           (allRt as Array<{
@@ -772,7 +791,7 @@ export function createReleaseRepository(
 
       // 7) リリースごとに、代表トラックにメンバーが居るグループのうち最優先のtierを採用
       const derived = new Map<string, DerivedSelection>();
-      for (const releaseId of singleReleaseIds) {
+      for (const releaseId of formationCandidateSingleIds) {
         const byGroup = repByRelease.get(releaseId);
         const release = releaseInfo.get(releaseId);
         if (!byGroup) continue;
@@ -783,10 +802,13 @@ export function createReleaseRepository(
         for (const rep of byGroup.values()) {
           const fm = formationByTrack.get(rep.trackId);
           if (!fm) continue; // 代表トラックにメンバーが居ない → 不該当
-          const candidate =
-            usesSakurazakaEightRule && rep.tier === "senbatsu"
+          // 櫻エイト期は表題曲(senbatsu)のみ導出。それ以外（BACKS曲等）は
+          // 列を使わず、後段で「BACKS」として補完する。
+          const candidate = usesSakurazakaEightRule
+            ? rep.tier === "senbatsu"
               ? toSakurazakaEightCandidate(rep, fm)
-              : toNormalDerivedCandidate(rep, fm);
+              : null
+            : toNormalDerivedCandidate(rep, fm);
           if (candidate && isBetterDerivedCandidate(candidate, best)) {
             best = candidate;
           }
@@ -799,6 +821,24 @@ export function createReleaseRepository(
             isFrontSpecial: best.isFrontSpecial,
           });
         }
+      }
+
+      // 7.5) 櫻エイト期: 表題曲に居ない参加メンバーは BACKS（アンダー・列なし）として補完
+      const participationReleaseIdSet = new Set(participationReleaseIds);
+      for (const releaseId of singleReleaseIds) {
+        if (derived.has(releaseId)) continue;
+        if (!participationReleaseIdSet.has(releaseId)) continue;
+        const release = releaseInfo.get(releaseId);
+        if (!release) continue;
+        if (!isSakurazakaEightEra(release.groupNameJa, release.numbering)) {
+          continue;
+        }
+        derived.set(releaseId, {
+          tier: "under",
+          rowNumber: null,
+          isCenter: false,
+          isFrontSpecial: false,
+        });
       }
 
       // 8) 組み立て（overlay反映・休業中は上書き／休業中のみのリリースも表示）

--- a/apps/oshikatsu-web/repositories/releaseRepository.ts
+++ b/apps/oshikatsu-web/repositories/releaseRepository.ts
@@ -11,6 +11,10 @@ import type {
 import type { ReleaseRepository } from "@/types/repositories";
 import { RepositoryError } from "@/types/errors";
 import { compareByGenerationThenName } from "@/lib/memberOrder";
+import {
+  getManualFrontSpecialSelectionLabel,
+  isSakurazakaEightEra,
+} from "@/lib/selectionPositionRules";
 
 type ReleaseGroupRow =
   | {
@@ -335,7 +339,75 @@ function labelDerivation(label: string | null | undefined) {
   return LABEL_DERIVATION.find((entry) => entry.label === label);
 }
 
-// overlay（福神/櫻エイト・休業中）の保存入力。いずれかが立つメンバーのみ送る。
+type FormationPlacement = { rowNumber: number; isCenter: boolean };
+
+type RepresentativeTrack = {
+  trackId: string;
+  trackNumber: number;
+  tier: SelectionTier;
+  priority: number;
+};
+
+type DerivedSelection = {
+  tier: SelectionTier;
+  rowNumber: number | null;
+  isCenter: boolean;
+  isFrontSpecial: boolean;
+};
+
+type RankedDerivedSelection = DerivedSelection & {
+  priority: number;
+  trackNumber: number;
+};
+
+function isBetterDerivedCandidate(
+  candidate: RankedDerivedSelection,
+  current: RankedDerivedSelection | null
+): boolean {
+  return (
+    !current ||
+    candidate.priority < current.priority ||
+    (candidate.priority === current.priority &&
+      candidate.trackNumber < current.trackNumber)
+  );
+}
+
+function toSakurazakaEightCandidate(
+  rep: RepresentativeTrack,
+  placement: FormationPlacement
+): RankedDerivedSelection | null {
+  if (rep.tier !== "senbatsu") return null;
+
+  const isFrontSpecial = placement.rowNumber <= 2;
+  return {
+    priority: rep.priority,
+    trackNumber: rep.trackNumber,
+    tier: isFrontSpecial ? "senbatsu" : "under",
+    rowNumber: placement.rowNumber,
+    isCenter: isFrontSpecial ? placement.isCenter : false,
+    isFrontSpecial,
+  };
+}
+
+function toNormalDerivedCandidate(
+  rep: RepresentativeTrack,
+  placement: FormationPlacement
+): RankedDerivedSelection {
+  return {
+    priority: rep.priority,
+    trackNumber: rep.trackNumber,
+    tier: rep.tier,
+    rowNumber: placement.rowNumber,
+    isCenter: placement.isCenter,
+    isFrontSpecial: false,
+  };
+}
+
+function canApplyManualFrontSpecial(groupNameJa: string): boolean {
+  return getManualFrontSpecialSelectionLabel(groupNameJa) !== null;
+}
+
+// overlay（福神・休業中）の保存入力。いずれかが立つメンバーのみ送る。
 function toMemberPositionRpcInput(
   positions: CreateReleaseInput["memberPositions"]
 ): Array<{
@@ -522,10 +594,7 @@ export function createReleaseRepository(
       }
 
       // track_id -> { 列, センター }（メンバーは1トラックにつき1行）
-      const formationByTrack = new Map<
-        string,
-        { rowNumber: number; isCenter: boolean }
-      >();
+      const formationByTrack = new Map<string, FormationPlacement>();
       for (const mr of memberRows) {
         const info = rowInfo.get(mr.formation_row_id);
         if (!info) continue;
@@ -567,7 +636,7 @@ export function createReleaseRepository(
         );
       }
 
-      // 4) overlay（福神/櫻エイト・休業中）
+      // 4) overlay（福神・休業中）
       const { data: overlayData, error: ovErr } = await supabase
         .from("orbit_release_member_positions")
         .select("release_id, is_front_special, is_hiatus")
@@ -631,13 +700,7 @@ export function createReleaseRepository(
 
       // 6) 候補シングルの全トラックから、グループごとの代表トラック（最小track_number）を求める。
       // グループキー = ラベル。ただし期別曲は期(generation)ごとに別グループとして潰さない。
-      type RepEntry = {
-        trackId: string;
-        trackNumber: number;
-        tier: SelectionTier;
-        priority: number;
-      };
-      const repByRelease = new Map<string, Map<string, RepEntry>>();
+      const repByRelease = new Map<string, Map<string, RepresentativeTrack>>();
       if (singleReleaseIds.length > 0) {
         const { data: allRt, error: allRtErr } = await supabase
           .from("orbit_release_tracks")
@@ -708,24 +771,24 @@ export function createReleaseRepository(
       }
 
       // 7) リリースごとに、代表トラックにメンバーが居るグループのうち最優先のtierを採用
-      const derived = new Map<
-        string,
-        { tier: SelectionTier; rowNumber: number | null; isCenter: boolean }
-      >();
+      const derived = new Map<string, DerivedSelection>();
       for (const releaseId of singleReleaseIds) {
         const byGroup = repByRelease.get(releaseId);
+        const release = releaseInfo.get(releaseId);
         if (!byGroup) continue;
-        let best: { priority: number; tier: SelectionTier; rowNumber: number; isCenter: boolean } | null = null;
+        const usesSakurazakaEightRule =
+          release != null &&
+          isSakurazakaEightEra(release.groupNameJa, release.numbering);
+        let best: RankedDerivedSelection | null = null;
         for (const rep of byGroup.values()) {
           const fm = formationByTrack.get(rep.trackId);
           if (!fm) continue; // 代表トラックにメンバーが居ない → 不該当
-          if (!best || rep.priority < best.priority) {
-            best = {
-              priority: rep.priority,
-              tier: rep.tier,
-              rowNumber: fm.rowNumber,
-              isCenter: fm.isCenter,
-            };
+          const candidate =
+            usesSakurazakaEightRule && rep.tier === "senbatsu"
+              ? toSakurazakaEightCandidate(rep, fm)
+              : toNormalDerivedCandidate(rep, fm);
+          if (candidate && isBetterDerivedCandidate(candidate, best)) {
+            best = candidate;
           }
         }
         if (best) {
@@ -733,6 +796,7 @@ export function createReleaseRepository(
             tier: best.tier,
             rowNumber: best.rowNumber,
             isCenter: best.isCenter,
+            isFrontSpecial: best.isFrontSpecial,
           });
         }
       }
@@ -772,9 +836,12 @@ export function createReleaseRepository(
           tier: base.tier,
           rowNumber: base.rowNumber,
           isCenter: base.isCenter,
-          // 福神/櫻エイトは選抜のメンバーにのみ反映する
+          // 福神は overlay、櫻エイトは初期櫻坂ルールの導出結果として反映する。
           isFrontSpecial:
-            base.tier === "senbatsu" ? (overlay?.isFrontSpecial ?? false) : false,
+            base.tier === "senbatsu" &&
+            (base.isFrontSpecial ||
+              (canApplyManualFrontSpecial(info.groupNameJa) &&
+                (overlay?.isFrontSpecial ?? false))),
         });
       }
 

--- a/apps/oshikatsu-web/types/release.ts
+++ b/apps/oshikatsu-web/types/release.ts
@@ -113,7 +113,7 @@ export const SELECTION_TIERS = [
 export type SelectionTier = (typeof SELECTION_TIERS)[number];
 
 // 選抜/アンダー/期生・列・センターはフォーメーションから導出する（Decision #177）。
-// リリース×メンバーで手動保持するのは overlay（福神/櫻エイト・休業中）のみ。
+// 手動保持する overlay は福神/休業中のみ。櫻エイトは初期櫻坂ルールで自動導出する。
 export type ReleaseMemberPosition = {
   memberId: string;
   isFrontSpecial: boolean;

--- a/apps/oshikatsu-web/usecases/validateRelease.ts
+++ b/apps/oshikatsu-web/usecases/validateRelease.ts
@@ -164,7 +164,7 @@ export function validateRelease(input: CreateReleaseInput): ValidationError[] {
     if (position.isFrontSpecial && position.isHiatus) {
       errors.push({
         field: "memberPositions",
-        message: "休業中のメンバーに福神/櫻エイトは設定できません",
+        message: "休業中のメンバーに福神は設定できません",
       });
       break;
     }


### PR DESCRIPTION
## 概要
櫻坂46の初期シングル（1st〜5th）に対して、櫻エイト期の選抜ポジション導出ルールを追加しました。

## 変更内容
- 櫻坂46 1st〜5th Single を櫻エイト期として判定するルールを追加
- 櫻エイト期では `title` / `senbatsu` 系代表トラックの列から以下を導出
  - 1・2列目: `senbatsu` + `isFrontSpecial`（櫻エイト）
  - 3列目以降: `under`（BACKS表示）
- 櫻エイトは手動 overlay ではなく自動導出に変更
- 手動の front special 指定は乃木坂46の福神のみ表示・保存対象に整理
- 櫻坂46 6th以降は櫻エイト表示を出さず、既存の #178 導出を維持

## 確認
- `pnpm --filter oshikatsu-web typecheck`
- `pnpm --filter oshikatsu-web lint`

Closes #179