### PR TITLE
feat: 制作陣の候補を担当(role)で絞り込む

### DIFF
--- a/apps/oshikatsu-web/app/(authenticated)/admin/releases/[id]/edit/page.tsx
+++ b/apps/oshikatsu-web/app/(authenticated)/admin/releases/[id]/edit/page.tsx
@@ -89,7 +89,7 @@ export default async function EditReleasePage({
         groups={groups}
         members={members}
         tracks={songOptions}
-        people={people.map((person) => person.displayName)}
+        people={people}
         onSubmit={handleSubmit}
       />
     </div>

--- a/apps/oshikatsu-web/app/(authenticated)/admin/releases/new/page.tsx
+++ b/apps/oshikatsu-web/app/(authenticated)/admin/releases/new/page.tsx
@@ -28,7 +28,7 @@ export default async function NewReleasePage() {
         groups={groups}
         members={members}
         tracks={songOptions}
-        people={people.map((person) => person.displayName)}
+        people={people}
         onSubmit={handleSubmit}
       />
     </div>

--- a/apps/oshikatsu-web/app/(authenticated)/admin/songs/[id]/edit/page.tsx
+++ b/apps/oshikatsu-web/app/(authenticated)/admin/songs/[id]/edit/page.tsx
@@ -109,7 +109,7 @@ export default async function EditSongPage({
         groups={groups}
         releases={releases}
         members={members}
-        people={people.map((person) => person.displayName)}
+        people={people}
         onSubmit={handleSubmit}
       />
     </div>

--- a/apps/oshikatsu-web/app/(authenticated)/admin/songs/new/page.tsx
+++ b/apps/oshikatsu-web/app/(authenticated)/admin/songs/new/page.tsx
@@ -27,7 +27,7 @@ export default async function NewSongPage() {
         groups={groups}
         releases={releases}
         members={members}
-        people={people.map((person) => person.displayName)}
+        people={people}
         onSubmit={handleSubmit}
       />
     </div>

--- a/apps/oshikatsu-web/components/admin/ReleaseForm.tsx
+++ b/apps/oshikatsu-web/components/admin/ReleaseForm.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import { useEffect, useMemo, useState } from "react";
 import type { Group } from "@/types/group";
 import type { MemberOption } from "@/types/member";
+import type { PersonOption } from "@/types/person";
 import {
   RELEASE_TYPES,
   RELEASE_TYPE_LABELS,
@@ -46,7 +47,7 @@ type ReleaseFormProps = {
   groups: Group[];
   members: MemberOption[];
   tracks: ReleaseTrackOption[];
-  people: string[];
+  people: PersonOption[];
   onSubmit: (
     values: CreateReleaseInput,
     imageFile?: ReleaseImageUploadInput
@@ -595,9 +596,11 @@ export function ReleaseForm({
           error={errors.artworkPersonName}
         />
         <datalist id="artwork-person-suggestions">
-          {people.map((personName) => (
-            <option key={personName} value={personName} />
-          ))}
+          {people
+            .filter((person) => person.roles.includes("artwork"))
+            .map((person) => (
+              <option key={person.id} value={person.displayName} />
+            ))}
         </datalist>
 
         <div>

--- a/apps/oshikatsu-web/components/admin/SongForm.tsx
+++ b/apps/oshikatsu-web/components/admin/SongForm.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import type { Group } from "@/types/group";
 import type { ReleaseOption } from "@/types/release";
 import type { MemberOption } from "@/types/member";
+import type { PersonOption, PersonRole } from "@/types/person";
 import type {
   CreateSongInput,
   CreateSongCostumeInput,
@@ -50,20 +51,31 @@ type SongFormProps = {
   groups: Group[];
   releases: ReleaseOption[];
   members: MemberOption[];
-  people: string[];
+  people: PersonOption[];
   onSubmit: (
     values: CreateSongInput
   ) => Promise<{ errors?: ValidationError[] }>;
 };
 
+// 制作陣フィールドと担当(role)の対応。編曲は作曲(music)を共用する。
 const CREDIT_FIELDS = [
-  { key: "lyricsPeople", label: "作詞" },
-  { key: "musicPeople", label: "作曲" },
-  { key: "arrangementPeople", label: "編曲" },
-  { key: "choreographyPeople", label: "振付" },
+  { key: "lyricsPeople", label: "作詞", role: "lyrics" },
+  { key: "musicPeople", label: "作曲", role: "music" },
+  { key: "arrangementPeople", label: "編曲", role: "music" },
+  { key: "choreographyPeople", label: "振付", role: "choreography" },
 ] as const;
 
 type CreditFieldKey = (typeof CREDIT_FIELDS)[number]["key"];
+
+// 担当(role)を持つ人物の表示名のみを候補に返す
+function peopleNamesForRole(
+  people: PersonOption[],
+  role: PersonRole
+): string[] {
+  return people
+    .filter((person) => person.roles.includes(role))
+    .map((person) => person.displayName);
+}
 
 function splitPeople(value: string): string[] {
   return value
@@ -812,10 +824,10 @@ export function SongForm({
       </div>
 
       <div className="space-y-3">
-        {CREDIT_FIELDS.map(({ key, label }) => {
+        {CREDIT_FIELDS.map(({ key, label, role }) => {
           const selectedPeople = splitPeople(values[key]);
           const query = creditQueries[key];
-          const suggestions = people
+          const suggestions = peopleNamesForRole(people, role)
             .filter((personName) => personName.toLowerCase().includes(query.trim().toLowerCase()))
             .slice(0, 20);
 
@@ -1080,7 +1092,7 @@ export function SongForm({
               <Input
                 id="mv-director"
                 label="監督"
-                list="song-person-suggestions"
+                list="person-suggestions-mv_director"
                 value={values.mv.directorName}
                 onChange={(e) => update("mv", { ...values.mv, directorName: e.target.value })}
                 error={errors["mv.directorName"]}
@@ -1140,7 +1152,7 @@ export function SongForm({
                 <Input
                   id={`costume-stylist-${costume._key}`}
                   label="衣装担当*"
-                  list="song-person-suggestions"
+                  list="person-suggestions-costume"
                   value={costume.stylistName}
                   onChange={(e) => updateCostume(costume._key, "stylistName", e.target.value)}
                   error={errors[`costumes.${index}.stylistName`]}
@@ -1170,8 +1182,13 @@ export function SongForm({
         </div>
       </div>
 
-      <datalist id="song-person-suggestions">
-        {people.map((personName) => (
+      <datalist id="person-suggestions-mv_director">
+        {peopleNamesForRole(people, "mv_director").map((personName) => (
+          <option key={personName} value={personName} />
+        ))}
+      </datalist>
+      <datalist id="person-suggestions-costume">
+        {peopleNamesForRole(people, "costume").map((personName) => (
           <option key={personName} value={personName} />
         ))}
       </datalist>

--- a/apps/oshikatsu-web/repositories/personRepository.ts
+++ b/apps/oshikatsu-web/repositories/personRepository.ts
@@ -14,6 +14,7 @@ type PersonRow = {
 type PersonOptionRow = {
   id: string;
   display_name: string;
+  roles: string[] | null;
 };
 
 export function createPersonRepository(supabase: SupabaseClient): PersonRepository {
@@ -30,6 +31,7 @@ export function createPersonRepository(supabase: SupabaseClient): PersonReposito
   const mapPersonOption = (row: PersonOptionRow): PersonOption => ({
     id: row.id,
     displayName: row.display_name,
+    roles: (row.roles ?? []) as PersonRole[],
   });
 
   return {
@@ -49,7 +51,7 @@ export function createPersonRepository(supabase: SupabaseClient): PersonReposito
     async findOptions() {
       const { data, error } = await supabase
         .from("orbit_people")
-        .select("id, display_name")
+        .select("id, display_name, roles")
         .order("display_name");
 
       if (error) {

--- a/apps/oshikatsu-web/types/person.ts
+++ b/apps/oshikatsu-web/types/person.ts
@@ -33,6 +33,7 @@ export type Person = {
 export type PersonOption = {
   id: string;
   displayName: string;
+  roles: PersonRole[];
 };
 
 export type CreatePersonInput = {


### PR DESCRIPTION
## 概要
制作陣（`orbit_people`）を選ぶ各フィールドで、対応する担当(role)を持つ人物のみを候補（datalist）に表示します。マイグレーション不要。

## フィールド→role 対応
- 作詞→`lyrics` / 作曲→`music` / **編曲→`music`（作曲を共用）** / 振付→`choreography`
- MV監督→`mv_director` / 衣装担当→`costume` / アートワーク担当→`artwork`

## 変更
- `PersonOption` に `roles` を追加し、`personRepository.findOptions` で `roles` も取得。
- `SongForm`: クレジット4フィールド・MV監督・衣装の候補を role で絞り込み（role別 datalist）。
- `ReleaseForm`: アートワーク担当を `artwork` role で絞り込み。
- 各フォームの `people` prop を `string[]` → `PersonOption[]` に変更し、ページは `PersonOption[]` をそのまま渡す。

## 決定事項の反映
- 編曲は作曲(music)を参照（新 role・migration なし）。
- MV監督は `mv_director` のみ（`pv_director` は未使用のまま温存）。

## 確認
- `tsc --noEmit` / `eslint` 通過
- 手動: 各フィールドの候補が該当 role の人物に絞られること（role 未設定の人物は候補に出ない → 追加は #185 で対応）

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)