### PR TITLE
feat: リリース収録曲に楽曲ラベルを表示

### DIFF
--- a/apps/oshikatsu-web/components/releases/ReleaseDetail.tsx
+++ b/apps/oshikatsu-web/components/releases/ReleaseDetail.tsx
@@ -4,13 +4,17 @@ import type { Release } from "@/types/release";
 import { RELEASE_TYPE_LABELS, ordinalNumber } from "@/types/release";
 import { GroupBadge } from "@/components/ui/GroupBadge";
 import { Card } from "@/components/ui/Card";
+import { Badge } from "@/components/ui/Badge";
 import { formatDate } from "@/lib/formatters";
 import { resolveReleaseImageSrc } from "@/lib/releaseImage";
 import { formatMemberCountSummary } from "@/lib/memberCountSummary";
+import { formatSongLabel } from "@/types/song";
 
 type ReleaseDetailProps = {
   release: Release;
 };
+
+const SONG_LABEL_COLOR = "#8B5CF6";
 
 export function ReleaseDetail({ release }: ReleaseDetailProps) {
   const artworkSrc = resolveReleaseImageSrc(release.artworkPath);
@@ -77,19 +81,28 @@ export function ReleaseDetail({ release }: ReleaseDetailProps) {
         <Card>
           <h2 className="mb-3 text-sm font-medium text-foreground/70">収録曲</h2>
           <ol className="space-y-2">
-            {release.tracks.map((track) => (
-              <li key={track.trackId} className="rounded-lg border border-foreground/10 p-3">
-                <div className="flex items-center justify-between gap-3">
-                  <span className="text-sm text-foreground/60">{track.trackNumber}.</span>
-                  <Link
-                    href={`/songs/${track.trackId}`}
-                    className="flex-1 text-sm text-foreground hover:underline"
-                  >
-                    {track.trackTitle}
-                  </Link>
-                </div>
-              </li>
-            ))}
+            {release.tracks.map((track) => {
+              const labelText = formatSongLabel(
+                track.label,
+                track.generation,
+                track.groupNameJa
+              );
+
+              return (
+                <li key={track.trackId} className="rounded-lg border border-foreground/10 p-3">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="text-sm text-foreground/60">{track.trackNumber}.</span>
+                    <Link
+                      href={`/songs/${track.trackId}`}
+                      className="min-w-0 flex-1 text-sm text-foreground hover:underline"
+                    >
+                      {track.trackTitle}
+                    </Link>
+                    {labelText && <Badge label={labelText} color={SONG_LABEL_COLOR} />}
+                  </div>
+                </li>
+              );
+            })}
           </ol>
         </Card>
       )}

--- a/apps/oshikatsu-web/components/releases/ReleaseDetail.tsx
+++ b/apps/oshikatsu-web/components/releases/ReleaseDetail.tsx
@@ -8,13 +8,11 @@ import { Badge } from "@/components/ui/Badge";
 import { formatDate } from "@/lib/formatters";
 import { resolveReleaseImageSrc } from "@/lib/releaseImage";
 import { formatMemberCountSummary } from "@/lib/memberCountSummary";
-import { formatSongLabel } from "@/types/song";
+import { SONG_LABEL_BADGE_COLOR, formatSongLabel } from "@/types/song";
 
 type ReleaseDetailProps = {
   release: Release;
 };
-
-const SONG_LABEL_COLOR = "#8B5CF6";
 
 export function ReleaseDetail({ release }: ReleaseDetailProps) {
   const artworkSrc = resolveReleaseImageSrc(release.artworkPath);
@@ -98,7 +96,7 @@ export function ReleaseDetail({ release }: ReleaseDetailProps) {
                     >
                       {track.trackTitle}
                     </Link>
-                    {labelText && <Badge label={labelText} color={SONG_LABEL_COLOR} />}
+                    {labelText && <Badge label={labelText} color={SONG_LABEL_BADGE_COLOR} />}
                   </div>
                 </li>
               );

--- a/apps/oshikatsu-web/components/songs/SongCard.tsx
+++ b/apps/oshikatsu-web/components/songs/SongCard.tsx
@@ -1,12 +1,10 @@
 import { PendingLink } from "@/components/ui/PendingLink";
 import { Badge } from "@/components/ui/Badge";
 import type { SongListItem } from "@/types/song";
-import { formatSongLabel } from "@/types/song";
+import { SONG_LABEL_BADGE_COLOR, formatSongLabel } from "@/types/song";
 import { formatReleaseTypeLabel } from "@/types/release";
 import { formatDate } from "@/lib/formatters";
 import { APP_ROUTES } from "@/lib/routes";
-
-const SONG_LABEL_COLOR = "#8B5CF6";
 
 type SongCardProps = {
   showGroupName?: boolean;
@@ -37,7 +35,7 @@ export function SongCard({ showGroupName = true, song }: SongCardProps) {
               )}
             </span>
           )}
-          {labelText && <Badge label={labelText} color={SONG_LABEL_COLOR} />}
+          {labelText && <Badge label={labelText} color={SONG_LABEL_BADGE_COLOR} />}
         </div>
       )}
       {song.firstReleaseDate && (

--- a/apps/oshikatsu-web/components/songs/SongDetail.tsx
+++ b/apps/oshikatsu-web/components/songs/SongDetail.tsx
@@ -6,7 +6,7 @@ import { Badge } from "@/components/ui/Badge";
 import { FormationDisplay } from "@/components/songs/FormationDisplay";
 import { formatDate } from "@/lib/formatters";
 import { formatReleaseTypeLabel, RELEASE_TYPE_LABELS } from "@/types/release";
-import { formatSongLabel } from "@/types/song";
+import { SONG_LABEL_BADGE_COLOR, formatSongLabel } from "@/types/song";
 
 const CREDIT_LABELS: Record<string, string> = {
   lyrics: "作詞",
@@ -14,8 +14,6 @@ const CREDIT_LABELS: Record<string, string> = {
   arrangement: "編曲",
   choreography: "振付",
 };
-
-const SONG_LABEL_COLOR = "#8B5CF6";
 
 export function SongDetail({ song }: { song: Song }) {
   const labelText = formatSongLabel(song.label, song.generation, song.groupNameJa);
@@ -40,7 +38,7 @@ export function SongDetail({ song }: { song: Song }) {
           {releaseLabelText && (
             <span className="text-sm text-foreground/50">{releaseLabelText}</span>
           )}
-          {labelText && <Badge label={labelText} color={SONG_LABEL_COLOR} />}
+          {labelText && <Badge label={labelText} color={SONG_LABEL_BADGE_COLOR} />}
         </div>
       </div>
 

--- a/apps/oshikatsu-web/repositories/releaseRepository.ts
+++ b/apps/oshikatsu-web/repositories/releaseRepository.ts
@@ -16,6 +16,7 @@ import {
   getManualFrontSpecialSelectionLabel,
   isSakurazakaEightEra,
 } from "@/lib/selectionPositionRules";
+import { isSongLabel, type SongLabel } from "@/types/song";
 
 type ReleaseGroupRow =
   | {
@@ -77,10 +78,16 @@ type ReleaseTrackRow = {
     | {
         id: string;
         title: string;
+        label: string | null;
+        generation: string | null;
+        orbit_groups: ReleaseGroupRow;
       }
     | Array<{
         id: string;
         title: string;
+        label: string | null;
+        generation: string | null;
+        orbit_groups: ReleaseGroupRow;
       }>
     | null;
 };
@@ -163,7 +170,7 @@ const RELEASE_DETAIL_SELECT = `
   orbit_release_bonus_videos(id, edition, title, description, sort_order),
   orbit_release_members(member_id, orbit_members(name_ja, name_kana, orbit_member_groups(group_id, generation))),
   orbit_release_member_positions(member_id, is_front_special, is_hiatus),
-  orbit_release_tracks(track_number, orbit_tracks(id, title))
+  orbit_release_tracks(track_number, orbit_tracks(id, title, label, generation, orbit_groups(name_ja, color)))
 `;
 
 const RELEASE_PUBLIC_LIST_SELECT = `
@@ -253,16 +260,25 @@ function mapToRelease(row: ReleaseRow): Release {
           ? item.orbit_tracks[0]
           : item.orbit_tracks;
         if (!track) return null;
+        const trackGroup = Array.isArray(track.orbit_groups)
+          ? track.orbit_groups[0]
+          : track.orbit_groups;
         return {
           trackId: track.id,
           trackTitle: track.title,
           trackNumber: item.track_number,
+          groupNameJa: trackGroup?.name_ja ?? "",
+          label: isSongLabel(track.label ?? "") ? (track.label as SongLabel) : null,
+          generation: track.generation,
         };
       })
       .filter((item): item is {
         trackId: string;
         trackTitle: string;
         trackNumber: number;
+        groupNameJa: string;
+        label: SongLabel | null;
+        generation: string | null;
       } => Boolean(item))
       .sort((a, b) => a.trackNumber - b.trackNumber),
   };

--- a/apps/oshikatsu-web/types/release.ts
+++ b/apps/oshikatsu-web/types/release.ts
@@ -1,4 +1,5 @@
 import type { Group } from "@/types/group";
+import type { SongLabel } from "@/types/song";
 
 export const RELEASE_TYPES = [
   "single",
@@ -81,6 +82,9 @@ export type ReleaseTrack = {
   trackId: string;
   trackTitle: string;
   trackNumber: number;
+  groupNameJa: string;
+  label: SongLabel | null;
+  generation: string | null;
 };
 
 export type Release = {

--- a/apps/oshikatsu-web/types/song.ts
+++ b/apps/oshikatsu-web/types/song.ts
@@ -21,6 +21,8 @@ export const SONG_LABEL_LABELS: Record<SongLabel, string> = {
   generation: "期別",
 };
 
+export const SONG_LABEL_BADGE_COLOR = "#8B5CF6";
+
 // アンダーのグループ別表示名（内部値は under 共通）
 const UNDER_LABEL_BY_GROUP: Record<string, string> = {
   乃木坂46: "アンダー",


### PR DESCRIPTION
## 概要

リリース詳細の「収録曲」に、楽曲ラベルを表示します。

## 変更内容

- `ReleaseTrack` に `label` / `generation` / 楽曲グループ名を追加
- リリース詳細取得で収録曲の `label` / `generation` / 楽曲グループを取得
- 収録曲行に既存の `Badge` と `formatSongLabel` を使ってラベルを表示
- アンダー/BACKS/ひなた坂や期別曲の表示は、リリースグループではなく楽曲グループ基準に統一

## 確認

- `pnpm --filter oshikatsu-web typecheck`
- `pnpm --filter oshikatsu-web lint`

Closes #188